### PR TITLE
fix: Evighedsabonnement vises ikke korrekt (#130)

### DIFF
--- a/contexts/AppleIAPContext.tsx
+++ b/contexts/AppleIAPContext.tsx
@@ -899,7 +899,7 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
   }, [appleTierSourceSku]);
 
   const effectiveSubscriptionTier = useMemo<SubscriptionTier | null>(() => {
-    return appleTier ?? complimentaryTier;
+    return complimentaryTier ?? appleTier;
   }, [appleTier, complimentaryTier]);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #130

Bulletliste (3–6):

Prioriterer partner/evighed/complimentary over aktiv IAP i effective tier.

Konsistent “effective plan” i abonnement-UI, så der ikke vises forkert aktiv plan.

Bevarer eksisterende purchase/restore/gating flows.

Test-resumé:

A) Partner/evighed (Trainer Premium) viser korrekt (ingen “Premium spiller”).

B) Ingen abonnement → onboarding/paywall fungerer.

C) Aktiv IAP → visning/gating OK.