### PR TITLE
fix: stabiliser subscription state uden at gemme fallback payloads

### DIFF
--- a/contexts/SubscriptionContext.tsx
+++ b/contexts/SubscriptionContext.tsx
@@ -182,8 +182,9 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const applyStatus = useCallback((next: SubscriptionStatus, reason: string) => {
+    const isAuthoritative = reason === 'fetch-success';
     const shouldPersist =
-      next.hasSubscription || next.isLifetime || Boolean(next.subscriptionTier) || Boolean(next.planName);
+      next.hasSubscription || next.isLifetime || Boolean(next.subscriptionTier) || Boolean(next.planName) || isAuthoritative;
 
     if (shouldPersist) {
       lastStableStatusRef.current = next;
@@ -367,6 +368,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       }
 
       const data = await response.json();
+      const payloadHasError = Boolean(data?.error);
 
       const statusData: SubscriptionStatus = {
         hasSubscription: Boolean(data?.hasSubscription),
@@ -379,7 +381,8 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         subscriptionTier: (data?.subscriptionTier as SubscriptionTier | null) ?? null,
       };
 
-      applyStatus(coerceWithEntitlements(statusData, 'fetch-success'), 'fetch-success');
+      const reason = payloadHasError ? 'fetch-fallback' : 'fetch-success';
+      applyStatus(coerceWithEntitlements(statusData, reason), reason);
     } catch {
       console.warn('[SubscriptionContext] Network request failed');
 


### PR DESCRIPTION
Title
Guard fallback subscription payloads from persisting

What changed

Gør fetch-success autoritativ i applyStatus, så afmeldinger/expiry med hasSubscription: false faktisk overskriver gamle premium snapshots.
Marker edge‑function svar med error som fetch-fallback, så de ikke bliver gemt som stabile og ikke nedgraderer/overrider et aktivt cachet abonnement.
Sender reason videre til entitlement‑coercion for klarere logs.
Why

Standard “no subscription” payload kommer som hasSubscription: false med tom plan/tier; tidligere blev de ignoreret til fordel for lastStableStatusRef, så UI kunne forblive aktivt efter afmelding.
Edge‑function fejl returnerer HTTP 200 + error; disse må ikke persistere og nulstille aktiv status.
Testing

Ikke kørt (lokale tests ikke anmodet).