### PR TITLE
fix: Evighedsabonnementer rettigheder (#77)

### DIFF
--- a/hooks/useSubscriptionFeatures.ts
+++ b/hooks/useSubscriptionFeatures.ts
@@ -1,7 +1,6 @@
-import { useEffect, useMemo, useState, useCallback } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useAppleIAP } from '@/contexts/AppleIAPContext';
 import type { SubscriptionTier } from '@/services/entitlementsSync';
-import { Platform } from 'react-native';
 
 interface SubscriptionFeatures {
   hasActiveSubscription: boolean;
@@ -50,6 +49,9 @@ export function useSubscriptionFeatures(): SubscriptionFeatures {
 
   useEffect(() => {
     if (!__DEV__) return;
+    if (hasActiveSubscription && !subscriptionTier) {
+      console.warn('[useSubscriptionFeatures] Active subscription without tier detected');
+    }
     console.log('[useSubscriptionFeatures] Derived feature access', {
       subscriptionTier,
       hasActiveSubscription,


### PR DESCRIPTION
Closes #77

- Apple IAP entitlement snapshot bruger on-device active SKU før server-verificering, så UI/gating opdaterer straks
- SubscriptionContext coerces backend status med entitlementSnapshot tier og bevarer complimentary/lifetime logik
- useSubscriptionFeatures baserer feature-access direkte på entitlement tier (clean imports)

Test:
- iPhone (Expo dev-client): npx expo start -c --tunnel --dev-client
- Køb/restore: verificeret at gating/tiers opdaterer uden app-restart