### PR TITLE
fix: Skjul opgaver på fremtidige aktiviteter (#98)

### DIFF
--- a/app/(tabs)/(home)/index.ios.tsx
+++ b/app/(tabs)/(home)/index.ios.tsx
@@ -1126,7 +1126,7 @@ export default function HomeScreen() {
             <ActivityCard
               activity={activity}
               resolvedDate={activity.__resolvedDateTime}
-              showTasks={item.section === 'today' || item.section === 'previous'}
+              showTasks={item.section === 'today'}
               feedbackActivityId={feedbackActivityId}
               feedbackCompletionByTaskId={mergedFeedbackCompletionByTaskId}
               feedbackCompletionByTemplateId={mergedFeedbackCompletionByTemplateId}

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -1276,7 +1276,7 @@ export default function HomeScreen() {
             <ActivityCard
               activity={activity}
               resolvedDate={activity.__resolvedDateTime}
-              showTasks={item.section === 'today' || item.section === 'previous'}
+              showTasks={item.section === 'today'}
               feedbackActivityId={feedbackActivityId}
               feedbackCompletionByTaskId={mergedFeedbackCompletionByTaskId}
               feedbackCompletionByTemplateId={mergedFeedbackCompletionByTemplateId}

--- a/components/ActivityCard.tsx
+++ b/components/ActivityCard.tsx
@@ -629,6 +629,7 @@ export default function ActivityCard({
   }, [activity?.id, activity?.is_external, activity?.title, optimisticTasks, showTasks]);
 
   const taskListItems = useMemo<TaskListItem[]>(() => {
+    if (showTasks === false) return [];
     const allTasks = Array.isArray(optimisticTasks) ? optimisticTasks : [];
     const visibleTasks = allTasks.filter(task => {
       if (activity?.is_external) {


### PR DESCRIPTION
Closes #98

Bullets (3–6):

Skjuler opgaver/feedback-opgaver på aktivitetskort for fremtidige aktiviteter

Opgaver vises kun i “I dag”-sektionen på Home

ActivityCard respekterer showTasks og skjuler tasks når showTasks === false

Test:

Testet på iPhone via dev-client: I dag viser tasks, kommende/tidligere skjuler tasks