### PR TITLE
fix: add stable testIDs for critical flows (#100)

### DIFF
--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -297,6 +297,8 @@ const ExerciseCard = memo(function ExerciseCard({
           activeOpacity={0.9}
           style={[styles.ctaBadge, { backgroundColor: ctaBgColor }]}
           disabled={ctaDisabled}
+          testID={`library.addToTasksButton.${exercise.id}`}
+          accessibilityLabel={isAdded ? 'Allerede tilføjet til opgaver' : 'Tilføj til opgaver'}
         >
           {isAdding ? (
             <>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1687,6 +1687,8 @@ export default function ProfileScreen() {
                   keyboardType="email-address"
                   editable={!loading}
                   autoCorrect={false}
+                  testID="auth.login.emailInput"
+                  accessibilityLabel="Email"
                 />
 
                 <Text style={[styles.label, { color: textColor }]}>Adgangskode</Text>
@@ -1706,6 +1708,8 @@ export default function ProfileScreen() {
                   editable={!loading}
                   autoCorrect={false}
                   autoCapitalize="none"
+                  testID="auth.login.passwordInput"
+                  accessibilityLabel="Adgangskode"
                 />
 
                 <TouchableOpacity
@@ -1713,6 +1717,8 @@ export default function ProfileScreen() {
                   onPress={isSignUp ? handleSignup : handleLogin}
                   disabled={loading}
                   activeOpacity={0.7}
+                  testID="auth.login.submitButton"
+                  accessibilityLabel={isSignUp ? 'Opret konto' : 'Log ind'}
                 >
                   {loading ? (
                     <View style={styles.loadingContainer}>
@@ -1877,6 +1883,8 @@ export default function ProfileScreen() {
                 onPress={closePaywallModal}
                 style={styles.paywallCloseButton}
                 activeOpacity={0.7}
+                testID="paywall.closeButton"
+                accessibilityLabel="Luk paywall"
               >
                 <IconSymbol
                   ios_icon_name="xmark"

--- a/app/(tabs)/profile.web.tsx
+++ b/app/(tabs)/profile.web.tsx
@@ -1173,6 +1173,8 @@ export default function ProfileScreen() {
                     placeholderTextColor={textSecondaryColor}
                     autoCapitalize="none"
                     autoCorrect={false}
+                    testID="auth.login.emailInput"
+                    accessibilityLabel="Email"
                   />
 
                   <Text style={[styles.label, { color: textColor }]}>Adgangskode</Text>
@@ -1185,6 +1187,8 @@ export default function ProfileScreen() {
                     secureTextEntry
                     autoCorrect={false}
                     autoCapitalize="none"
+                    testID="auth.login.passwordInput"
+                    accessibilityLabel="Adgangskode"
                   />
 
                   <TouchableOpacity
@@ -1196,6 +1200,8 @@ export default function ProfileScreen() {
                     onPress={isSignUp ? handleSignup : handleLogin}
                     disabled={loading}
                     activeOpacity={0.7}
+                    testID="auth.login.submitButton"
+                    accessibilityLabel={isSignUp ? 'Opret konto' : 'Log ind'}
                   >
                     {loading ? (
                       <View style={styles.loadingContainer}>

--- a/components/AppleSubscriptionManager.tsx
+++ b/components/AppleSubscriptionManager.tsx
@@ -699,6 +699,8 @@ export default function AppleSubscriptionManager({
           onPress={() => handleSelectPlan(item.productId)}
           disabled={blockInteractions || isCurrentActive || disabledByComplimentary}
           activeOpacity={0.7}
+          testID={`paywall.planCard.${item.productId}`}
+          accessibilityLabel={`Abonnement ${getPlanName(item)}`}
         >
           {isComplimentaryForProduct(item.productId) && (
             <View style={[styles.partnerBadge, { backgroundColor: colors.secondary }]}>
@@ -786,6 +788,8 @@ export default function AppleSubscriptionManager({
               ]}
               onPress={() => handleSelectPlan(item.productId)}
               disabled={blockInteractions || disabledByComplimentary}
+              testID="paywall.primaryCtaButton"
+              accessibilityLabel={isSignupFlow ? 'Vælg denne plan' : 'Skift til denne plan'}
             >
               {purchasing ? (
                 <ActivityIndicator color={isPopular ? '#fff' : colors.primary} size="small" />
@@ -986,6 +990,8 @@ export default function AppleSubscriptionManager({
         onPress={handleRestorePurchases}
         activeOpacity={0.7}
         disabled={blockInteractions}
+        testID="paywall.restoreButton"
+        accessibilityLabel="Gendan køb"
       >
         <IconSymbol
           ios_icon_name="arrow.clockwise"

--- a/components/NotificationPermissionPrompt.tsx
+++ b/components/NotificationPermissionPrompt.tsx
@@ -150,16 +150,31 @@ export default function NotificationPermissionPrompt() {
 
           <View style={styles.buttons}>
             {status === 'denied' ? (
-              <TouchableOpacity style={[styles.button, styles.primary]} onPress={handleOpenSettings}>
+              <TouchableOpacity
+                style={[styles.button, styles.primary]}
+                onPress={handleOpenSettings}
+                testID="notifications.openSettingsButton"
+                accessibilityLabel="Åbn indstillinger"
+              >
                 <Text style={styles.primaryText}>Åbn indstillinger</Text>
               </TouchableOpacity>
             ) : (
-              <TouchableOpacity style={[styles.button, styles.primary]} onPress={handleAllow}>
+              <TouchableOpacity
+                style={[styles.button, styles.primary]}
+                onPress={handleAllow}
+                testID="notifications.enableButton"
+                accessibilityLabel="Tillad notifikationer"
+              >
                 <Text style={styles.primaryText}>Tillad notifikationer</Text>
               </TouchableOpacity>
             )}
 
-            <TouchableOpacity style={[styles.button, styles.secondary]} onPress={handleLater}>
+            <TouchableOpacity
+              style={[styles.button, styles.secondary]}
+              onPress={handleLater}
+              testID="notifications.notNowButton"
+              accessibilityLabel="Ikke nu"
+            >
               <Text style={styles.secondaryText}>Ikke nu</Text>
             </TouchableOpacity>
           </View>
@@ -171,7 +186,12 @@ export default function NotificationPermissionPrompt() {
   if (canShowCta) {
     return (
       <View style={styles.ctaContainer}>
-        <TouchableOpacity style={styles.ctaButton} onPress={reopen}>
+        <TouchableOpacity
+          style={styles.ctaButton}
+          onPress={reopen}
+          testID="notifications.enableButton"
+          accessibilityLabel="Aktiver notifikationer"
+        >
           <Text style={styles.ctaText}>Aktiver notifikationer</Text>
         </TouchableOpacity>
       </View>

--- a/components/SubscriptionManager.tsx
+++ b/components/SubscriptionManager.tsx
@@ -611,6 +611,8 @@ const statusTone = useMemo(() => {
                 onPress={() => handleSelectPlan(plan.id, plan.name, plan.max_players)}
                 disabled={isCreating || isPlanCurrent}
                 activeOpacity={0.7}
+                testID={`paywall.planCard.${plan.id}`}
+                accessibilityLabel={`Abonnement ${plan.name}`}
               >
                 {isPopular && !isPlanCurrent && (
                   <View style={[styles.popularBadge, { backgroundColor: colors.primary }]}>
@@ -713,6 +715,8 @@ const statusTone = useMemo(() => {
                     ]}
                     onPress={() => handleSelectPlan(plan.id, plan.name, plan.max_players)}
                     disabled={isCreating}
+                    testID="paywall.primaryCtaButton"
+                    accessibilityLabel={isSignupFlow ? 'Vælg denne plan' : 'Skift til denne plan'}
                   >
                     {isCreating ? (
                       <ActivityIndicator color={isPopular ? '#fff' : colors.primary} size="small" />

--- a/components/SubscriptionManager.web.tsx
+++ b/components/SubscriptionManager.web.tsx
@@ -421,6 +421,8 @@ export default function SubscriptionManager({
                 onPress={() => handleSelectPlan(plan.id, plan.name, plan.max_players)}
                 disabled={isCreating || isCurrentPlan}
                 activeOpacity={0.7}
+                testID={`paywall.planCard.${plan.id}`}
+                accessibilityLabel={`Abonnement ${plan.name}`}
               >
                 {isPopular && !isCurrentPlan && (
                   <View style={[styles.popularBadge, { backgroundColor: colors.primary }]}>
@@ -523,6 +525,8 @@ export default function SubscriptionManager({
                     ]}
                     onPress={() => handleSelectPlan(plan.id, plan.name, plan.max_players)}
                     disabled={isCreating}
+                    testID="paywall.primaryCtaButton"
+                    accessibilityLabel={isSignupFlow ? 'Vælg denne plan' : 'Skift til denne plan'}
                   >
                     {isCreating ? (
                       <ActivityIndicator color={isPopular ? '#fff' : colors.primary} size="small" />

--- a/components/TaskDetailsModal.tsx
+++ b/components/TaskDetailsModal.tsx
@@ -152,6 +152,8 @@ function TaskDetailsModalComponent({
                   onPress={onComplete}
                   disabled={disable}
                   style={[styles.primaryButtonShadow, { shadowColor: base }, disable && styles.primaryButtonDisabled]}
+                  testID="activity.completeButton"
+                  accessibilityLabel={completed ? 'Markér som ikke udført' : 'Markér som udført'}
                 >
                   <LinearGradient
                     colors={[base, lighten(base, 0.25)]}

--- a/components/TaskScoreNoteModal.tsx
+++ b/components/TaskScoreNoteModal.tsx
@@ -200,6 +200,8 @@ function TaskScoreNoteModalComponent({
         horizontal
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.scoringRow}
+        testID="feedback.scoreInput"
+        accessibilityLabel="Vælg score"
       >
         {SCORE_VALUES.map(value => {
           const isSelected = score === value;
@@ -208,6 +210,7 @@ function TaskScoreNoteModalComponent({
               key={`score-${value}`}
               style={[styles.chip, isSelected && styles.chipSelected, disableInteractions && styles.chipDisabled]}
               accessibilityRole="button"
+              testID={`feedback.scoreOption.${value}`}
               accessibilityLabel={`Score ${value}`}
               hitSlop={CHIP_HIT_SLOP}
               onPress={() => handleSelectScore(value)}
@@ -294,6 +297,8 @@ function TaskScoreNoteModalComponent({
                     placeholderTextColor="rgba(53, 65, 98, 0.5)"
                     style={[styles.noteInput, disableInteractions && styles.noteInputDisabled]}
                     textAlignVertical="top"
+                    testID="feedback.noteInput"
+                    accessibilityLabel={noteLabel}
                   />
                 </View>
               ) : null}
@@ -306,6 +311,8 @@ function TaskScoreNoteModalComponent({
                     styles.primaryButtonShadow,
                     (disableInteractions || scoreRequired) && styles.primaryButtonDisabled,
                   ]}
+                  testID="feedback.saveButton"
+                  accessibilityLabel={primaryButtonLabelResolved}
                 >
                   <LinearGradient
                     colors={[colors.primary, '#6DDC5F']}

--- a/maestro-workspace-template/01-login.yaml
+++ b/maestro-workspace-template/01-login.yaml
@@ -1,0 +1,15 @@
+appId: ${APP_ID}
+---
+- launchApp
+
+# If needed, open the profile tab where login lives.
+- tapOn:
+    text: "Profil"
+    optional: true
+
+- assertVisible:
+    id: "auth.login.emailInput"
+- assertVisible:
+    id: "auth.login.passwordInput"
+- assertVisible:
+    id: "auth.login.submitButton"

--- a/maestro-workspace-template/02-paywall.yaml
+++ b/maestro-workspace-template/02-paywall.yaml
@@ -1,0 +1,35 @@
+appId: ${APP_ID}
+---
+- launchApp
+
+# Open paywall from profile if needed.
+- tapOn:
+    text: "Profil"
+    optional: true
+- tapOn:
+    text: "Opgrader"
+    optional: true
+- tapOn:
+    text: "Premium"
+    optional: true
+
+- assertVisible:
+    id: "paywall.primaryCtaButton"
+- assertVisible:
+    id: "paywall.restoreButton"
+
+# Plan card IDs (Apple examples from this codebase).
+- assertVisible:
+    id: "paywall.planCard.fc_player_premium_monthly"
+    optional: true
+- assertVisible:
+    id: "paywall.planCard.fc_spiller_monthly"
+    optional: true
+- assertVisible:
+    id: "paywall.planCard.fc_trainer_basic_monthly"
+    optional: true
+
+# Modal close button may only exist in modal paywall contexts.
+- assertVisible:
+    id: "paywall.closeButton"
+    optional: true

--- a/maestro-workspace-template/03-activity-complete.yaml
+++ b/maestro-workspace-template/03-activity-complete.yaml
@@ -1,0 +1,9 @@
+appId: ${APP_ID}
+---
+- launchApp
+
+# Precondition: open an Activity task modal with the "Fuldfør" action.
+# Then run this test to validate the testID exists.
+
+- assertVisible:
+    id: "activity.completeButton"

--- a/maestro-workspace-template/04-feedback-modal.yaml
+++ b/maestro-workspace-template/04-feedback-modal.yaml
@@ -1,0 +1,23 @@
+appId: ${APP_ID}
+---
+- launchApp
+
+# Precondition: open Feedback modal first.
+
+- assertVisible:
+    id: "feedback.scoreInput"
+- assertVisible:
+    id: "feedback.noteInput"
+- assertVisible:
+    id: "feedback.saveButton"
+
+# Score options are dynamic by value. Check a few common values.
+- assertVisible:
+    id: "feedback.scoreOption.1"
+    optional: true
+- assertVisible:
+    id: "feedback.scoreOption.3"
+    optional: true
+- assertVisible:
+    id: "feedback.scoreOption.5"
+    optional: true

--- a/maestro-workspace-template/05-library-add-to-tasks.yaml
+++ b/maestro-workspace-template/05-library-add-to-tasks.yaml
@@ -1,0 +1,13 @@
+appId: ${APP_ID}
+---
+- launchApp
+
+# Open Library tab if needed.
+- tapOn:
+    text: "Library"
+    optional: true
+
+# Dynamic ID: library.addToTasksButton.<exerciseId>
+# Replace REPLACE_EXERCISE_ID before running.
+- assertVisible:
+    id: "library.addToTasksButton.REPLACE_EXERCISE_ID"

--- a/maestro-workspace-template/06-notifications.yaml
+++ b/maestro-workspace-template/06-notifications.yaml
@@ -1,0 +1,14 @@
+appId: ${APP_ID}
+---
+- launchApp
+
+# Depending on permission state, different buttons may be visible.
+- assertVisible:
+    id: "notifications.enableButton"
+    optional: true
+- assertVisible:
+    id: "notifications.openSettingsButton"
+    optional: true
+- assertVisible:
+    id: "notifications.notNowButton"
+    optional: true

--- a/maestro-workspace-template/README.md
+++ b/maestro-workspace-template/README.md
@@ -1,0 +1,33 @@
+# Maestro Test Template (FootballCoach)
+
+Copy these files into your Maestro workspace folder.
+
+## 1) Set app id (PowerShell)
+
+iOS:
+```powershell
+$env:APP_ID="com.erichsen.footballcoach"
+```
+
+Android:
+```powershell
+$env:APP_ID="com.anonymous.FootballCoach"
+```
+
+## 2) Run one test
+
+```powershell
+maestro test .\01-login.yaml
+```
+
+## 3) Run all tests
+
+```powershell
+maestro test .
+```
+
+## Notes
+
+- These are simple smoke tests for your new `testID`s.
+- Some tests need you to be logged in and/or already on the right screen.
+- If navigation text differs on your device language, update `tapOn` text lines.


### PR DESCRIPTION
Closes #100

- Added stable testIDs across 6 critical flows (login, paywall, activity complete, feedback modal, library add-to-tasks, notifications permission).
- Kept testIDs stable and made accessibility labels human-friendly (VoiceOver/TalkBack).
- Typecheck + lint pass.

Test:
- iPhone (dev-client): login, paywall CTA/restore/close, complete activity, feedback save, library add-to-tasks, notifications prompt/fallback.
