### PR TITLE
fix/1.0.1 - Tilføj til opgaver virker ikke (#66)

### DIFF
--- a/contexts/FootballContext.tsx
+++ b/contexts/FootballContext.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useContext, ReactNode, useMemo } from 'react';
 import { useFootballData } from '@/hooks/useFootballData';
 import { Activity, ActivityCategory, Task, Trophy, ExternalCalendar } from '@/types';
 
+type AddTaskOptions = { skipRefresh?: boolean; sourceFolder?: string | null };
+
 interface FootballContextType {
   categories: ActivityCategory[];
   tasks: Task[];
@@ -58,7 +60,7 @@ interface FootballContextType {
   deleteActivitySingle: (activityId: string) => Promise<void>;
   deleteActivitySeries: (seriesId: string) => Promise<void>;
   duplicateActivity: (id: string) => void;
-  addTask: (task: Omit<Task, 'id'>) => Promise<void>;
+  addTask: (task: Omit<Task, 'id'>, options?: AddTaskOptions) => Promise<Task>;
   updateTask: (id: string, updates: Partial<Task>) => Promise<void>;
   deleteTask: (id: string) => Promise<void>;
   duplicateTask: (id: string) => Promise<void>;

--- a/hooks/useFootballData.ts
+++ b/hooks/useFootballData.ts
@@ -631,8 +631,10 @@ export const useFootballData = () => {
     await forceRefreshNotificationQueue();
   }, [fetchAllData]);
 
+  type AddTaskOptions = { skipRefresh?: boolean; sourceFolder?: string | null };
+
   const addTask = useCallback(
-    async (task: Omit<Task, 'id'>) => {
+    async (task: Omit<Task, 'id'>, options?: AddTaskOptions) => {
       try {
         console.log('[addTask] Creating task with data:', task);
 
@@ -662,6 +664,7 @@ export const useFootballData = () => {
           afterTrainingFeedbackEnableNote: task.afterTrainingFeedbackEnableNote ?? true,
           playerId,
           teamId,
+          sourceFolder: options?.sourceFolder ?? null,
         });
 
         if (!created?.id) {
@@ -675,10 +678,11 @@ export const useFootballData = () => {
           return [created, ...prev];
         });
 
-        console.log('[addTask] Task created successfully, refreshing tasks...');
-
-        // Refresh tasks after creation to ensure consistency
-        await fetchTasks();
+        console.log('[addTask] Task created successfully');
+        if (!options?.skipRefresh) {
+          console.log('[addTask] Refreshing tasks for consistency');
+          await fetchTasks();
+        }
         return created;
       } catch (error) {
         console.error('[addTask] Error adding task:', error);

--- a/services/taskService.ts
+++ b/services/taskService.ts
@@ -17,6 +17,7 @@ export interface CreateTaskData {
   afterTrainingFeedbackEnableNote?: boolean;
   playerId?: string | null;
   teamId?: string | null;
+  sourceFolder?: string | null;
 }
 
 export interface UpdateTaskData {
@@ -112,6 +113,12 @@ export const taskService = {
       ('afterTrainingFeedbackEnableNote' in sourceTask
         ? (sourceTask as any).afterTrainingFeedbackEnableNote
         : (rawData as CreateTaskData).afterTrainingFeedbackEnableNote) ?? true;
+    const resolvedSourceFolder =
+      ('source_folder' in sourceTask
+        ? (sourceTask as any).source_folder
+        : ('sourceFolder' in sourceTask
+            ? (sourceTask as any).sourceFolder
+            : (rawData as CreateTaskData).sourceFolder)) ?? null;
 
     let resolvedPlayerId: string | null =
       (rawData as CreateTaskData).playerId ?? null;
@@ -146,6 +153,7 @@ export const taskService = {
           : null,
         after_training_feedback_enable_intensity: true,
         after_training_feedback_enable_note: resolvedAfterTrainingFeedbackEnableNote,
+        source_folder: resolvedSourceFolder,
         player_id: resolvedPlayerId,
         team_id: resolvedTeamId,
       })


### PR DESCRIPTION
Closes #66

- Tilføjede exercise→task mapping state + ref, så vi kan tracke hvilke tasks der blev oprettet fra hvilke øvelser.
- Synkede mapping i ref via effect, så andre effects kan læse seneste map uden re-renders.
- Tilføjede cleanup-effect på tasksFromContext, der pruner mappings når task-id ikke længere findes.
- Når en mapped task forsvinder, nulstilles “Tilføj til opgaver”-status konsekvent på tværs af alle lokale exercise-lister.
- Sikrede at UI ikke bliver “låst” i “Allerede tilføjet til opgaver”, hvis opgaven er slettet/ikke længere findes.

Test:
- iPhone (dev build): npx expo start -c --tunnel --dev-client
- Flow: Bibliotek → Tilføj øvelse → verificér at CTA skifter til “Allerede tilføjet…”
- Slet opgaven i Tasks → gå tilbage til Bibliotek → CTA skal være “Tilføj til opgaver” igen (uden app-restart)
