### PR TITLE
Fix/1.0.1: Rediger/slet knapper i bibliotek (#57)

### DIFF
--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -248,7 +248,9 @@ const ExerciseCard = memo(function ExerciseCard({
               ))}
             </View>
 
-            <View style={[styles.positionPill, { backgroundColor: theme.highlight }, positionIsPlaceholder ? { opacity: 0.55 } : null]}>
+            <View
+              style={[styles.positionPill, { backgroundColor: theme.highlight }, positionIsPlaceholder ? { opacity: 0.55 } : null]}
+            >
               <Text style={[styles.positionPillText, { color: theme.textSecondary }]} numberOfLines={1}>
                 {positionText}
               </Text>
@@ -1012,7 +1014,16 @@ export default function LibraryScreen() {
         />
       );
     },
-    [handleFolderPress, handlePressCard, handlePressCta, selectedPathIds, nav.root, nav.level3Id, searchOpen, searchQuery]
+    [
+      handleFolderPress,
+      handlePressCard,
+      handlePressCta,
+      selectedPathIds,
+      nav.root,
+      nav.level3Id,
+      searchOpen,
+      searchQuery,
+    ]
   );
 
   const keyExtractor = useCallback((item: any, index: number) => {
@@ -1373,7 +1384,6 @@ const styles = StyleSheet.create({
     borderRadius: 999,
   },
   ctaText: { fontSize: 13, fontWeight: '800' },
-
   stateCard: {
     marginHorizontal: 18,
     marginTop: 18,


### PR DESCRIPTION
Closes #57 

- Fjernede “Rediger/Slet” fra øvelseskort i Bibliotek, så kort nu kun navigerer + bevarer CTA-flow.
- Tilføjede “Rediger”/“Slet” i øvelses-detaljevisningen, kun for træner-ejede og ikke-system-øvelser (canManageExercise-guard).
- Udvidede create-exercise med edit-mode (route params), data-fetch + ejerskabsguard, og update-flow (Supabase update) i stedet for at oprette ny.
- Tilføjede loading/lock state i edit-mode, så man ikke kan gemme før data/rettigheder er klar.
- Bevarede delete-flow med confirmation + loading state og navigation tilbage efter slet.

Test:
- iPhone (dev-client): OK
- Kommando: npx expo start -c --tunnel --dev-client
- Testet: Åbn øvelse → Rediger → Gem → verificér at samme øvelse er opdateret (ikke ny). Åbn igen → Slet → verificér at øvelsen er væk i biblioteket efter tilbage-navigation.