### PR TITLE
fix/1.0.2 - Feedback-opgaver: ekstern gem + completion + oprydning

### DIFF
--- a/app/(tabs)/(home)/index.ios.tsx
+++ b/app/(tabs)/(home)/index.ios.tsx
@@ -58,9 +58,10 @@
  */
 
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
-import { FlatList, View, Text, StyleSheet, Pressable, StatusBar, RefreshControl, Platform, useColorScheme } from 'react-native';
+import { FlatList, View, Text, StyleSheet, Pressable, StatusBar, RefreshControl, Platform, useColorScheme, DeviceEventEmitter } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
+import { useFocusEffect } from '@react-navigation/native';
 import { useHomeActivities } from '@/hooks/useHomeActivities';
 import { useFootball } from '@/contexts/FootballContext';
 import { useAdmin } from '@/contexts/AdminContext';
@@ -75,6 +76,9 @@ import { format, startOfWeek, endOfWeek, getWeek } from 'date-fns';
 import { da } from 'date-fns/locale';
 import { supabase } from '@/integrations/supabase/client';
 import { canTrainerManageActivity } from '@/utils/permissions';
+import { fetchSelfFeedbackForActivities } from '@/services/feedbackService';
+import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
+import type { TaskTemplateSelfFeedback } from '@/types';
 
 const FALLBACK_COLORS = {
   primary: '#4CAF50',
@@ -154,6 +158,153 @@ function getPerformanceGradient(percentage: number): readonly [string, string, s
   }
 }
 
+function isExternalActivity(activity: any): boolean {
+  return Boolean(activity?.is_external ?? activity?.isExternal);
+}
+
+type AfterTrainingFeedbackConfig = {
+  enableScore: boolean;
+  scoreExplanation?: string | null;
+  enableNote: boolean;
+};
+
+function normalizeId(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = String(value).trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function isUuidString(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+function getFeedbackActivityIdCandidatesForActivity(activity: any): string[] {
+  if (!activity) return [];
+  const candidates: string[] = [];
+
+  const push = (value: unknown) => {
+    const normalized = normalizeId(value);
+    if (!normalized) return;
+    if (!isUuidString(normalized)) return;
+    if (!candidates.includes(normalized)) candidates.push(normalized);
+  };
+
+  if (isExternalActivity(activity)) {
+    push((activity as any)?.id ?? (activity as any)?.activity_id);
+    push((activity as any)?.externalEventRowId ?? (activity as any)?.external_event_row_id);
+    push((activity as any)?.externalEventId ?? (activity as any)?.external_event_id);
+    return candidates;
+  }
+
+  push((activity as any)?.activity_id ?? (activity as any)?.activityId);
+  push((activity as any)?.id);
+  return candidates;
+}
+
+function safeDateMs(value: unknown): number {
+  const ms = new Date(String(value ?? '')).getTime();
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+function normalizeFeedbackTitle(value?: string | null): string {
+  if (typeof value !== 'string') return '';
+  return value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '').trim().toLowerCase();
+}
+
+function isFeedbackTitle(title?: string | null): boolean {
+  if (typeof title !== 'string') return false;
+  const normalized = normalizeFeedbackTitle(title);
+  return normalized.startsWith('feedback pa');
+}
+
+function getMarkerTemplateIdFromTask(task: any): string | null {
+  if (!task) return null;
+  if (typeof task.description === 'string') {
+    const fromMarker = parseTemplateIdFromMarker(task.description);
+    if (fromMarker) return fromMarker;
+  }
+  if (typeof task.title === 'string') {
+    const fromTitle = parseTemplateIdFromMarker(task.title);
+    if (fromTitle) return fromTitle;
+  }
+  return null;
+}
+
+function resolveFeedbackTemplateIdFromTask(task: any): string | null {
+  if (!task) return null;
+  const direct = normalizeId(task.feedbackTemplateId ?? task.feedback_template_id);
+  if (direct) return direct;
+  const markerTemplateId = getMarkerTemplateIdFromTask(task);
+  if (markerTemplateId) return markerTemplateId;
+
+  if (isFeedbackTitle(task.title)) {
+    const fallbackTemplateId = task.taskTemplateId ?? task.task_template_id;
+    const normalized = normalizeId(fallbackTemplateId);
+    if (normalized) return normalized;
+  }
+
+  return null;
+}
+
+function isFeedbackTaskFromTask(task: any): boolean {
+  if (!task) return false;
+  const direct = normalizeId(task.feedbackTemplateId ?? task.feedback_template_id);
+  if (direct) return true;
+  return !!getMarkerTemplateIdFromTask(task) || isFeedbackTitle(task.title);
+}
+
+function normalizeScoreExplanation(value?: string | null): string | null {
+  if (typeof value !== 'string') {
+    return value ?? null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function buildFeedbackConfig(row?: any): AfterTrainingFeedbackConfig {
+  if (!row) {
+    return {
+      enableScore: true,
+      scoreExplanation: null,
+      enableNote: true,
+    };
+  }
+
+  return {
+    enableScore: row.after_training_feedback_enable_score ?? true,
+    scoreExplanation: normalizeScoreExplanation(row.after_training_feedback_score_explanation),
+    enableNote: row.after_training_feedback_enable_note ?? true,
+  };
+}
+
+function isFeedbackAnswered(
+  feedback?: TaskTemplateSelfFeedback,
+  config?: AfterTrainingFeedbackConfig,
+): boolean {
+  if (!feedback) return false;
+
+  const enableScore = config?.enableScore !== false;
+  const enableNote = config?.enableNote !== false;
+
+  const hasScore = typeof feedback.rating === 'number';
+  const hasNote = (feedback.note?.trim() ?? '').length > 0;
+
+  if (enableScore && hasScore) return true;
+  if (enableNote && hasNote) return true;
+  return false;
+}
+
+function getActivityTasks(activity: any): any[] {
+  if (!activity) return [];
+  const primary = Array.isArray(activity?.tasks) ? activity.tasks : [];
+  if (primary.length) return primary;
+  const fallback =
+    Array.isArray(activity?.external_tasks) ? activity.external_tasks :
+    Array.isArray(activity?.calendar_tasks) ? activity.calendar_tasks :
+    [];
+  return Array.isArray(fallback) ? fallback : [];
+}
+
 export default function HomeScreen() {
   const router = useRouter();
   const { activities, loading, refresh: refreshActivities } = useHomeActivities();
@@ -165,8 +316,78 @@ export default function HomeScreen() {
   const [isPreviousExpanded, setIsPreviousExpanded] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [currentTrainerId, setCurrentTrainerId] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [feedbackConfigByTemplate, setFeedbackConfigByTemplate] = useState<Record<string, AfterTrainingFeedbackConfig>>({});
+  const [selfFeedbackRows, setSelfFeedbackRows] = useState<TaskTemplateSelfFeedback[]>([]);
+  const [feedbackRefreshKey, setFeedbackRefreshKey] = useState(0);
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
+
+  useEffect(() => {
+    const handleSaved = (payload: any) => {
+      const activityId = String(payload?.activityId ?? '').trim();
+      const templateId = String(payload?.templateId ?? '').trim();
+      if (!activityId || !templateId) return;
+
+      const createdAt =
+        typeof payload?.createdAt === 'string' && payload.createdAt.length
+          ? payload.createdAt
+          : new Date().toISOString();
+      const optimisticId =
+        typeof payload?.optimisticId === 'string' && payload.optimisticId.length
+          ? payload.optimisticId
+          : `optimistic:${activityId}:${templateId}:${createdAt}`;
+
+      const optimisticRow: TaskTemplateSelfFeedback = {
+        id: optimisticId,
+        userId: currentUserId ?? 'optimistic',
+        taskTemplateId: templateId,
+        activityId,
+        rating: typeof payload?.rating === 'number' ? payload.rating : null,
+        note: typeof payload?.note === 'string' ? payload.note : null,
+        createdAt,
+        updatedAt: createdAt,
+      };
+
+      setSelfFeedbackRows((prev) => {
+        const next = prev.filter((row) => {
+          if (!row?.id?.startsWith('optimistic:')) return true;
+          if (row.id === optimisticId) return false;
+          if (row.activityId === activityId && row.taskTemplateId === templateId) return false;
+          return true;
+        });
+        return [optimisticRow, ...next];
+      });
+    };
+
+    const handleFailed = (payload: any) => {
+      const activityId = String(payload?.activityId ?? '').trim();
+      const templateId = String(payload?.templateId ?? '').trim();
+      const optimisticId =
+        typeof payload?.optimisticId === 'string' && payload.optimisticId.length
+          ? payload.optimisticId
+          : null;
+
+      if (!activityId || !templateId) return;
+
+      setSelfFeedbackRows((prev) =>
+        prev.filter((row) => {
+          if (!row?.id?.startsWith('optimistic:')) return true;
+          if (optimisticId && row.id === optimisticId) return false;
+          if (row.activityId === activityId && row.taskTemplateId === templateId) return false;
+          return true;
+        })
+      );
+    };
+
+    const savedSub = DeviceEventEmitter.addListener('feedback:saved', handleSaved);
+    const failedSub = DeviceEventEmitter.addListener('feedback:save_failed', handleFailed);
+
+    return () => {
+      savedSub.remove();
+      failedSub.remove();
+    };
+  }, [currentUserId]);
 
   const currentWeekNumber = getWeek(new Date(), { weekStartsOn: 1, locale: da });
   const currentWeekLabel = getWeekLabel(new Date());
@@ -193,6 +414,7 @@ export default function HomeScreen() {
         const { data: { user } } = await supabase.auth.getUser();
         if (user) {
           setCurrentTrainerId(user.id);
+          setCurrentUserId(user.id);
         }
       } catch (error) {
         console.error('[Home] Error fetching current trainer ID:', error);
@@ -343,6 +565,143 @@ export default function HomeScreen() {
 
     return { todayActivities, upcomingByWeek, previousByWeek };
   }, [activities, categoriesById]);
+
+  const feedbackActivityIds = useMemo(() => {
+    const ids = new Set<string>();
+    const safeActivities = Array.isArray(activities) ? activities : [];
+    safeActivities.forEach((activity: any) => {
+      const candidates = getFeedbackActivityIdCandidatesForActivity(activity);
+      candidates.forEach((candidate) => ids.add(candidate));
+    });
+    return Array.from(ids);
+  }, [activities]);
+
+  const feedbackActivityIdsKey = useMemo(
+    () => feedbackActivityIds.join("|"),
+    [feedbackActivityIds]
+  );
+
+  const getFeedbackActivityCandidates = useCallback(
+    (activity: any): string[] => getFeedbackActivityIdCandidatesForActivity(activity),
+    [],
+  );
+
+  const feedbackTemplateIds = useMemo(() => {
+    const ids = new Set<string>();
+    const safeActivities = Array.isArray(activities) ? activities : [];
+    safeActivities.forEach((activity) => {
+      const tasks = getActivityTasks(activity);
+      tasks.forEach((task) => {
+        if (!isFeedbackTaskFromTask(task)) return;
+        const templateId = resolveFeedbackTemplateIdFromTask(task);
+        if (templateId) ids.add(templateId);
+      });
+    });
+    return Array.from(ids);
+  }, [activities]);
+
+  const feedbackTemplateIdsKey = useMemo(
+    () => feedbackTemplateIds.join('|'),
+    [feedbackTemplateIds]
+  );
+
+  const triggerFeedbackRefresh = useCallback(() => {
+    setFeedbackRefreshKey((prev) => prev + 1);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!currentUserId || !feedbackActivityIds.length) return;
+      triggerFeedbackRefresh();
+    }, [currentUserId, feedbackActivityIds.length, triggerFeedbackRefresh])
+  );
+
+  useEffect(() => {
+    if (Array.isArray(activities) && activities.length > 0) {
+      setFeedbackRefreshKey((prev) => prev + 1);
+    }
+  }, [activities]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!feedbackActivityIds.length || !currentUserId) {
+      setSelfFeedbackRows([]);
+      return;
+    }
+
+    (async () => {
+      if (feedbackTemplateIds.length) {
+        try {
+          const { data } = await supabase
+            .from('task_templates')
+            .select('id, after_training_feedback_enable_score, after_training_feedback_score_explanation, after_training_feedback_enable_note')
+            .in('id', feedbackTemplateIds);
+
+          if (!cancelled && Array.isArray(data)) {
+            const next: Record<string, AfterTrainingFeedbackConfig> = {};
+            for (const row of data as any[]) {
+              if (!row?.id) continue;
+              next[String(row.id)] = buildFeedbackConfig(row);
+            }
+            setFeedbackConfigByTemplate((prev) => ({ ...prev, ...next }));
+          }
+        } catch (error) {
+          if (__DEV__) console.log('[Home] feedback config fetch failed', error);
+        }
+      }
+
+      try {
+        const rows = await fetchSelfFeedbackForActivities(currentUserId, feedbackActivityIds);
+        if (cancelled) return;
+        setSelfFeedbackRows(Array.isArray(rows) ? rows : []);
+      } catch (error) {
+        if (__DEV__) console.log('[Home] self feedback fetch failed', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentUserId, feedbackActivityIds, feedbackActivityIdsKey, feedbackTemplateIds, feedbackTemplateIdsKey, feedbackRefreshKey]);
+
+  const feedbackCompletionByActivityId = useMemo(() => {
+    const latestByKey: Record<string, TaskTemplateSelfFeedback> = {};
+    for (const row of selfFeedbackRows) {
+      const activityId = normalizeId((row as any)?.activityId ?? (row as any)?.activity_id);
+      const templateId = normalizeId((row as any)?.taskTemplateId ?? (row as any)?.task_template_id);
+      if (!activityId || !templateId) continue;
+
+      const key = `${activityId}::${templateId}`;
+      if (!latestByKey[key] || safeDateMs(row.createdAt) > safeDateMs(latestByKey[key].createdAt)) {
+        latestByKey[key] = row;
+      }
+    }
+
+    const completionByActivity: Record<string, Record<string, boolean>> = {};
+    Object.entries(latestByKey).forEach(([key, row]) => {
+      const [activityId, templateId] = key.split('::');
+      if (!activityId || !templateId) return;
+
+      const config = feedbackConfigByTemplate[templateId] ?? buildFeedbackConfig(undefined);
+      if (!completionByActivity[activityId]) {
+        completionByActivity[activityId] = {};
+      }
+      completionByActivity[activityId][templateId] = isFeedbackAnswered(row, config);
+    });
+
+    return completionByActivity;
+  }, [feedbackConfigByTemplate, selfFeedbackRows]);
+
+  const feedbackDoneByActivityId = useMemo(() => {
+    const doneMap: Record<string, boolean> = {};
+    Object.entries(feedbackCompletionByActivityId).forEach(([activityId, templateMap]) => {
+      if (Object.values(templateMap).some(Boolean)) {
+        doneMap[activityId] = true;
+      }
+    });
+    return doneMap;
+  }, [feedbackCompletionByActivityId]);
 
   // Calculate how many previous weeks to display
   const visiblePreviousWeeks = useMemo(() => {
@@ -670,6 +1029,28 @@ export default function HomeScreen() {
           }
         };
 
+        const feedbackActivityCandidates = getFeedbackActivityCandidates(activity);
+        const feedbackActivityId = feedbackActivityCandidates.length ? feedbackActivityCandidates[0] : null;
+
+        const mergedFeedbackCompletionByTemplateId: Record<string, boolean> = {};
+        for (const candidateId of feedbackActivityCandidates) {
+          const perTemplate = feedbackCompletionByActivityId[candidateId];
+          if (!perTemplate) continue;
+          for (const [templateId, done] of Object.entries(perTemplate)) {
+            const tid = normalizeId(templateId);
+            if (!tid) continue;
+            if (done) {
+              mergedFeedbackCompletionByTemplateId[tid] = true;
+            } else if (mergedFeedbackCompletionByTemplateId[tid] === undefined) {
+              mergedFeedbackCompletionByTemplateId[tid] = false;
+            }
+          }
+        }
+
+        const feedbackDone = feedbackActivityCandidates.some(
+          (candidateId) => feedbackDoneByActivityId[candidateId] === true,
+        );
+
         return (
           <View
             style={[
@@ -682,6 +1063,9 @@ export default function HomeScreen() {
               activity={activity}
               resolvedDate={activity.__resolvedDateTime}
               showTasks={item.section === 'today' || item.section === 'previous'}
+              feedbackActivityId={feedbackActivityId}
+              feedbackCompletionByTemplateId={mergedFeedbackCompletionByTemplateId}
+              feedbackDone={feedbackDone}
               onPress={handleActivityPress}
             />
           </View>
@@ -717,7 +1101,20 @@ export default function HomeScreen() {
       default:
         return null;
     }
-  }, [isDark, isPreviousExpanded, togglePreviousExpanded, isAdminMode, currentTrainerId, adminMode, router, handleLoadMorePrevious, showPreviousWeeks]);
+  }, [
+    isDark,
+    isPreviousExpanded,
+    togglePreviousExpanded,
+    isAdminMode,
+    currentTrainerId,
+    adminMode,
+    router,
+    handleLoadMorePrevious,
+    showPreviousWeeks,
+    feedbackCompletionByActivityId,
+    feedbackDoneByActivityId,
+    getFeedbackActivityCandidates,
+  ]);
 
   // Key extractor for FlatList
   const keyExtractor = useCallback((item: any, index: number) => {

--- a/scripts/qa-bundle.ps1
+++ b/scripts/qa-bundle.ps1
@@ -1,0 +1,102 @@
+# scripts/qa-bundle.ps1
+# === QA bundle after Codex — zip only (temp folder removed) ===
+# Usage (recommended):
+#   powershell -ExecutionPolicy Bypass -File scripts/qa-bundle.ps1
+# Optional: run QA commands and capture output:
+#   powershell -ExecutionPolicy Bypass -File scripts/qa-bundle.ps1 -QaCommands "npm run lint","npm run typecheck","npm test"
+
+param(
+  [string[]]$QaCommands = @()
+)
+
+$ErrorActionPreference = "Stop"
+
+# 1) Find repo root
+$repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+if (-not $repoRoot) { throw "Ikke et git-repo. Åbn PowerShell i projektmappen (eller en undermappe i repo'et)." }
+Set-Location $repoRoot
+
+# Helper: run cmd quietly (suppresses stderr warnings)
+function Get-CmdOut([string]$cmd) {
+  try {
+    $out = (cmd /c "$cmd 2>nul") | Select-Object -First 1
+    if ($null -eq $out) { return "" }
+    return $out.Trim()
+  } catch { return "" }
+}
+
+# 2) Output folder (temp) + zip path (kept)
+$ts = Get-Date -Format "yyyyMMdd-HHmmss"
+$baseDir = Join-Path $repoRoot ".qa-export"
+$outDir  = Join-Path $baseDir $ts
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+# 3) Paths
+$patchFile  = Join-Path $outDir "changes.patch"
+$namesFile  = Join-Path $outDir "files.txt"
+$statFile   = Join-Path $outDir "stats.txt"
+$statusFile = Join-Path $outDir "status.txt"
+$metaFile   = Join-Path $outDir "meta.txt"
+$checkFile  = Join-Path $outDir "diff-check.txt"
+$cmdFile    = Join-Path $outDir "qa-commands.txt"
+
+$zipPath = Join-Path $baseDir "$ts.zip"
+
+# 4) Meta/status
+$branch = (git rev-parse --abbrev-ref HEAD).Trim()
+$head   = (git rev-parse --short HEAD).Trim()
+$last   = (git log -1 --oneline).Trim()
+$nodeV  = Get-CmdOut "node -v"
+$npmV   = Get-CmdOut "npm -v"
+
+@(
+  "timestamp: $(Get-Date -Format o)"
+  "repoRoot:   $repoRoot"
+  "branch:     $branch"
+  "head:       $head"
+  "lastCommit: $last"
+  "node:       $nodeV"
+  "npm:        $npmV"
+) | Out-File -Encoding utf8 $metaFile
+
+git status -sb | Out-File -Encoding utf8 $statusFile
+
+# 5) Diff artefacts (alt ift. HEAD)
+git diff --name-status HEAD | Out-File -Encoding utf8 $namesFile
+git diff --stat HEAD        | Out-File -Encoding utf8 $statFile
+git diff --check HEAD       | Out-File -Encoding utf8 $checkFile
+git diff --binary HEAD      | Out-File -Encoding utf8 $patchFile
+
+# 6) Optional QA commands output
+"=== QA commands output ===" | Out-File -Encoding utf8 $cmdFile
+if ($QaCommands.Count -gt 0) {
+  foreach ($c in $QaCommands) {
+    "" | Out-File -Append -Encoding utf8 $cmdFile
+    ">>> $c" | Out-File -Append -Encoding utf8 $cmdFile
+    cmd /c "$c" 2>&1 | Out-File -Append -Encoding utf8 $cmdFile
+    "exitCode: $LASTEXITCODE" | Out-File -Append -Encoding utf8 $cmdFile
+    if ($LASTEXITCODE -ne 0) {
+      "" | Out-File -Append -Encoding utf8 $cmdFile
+      "NOTE: Kommando fejlede (exitCode != 0). Se output ovenfor." | Out-File -Append -Encoding utf8 $cmdFile
+      # Fortsæt stadig med at lave bundle, så QA kan se fejlen.
+    }
+  }
+} else {
+  "NOTE: Ingen QA-kommandoer kørt. Kald scriptet med -QaCommands for at køre lint/typecheck/tests." |
+    Out-File -Append -Encoding utf8 $cmdFile
+}
+
+# 7) Zip + remove folder (keep only zip)
+Compress-Archive -Path (Join-Path $outDir "*") -DestinationPath $zipPath -Force
+Remove-Item -Recurse -Force $outDir
+
+# 8) Summary + open base folder
+Write-Host ""
+Write-Host "✅ QA bundle (zip only) lavet:" -ForegroundColor Green
+Write-Host "  Zip: $zipPath"
+Write-Host ""
+git diff --stat HEAD
+Write-Host ""
+
+# Open folder in Explorer (Windows). No-op on non-Windows.
+try { Invoke-Item $baseDir | Out-Null } catch {}

--- a/services/feedbackService.ts
+++ b/services/feedbackService.ts
@@ -45,6 +45,73 @@ export async function fetchSelfFeedbackForTemplates(
   return (data || []).map(mapRow);
 }
 
+export async function fetchSelfFeedbackForActivities(
+  userId: string,
+  activityIds: string[]
+): Promise<TaskTemplateSelfFeedback[]> {
+  const trimmedUserId = String(userId ?? '').trim();
+  if (!trimmedUserId || !activityIds?.length) {
+    return [];
+  }
+
+  const isUuidString = (value: string): boolean =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+
+  const normalizedActivityIds = Array.from(
+    new Set(
+      activityIds
+        .map((id) => String(id ?? '').trim())
+        .filter(Boolean)
+        // `activity_id` is a uuid column. Filter out non-uuid candidates (e.g. provider_event_uid)
+        // to avoid the entire query failing.
+        .filter(isUuidString)
+    )
+  );
+
+  if (!normalizedActivityIds.length) {
+    return [];
+  }
+
+  const CHUNK_SIZE = 50;
+  const chunkCount = Math.ceil(normalizedActivityIds.length / CHUNK_SIZE);
+
+  if (__DEV__) {
+    console.log('[feedbackService] fetchSelfFeedbackForActivities', {
+      totalActivityIds: normalizedActivityIds.length,
+      chunks: chunkCount,
+      sampleActivityIds: normalizedActivityIds.slice(0, 3),
+    });
+  }
+
+  const allRows: any[] = [];
+  for (let i = 0; i < normalizedActivityIds.length; i += CHUNK_SIZE) {
+    const chunk = normalizedActivityIds.slice(i, i + CHUNK_SIZE);
+    const { data, error } = await supabase
+      .from('task_template_self_feedback')
+      .select('*')
+      .eq('user_id', trimmedUserId)
+      .in('activity_id', chunk)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      throw error;
+    }
+
+    if (Array.isArray(data) && data.length) {
+      allRows.push(...data);
+    }
+  }
+
+  const mapped = allRows.map(mapRow);
+  mapped.sort((a, b) => {
+    const aMs = new Date(String((a as any)?.createdAt ?? '')).getTime();
+    const bMs = new Date(String((b as any)?.createdAt ?? '')).getTime();
+    return (Number.isFinite(bMs) ? bMs : 0) - (Number.isFinite(aMs) ? aMs : 0);
+  });
+
+  return mapped;
+}
+
 type UpsertSelfFeedbackArgs = {
   templateId: string;
   userId: string;
@@ -65,6 +132,18 @@ function requireNonEmpty(label: string, value: unknown): string {
 function requireActivityId(input: UpsertSelfFeedbackArgs): string {
   const raw = input.activity_id ?? input.activityId;
   return requireNonEmpty('activity id (activity_id/activityId)', raw);
+}
+
+function logSupabaseError(context: string, error: any, meta?: Record<string, unknown>) {
+  if (!__DEV__) return;
+  console.log(`[feedbackService] ${context}`, {
+    ...meta,
+    message: error?.message,
+    details: error?.details,
+    hint: error?.hint,
+    code: error?.code,
+    status: error?.status,
+  });
 }
 
 export async function upsertSelfFeedback(args: UpsertSelfFeedbackArgs) {
@@ -92,6 +171,11 @@ export async function upsertSelfFeedback(args: UpsertSelfFeedbackArgs) {
     .single();
 
   if (error) {
+    logSupabaseError('upsertSelfFeedback failed', error, {
+      activityId,
+      userId,
+      templateId,
+    });
     throw error;
   }
 

--- a/supabase/migrations/20260204120000_task_template_self_feedback_activity_id_fix.sql
+++ b/supabase/migrations/20260204120000_task_template_self_feedback_activity_id_fix.sql
@@ -1,0 +1,39 @@
+-- Allow external activities in task_template_self_feedback by replacing the FK
+-- with a trigger that validates against activities OR events_external.
+
+alter table public.task_template_self_feedback
+  drop constraint if exists task_template_self_feedback_activity_id_fkey;
+
+create or replace function public.validate_task_template_self_feedback_activity_id()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.activity_id is null then
+    raise exception 'task_template_self_feedback.activity_id is required'
+      using errcode = '23502';
+  end if;
+
+  if exists (select 1 from public.activities where id = new.activity_id) then
+    return new;
+  end if;
+
+  if exists (select 1 from public.events_external where id = new.activity_id) then
+    return new;
+  end if;
+
+  raise exception
+    'task_template_self_feedback.activity_id must reference activities.id or events_external.id (got %)',
+    new.activity_id
+    using errcode = '23503';
+end;
+$$;
+
+drop trigger if exists validate_task_template_self_feedback_activity_id on public.task_template_self_feedback;
+
+create trigger validate_task_template_self_feedback_activity_id
+before insert or update on public.task_template_self_feedback
+for each row
+execute function public.validate_task_template_self_feedback_activity_id();


### PR DESCRIPTION
Problem

Feedback-opgaver opførte sig forskelligt på tværs af intern vs. ekstern aktivitet.

Eksterne feedback gem fejlede pga. FK-constraint på task_template_self_feedback.activity_id (events_external ikke tilladt).

Home-kort/oversigt reflekterede ikke altid completion korrekt (self-feedback fetch kunne fejle / inkonsistente activity ids).

Feedback-opgaver kunne blive hængende som “orphan” efter parent-opgave blev slettet.

UI på ActivityCard havde for mange badges/støj.

Løsning (hovedpunkter)

Ensrettet feedback-detektion (bruger feedback_template_id som source-of-truth og robust fallback) så feedback altid åbner score/note-modal og ikke degrader til “Fuldfør”.

Robust upsertSelfFeedback og ID-håndtering for eksterne aktiviteter, så gem virker stabilt.

DB-fix: Fjernede hard FK på task_template_self_feedback.activity_id og erstattede med trigger-validering, der tillader reference til enten activities.id eller events_external.id.

Forhindrer Home self-feedback fetch i at fejle på store/ugyldige id-lister (chunking/filtrering) så completion altid kan beregnes.

Oprydning: Feedback-opgaver fjernes når parent-opgave slettes, og orphan-feedback ryddes op (inkl. for eksterne aktiviteter).

Fjernet badges på ActivityCard (“x/y fuldført” + “feedback udfyldt”) for at holde UI simpelt.

Ændrede filer (overblik)

app/activity-details.tsx

app/(modals)/task-feedback-note.tsx

app/(tabs)/(home)/index.tsx

app/(tabs)/(home)/index.ios.tsx

components/ActivityCard.tsx

hooks/useHomeActivities.ts

services/feedbackService.ts

hooks/useProgressionData.ts (PGRST200 embed-fix / enrichment uden relation)

supabase/migrations/20260204120000_task_template_self_feedback_activity_id_fix.sql

Migration

20260204120000_task_template_self_feedback_activity_id_fix.sql

Dropper FK task_template_self_feedback_activity_id_fkey

Tilføjer trigger validate_task_template_self_feedback_activity_id der validerer mod activities eller events_external.

Testet manuelt (QA)

Intern aktivitet: Åbn → feedback-opgave → vælg score + note → gem → oversigt viser completion korrekt.

Ekstern aktivitet: Åbn → feedback-opgave → vælg score + note → gem → oversigt + detaljer reflekterer completion korrekt.

Oprydning: Slet parent-opgave → tilhørende feedback-opgave fjernes (intern + ekstern) og orphan-feedback ryddes op.

UI: Badges fjernet fra ActivityCard.