### PR TITLE
chore: Version bump + release notes (#71)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,9 @@
+# Release Notes
+## 1.0.1
+- Rettet visning af næste dato for abonnementfornyelse.
+- Forbedret flowet for valg af abonnement efter oprettelse.
+- Bibliotek: Trænere kan nu oprette øvelser direkte fra biblioteket.
+- Bibliotek: Tilføjet redigér- og slet-funktion på øvelser.
+- Træner: Mulighed for at tildele øvelser til spillere.
+- Aktiviteter: Redigering virker igen.
+- Opgaver: “Tilføj til opgaver” knappen virker igen.

--- a/app.config.js
+++ b/app.config.js
@@ -5,15 +5,21 @@ module.exports = ({ config }) => {
   const appVariant = process.env.APP_VARIANT === 'dev' ? 'dev' : 'prod';
   const pickFirst = value => (Array.isArray(value) ? value[0] : value);
   const scheme = pickFirst(config.scheme) || 'footballcoach';
+  const expoVersion = '1.0.1';
+  const iosBuildNumber = '2';
+  const androidVersionCode = 2;
 
   return {
     ...config,
+    version: expoVersion,
     scheme,
     ios: {
       ...config.ios,
+      buildNumber: iosBuildNumber,
     },
     android: {
       ...config.android,
+      versionCode: androidVersionCode,
     },
     extra: {
       ...(config.extra ?? {}),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Natively",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "expo-router/entry",
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start --clear --tunnel",


### PR DESCRIPTION
Closes #71

Version bump til 1.0.1 (Expo).

iOS buildNumber incrementeret (+1).

Android versionCode incrementeret (+1).

Tilføjet App Store release notes for 1.0.1 (RELEASE_NOTES.md).

Test: Testet på iPhone via npx expo start -c --tunnel --dev-client.