### PR TITLE
Ensure fetch-success overwrites stale subscription snapshot

### DIFF
--- a/contexts/SubscriptionContext.tsx
+++ b/contexts/SubscriptionContext.tsx
@@ -372,6 +372,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       }
 
       const data = await response.json();
+      const payloadHasError = Boolean(data?.error);
 
       const statusData: SubscriptionStatus = {
         hasSubscription: Boolean(data?.hasSubscription),
@@ -384,7 +385,8 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         subscriptionTier: (data?.subscriptionTier as SubscriptionTier | null) ?? null,
       };
 
-      applyStatus(coerceWithEntitlements(statusData, 'fetch-success'), 'fetch-success');
+      const reason = payloadHasError ? 'fetch-fallback' : 'fetch-success';
+      applyStatus(coerceWithEntitlements(statusData, reason), reason);
     } catch {
       console.warn('[SubscriptionContext] Network request failed');
 


### PR DESCRIPTION
What changed

Treat fetch-success as authoritative in applyStatus, persisting even when hasSubscription is false.
Prevents expired/cancelled subscriptions from reusing lastStableStatusRef and leaving entitlements/UI stuck as active.
Why

get-subscription-status returns hasSubscription: false with null tier/plan on cancellation; previously the stabilization path reused the prior premium snapshot, so users could appear subscribed until relogging.
Testing

Not run (local tests not requested).