### PR TITLE
chore/1.0.2 - Chore - Version bump + release notes #83

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -5,9 +5,9 @@ module.exports = ({ config }) => {
   const appVariant = process.env.APP_VARIANT === 'dev' ? 'dev' : 'prod';
   const pickFirst = value => (Array.isArray(value) ? value[0] : value);
   const scheme = pickFirst(config.scheme) || 'footballcoach';
-  const expoVersion = '1.0.1';
-  const iosBuildNumber = '2';
-  const androidVersionCode = 2;
+  const expoVersion = '1.0.2';
+  const iosBuildNumber = '3';
+  const androidVersionCode = 3;
 
   return {
     ...config,


### PR DESCRIPTION
Body (kopiér):

Closes #83

Bullets: “Bumpet Expo version til 1.0.2”, “Incrementet iOS buildNumber”, “Incrementet Android versionCode”, “Opdateret release notes (inkl. #74 #75 #77 #82)”

Test: “Smoke-test på iPhone via dev-client (tunnel)”

Merge PR ind i fix/1.0.2