### PR TITLE
fix: API mocking / integration harness (#103)

### DIFF
--- a/__tests__/apiMockingHarness.test.ts
+++ b/__tests__/apiMockingHarness.test.ts
@@ -1,0 +1,94 @@
+import { activityService } from '@/services/activityService';
+import { upsertSelfFeedback } from '@/services/feedbackService';
+import { getProfileEntitlements } from '@/utils/profileEntitlements';
+import {
+  fixtureActivityWithTasks,
+  fixtureFeedbackSaved,
+  fixtureUsers,
+  getMockApiRequestLog,
+} from '../test-harness';
+
+describe('API mocking harness (offline deterministic)', () => {
+  it('returns user with entitlement from deterministic fixture', async () => {
+    const result = await getProfileEntitlements(fixtureUsers.entitled.id);
+
+    expect(result).toEqual({
+      tier: fixtureUsers.entitled.subscription_tier,
+      productId: fixtureUsers.entitled.subscription_product_id,
+      hasEntitlement: true,
+    });
+
+    const log = getMockApiRequestLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({ method: 'GET', table: 'profiles' });
+  });
+
+  it('returns user without entitlement from deterministic fixture', async () => {
+    const result = await getProfileEntitlements(fixtureUsers.notEntitled.id);
+
+    expect(result).toEqual({
+      tier: null,
+      productId: null,
+      hasEntitlement: false,
+    });
+
+    const log = getMockApiRequestLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({ method: 'GET', table: 'profiles' });
+  });
+
+  it('saves feedback via mocked POST/UPSERT and returns deterministic row', async () => {
+    const result = await upsertSelfFeedback({
+      templateId: fixtureFeedbackSaved.task_template_id,
+      userId: fixtureFeedbackSaved.user_id,
+      taskInstanceId: fixtureFeedbackSaved.task_instance_id,
+      activity_id: fixtureFeedbackSaved.activity_id,
+      rating: fixtureFeedbackSaved.rating,
+      note: fixtureFeedbackSaved.note,
+    });
+
+    expect(result).toEqual({
+      id: fixtureFeedbackSaved.id,
+      userId: fixtureFeedbackSaved.user_id,
+      taskTemplateId: fixtureFeedbackSaved.task_template_id,
+      taskInstanceId: fixtureFeedbackSaved.task_instance_id,
+      activityId: fixtureFeedbackSaved.activity_id,
+      rating: fixtureFeedbackSaved.rating,
+      note: fixtureFeedbackSaved.note,
+      createdAt: fixtureFeedbackSaved.created_at,
+      updatedAt: fixtureFeedbackSaved.updated_at,
+    });
+
+    const log = getMockApiRequestLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({ method: 'POST', table: 'task_template_self_feedback' });
+  });
+
+  it('duplicates deterministic activity with tasks without real backend access', async () => {
+    await activityService.duplicateActivity(
+      fixtureActivityWithTasks.id,
+      fixtureUsers.entitled.id,
+      'player-001',
+      'team-001',
+    );
+
+    const log = getMockApiRequestLog();
+    expect(log.map(entry => `${entry.method}:${entry.table}`)).toEqual([
+      'GET:activities',
+      'POST:activities',
+      'POST:activity_tasks',
+    ]);
+
+    const taskInsertBody = (log[2]?.body ?? []) as { title?: string; activity_id?: string }[];
+    expect(Array.isArray(taskInsertBody)).toBe(true);
+    expect(taskInsertBody).toHaveLength(2);
+    expect(taskInsertBody[0]).toMatchObject({
+      title: fixtureActivityWithTasks.activity_tasks[0].title,
+      activity_id: 'activity-duplicate-001',
+    });
+    expect(taskInsertBody[1]).toMatchObject({
+      title: fixtureActivityWithTasks.activity_tasks[1].title,
+      activity_id: 'activity-duplicate-001',
+    });
+  });
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,19 @@
+/* global beforeAll, afterEach, afterAll, jest */
 import "@testing-library/jest-native/extend-expect";
+import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
+import { mockApiServer, resetMockApiState } from './test-harness';
+
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
+
+beforeAll(() => {
+  mockApiServer.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  mockApiServer.resetHandlers();
+  resetMockApiState();
+});
+
+afterAll(() => {
+  mockApiServer.close();
+});

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "globals": "^15.14.0",
     "jest": "~29.7.0",
     "jest-expo": "~54.0.17",
+    "msw": "^1.3.5",
     "react-test-renderer": "19.1.0",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3",

--- a/test-harness/fixtures.ts
+++ b/test-harness/fixtures.ts
@@ -1,0 +1,55 @@
+export const FIXTURE_NOW_ISO = '2026-02-01T10:00:00.000Z';
+
+export const fixtureUsers = {
+  entitled: {
+    id: 'user-entitled-001',
+    subscription_tier: 'trainer_basic',
+    subscription_product_id: 'com.footballcoach.trainer.basic.monthly',
+  },
+  notEntitled: {
+    id: 'user-no-entitlement-001',
+    subscription_tier: null,
+    subscription_product_id: null,
+  },
+} as const;
+
+export const fixtureActivityWithTasks = {
+  id: 'activity-001',
+  user_id: fixtureUsers.entitled.id,
+  title: 'Passing Drill',
+  activity_date: '2026-02-12',
+  activity_time: '17:30',
+  location: 'Pitch A',
+  category_id: 'category-technical',
+  is_external: false,
+  created_at: '2026-02-01T09:00:00.000Z',
+  updated_at: '2026-02-01T09:00:00.000Z',
+  activity_tasks: [
+    {
+      id: 'task-001',
+      title: 'Warm-up rondo',
+      description: '5v2 rondo, 2 touches',
+      completed: false,
+      reminder_minutes: 30,
+    },
+    {
+      id: 'task-002',
+      title: 'One-touch passing',
+      description: 'Triangle passing circuit',
+      completed: false,
+      reminder_minutes: 15,
+    },
+  ],
+} as const;
+
+export const fixtureFeedbackSaved = {
+  id: 'feedback-001',
+  user_id: fixtureUsers.entitled.id,
+  task_template_id: 'template-001',
+  task_instance_id: 'instance-001',
+  activity_id: fixtureActivityWithTasks.id,
+  rating: 8,
+  note: 'Great intensity and focus',
+  created_at: '2026-02-01T10:00:00.000Z',
+  updated_at: '2026-02-01T10:00:00.000Z',
+} as const;

--- a/test-harness/index.ts
+++ b/test-harness/index.ts
@@ -1,0 +1,3 @@
+export { mockApiServer } from './mswServer';
+export { fixtureActivityWithTasks, fixtureFeedbackSaved, fixtureUsers } from './fixtures';
+export { getMockApiRequestLog, resetMockApiState, useMockScenario } from './scenarios';

--- a/test-harness/mswServer.ts
+++ b/test-harness/mswServer.ts
@@ -1,0 +1,40 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { handleSupabaseTable } from './scenarios';
+
+const SUPABASE_REST_ROUTE = '*/rest/v1/:table';
+
+export const mockApiServer = setupServer(
+  rest.get(SUPABASE_REST_ROUTE, (req, res, ctx) => {
+    const table = String(req.params.table ?? '');
+    const payload = handleSupabaseTable(req, table);
+    if (payload === null) {
+      return res(ctx.status(500), ctx.json({ message: `Unhandled GET table mock: ${table}` }));
+    }
+    return res(ctx.status(200), ctx.json(payload));
+  }),
+  rest.post(SUPABASE_REST_ROUTE, (req, res, ctx) => {
+    const table = String(req.params.table ?? '');
+    const payload = handleSupabaseTable(req, table);
+    if (payload === null) {
+      return res(ctx.status(500), ctx.json({ message: `Unhandled POST table mock: ${table}` }));
+    }
+    return res(ctx.status(201), ctx.json(payload));
+  }),
+  rest.patch(SUPABASE_REST_ROUTE, (req, res, ctx) => {
+    const table = String(req.params.table ?? '');
+    const payload = handleSupabaseTable(req, table);
+    if (payload === null) {
+      return res(ctx.status(500), ctx.json({ message: `Unhandled PATCH table mock: ${table}` }));
+    }
+    return res(ctx.status(200), ctx.json(payload));
+  }),
+  rest.delete(SUPABASE_REST_ROUTE, (req, res, ctx) => {
+    const table = String(req.params.table ?? '');
+    const payload = handleSupabaseTable(req, table);
+    if (payload === null) {
+      return res(ctx.status(500), ctx.json({ message: `Unhandled DELETE table mock: ${table}` }));
+    }
+    return res(ctx.status(200), ctx.json(payload));
+  })
+);

--- a/test-harness/scenarios.ts
+++ b/test-harness/scenarios.ts
@@ -1,0 +1,203 @@
+import { RestRequest } from 'msw';
+import {
+  fixtureActivityWithTasks,
+  fixtureFeedbackSaved,
+  fixtureUsers,
+} from './fixtures';
+
+type TableName =
+  | 'profiles'
+  | 'user_roles'
+  | 'activities'
+  | 'activity_tasks'
+  | 'task_template_self_feedback';
+
+type MockScenario = {
+  entitledUserId: string;
+  nonEntitledUserId: string;
+  feedbackSaved: typeof fixtureFeedbackSaved;
+  activityWithTasks: typeof fixtureActivityWithTasks;
+  userRoles: Record<string, 'player' | 'trainer' | 'admin'>;
+};
+
+const baseScenario: MockScenario = {
+  entitledUserId: fixtureUsers.entitled.id,
+  nonEntitledUserId: fixtureUsers.notEntitled.id,
+  feedbackSaved: fixtureFeedbackSaved,
+  activityWithTasks: fixtureActivityWithTasks,
+  userRoles: {
+    [fixtureUsers.entitled.id]: 'trainer',
+    [fixtureUsers.notEntitled.id]: 'player',
+  },
+};
+
+const requestLog: { method: string; table: string; url: string; body?: unknown }[] = [];
+let scenario: MockScenario = {
+  ...baseScenario,
+  userRoles: { ...baseScenario.userRoles },
+};
+
+function cloneFeedback() {
+  return { ...scenario.feedbackSaved };
+}
+
+function cloneActivityWithTasks() {
+  return {
+    ...scenario.activityWithTasks,
+    activity_tasks: scenario.activityWithTasks.activity_tasks.map(task => ({ ...task })),
+  };
+}
+
+function maybeSingleFromArray<T>(items: T[], req: RestRequest) {
+  if (req.headers.get('accept')?.includes('application/vnd.pgrst.object+json')) {
+    return items[0] ?? null;
+  }
+  return items;
+}
+
+function readReqBody(req: RestRequest) {
+  const contentType = req.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return null;
+  }
+
+  const rawBody = req.body as unknown;
+  if (rawBody && typeof rawBody === 'object') {
+    return rawBody;
+  }
+
+  try {
+    return rawBody ? JSON.parse(String(rawBody)) : null;
+  } catch {
+    return null;
+  }
+}
+
+function logRequest(req: RestRequest, table: string) {
+  requestLog.push({
+    method: req.method.toUpperCase(),
+    table,
+    url: req.url.toString(),
+    body: readReqBody(req),
+  });
+}
+
+export function resetMockApiState() {
+  requestLog.length = 0;
+  scenario = {
+    ...baseScenario,
+    userRoles: { ...baseScenario.userRoles },
+  };
+}
+
+export function useMockScenario(next: Partial<MockScenario>) {
+  scenario = {
+    ...scenario,
+    ...next,
+    userRoles: next.userRoles ? { ...next.userRoles } : { ...scenario.userRoles },
+  };
+}
+
+export function getMockApiRequestLog() {
+  return requestLog.map(entry => ({ ...entry }));
+}
+
+export function handleSupabaseTable(req: RestRequest, table: string) {
+  const normalizedTable = table as TableName;
+  logRequest(req, normalizedTable);
+
+  if (normalizedTable === 'profiles' && req.method === 'GET') {
+    const idFilter = req.url.searchParams.get('id');
+    const userId = idFilter?.replace(/^eq\./, '') ?? '';
+
+    if (userId === scenario.entitledUserId) {
+      return maybeSingleFromArray(
+        [
+          {
+            subscription_tier: fixtureUsers.entitled.subscription_tier,
+            subscription_product_id: fixtureUsers.entitled.subscription_product_id,
+          },
+        ],
+        req
+      );
+    }
+
+    if (userId === scenario.nonEntitledUserId) {
+      return maybeSingleFromArray(
+        [
+          {
+            subscription_tier: null,
+            subscription_product_id: null,
+          },
+        ],
+        req
+      );
+    }
+
+    return maybeSingleFromArray([], req);
+  }
+
+  if (normalizedTable === 'profiles' && req.method === 'POST') {
+    const body = readReqBody(req);
+    return Array.isArray(body) ? body : [body];
+  }
+
+  if (normalizedTable === 'user_roles' && req.method === 'GET') {
+    const userFilter = req.url.searchParams.get('user_id');
+    const userId = userFilter?.replace(/^eq\./, '') ?? '';
+    const role = scenario.userRoles[userId];
+    return maybeSingleFromArray(role ? [{ role }] : [], req);
+  }
+
+  if (normalizedTable === 'user_roles' && req.method === 'POST') {
+    const body = readReqBody(req);
+    const row = Array.isArray(body) ? body[0] : body;
+    const userId = String((row as any)?.user_id ?? '').trim();
+    const role = (row as any)?.role as 'player' | 'trainer' | 'admin' | undefined;
+    if (userId && role) {
+      scenario.userRoles[userId] = role;
+    }
+    return [row];
+  }
+
+  if (normalizedTable === 'activities' && req.method === 'GET') {
+    const idFilter = req.url.searchParams.get('id');
+    const activityId = idFilter?.replace(/^eq\./, '') ?? '';
+    if (activityId === scenario.activityWithTasks.id) {
+      return maybeSingleFromArray([cloneActivityWithTasks()], req);
+    }
+    return maybeSingleFromArray([], req);
+  }
+
+  if (normalizedTable === 'activities' && req.method === 'POST') {
+    const body = readReqBody(req);
+    const row = Array.isArray(body) ? body[0] : body;
+    return maybeSingleFromArray(
+      [{ ...(row as Record<string, unknown>), id: 'activity-duplicate-001' }],
+      req
+    );
+  }
+
+  if (normalizedTable === 'activity_tasks' && req.method === 'POST') {
+    const body = readReqBody(req);
+    return Array.isArray(body) ? body : [body];
+  }
+
+  if (normalizedTable === 'task_template_self_feedback' && req.method === 'GET') {
+    const userFilter = req.url.searchParams.get('user_id')?.replace(/^eq\./, '') ?? '';
+    const templateFilter = req.url.searchParams.get('task_template_id') ?? '';
+    if (
+      userFilter === scenario.feedbackSaved.user_id &&
+      templateFilter.includes(scenario.feedbackSaved.task_template_id)
+    ) {
+      return [cloneFeedback()];
+    }
+    return [];
+  }
+
+  if (normalizedTable === 'task_template_self_feedback' && req.method === 'POST') {
+    return maybeSingleFromArray([cloneFeedback()], req);
+  }
+
+  return null;
+}


### PR DESCRIPTION
Closes #103

Adds MSW (node) Jest harness with strict onUnhandledRequest: "error"

Deterministic fixtures + scenarios for entitlements/activities/tasks/feedback

Example tests proving offline, deterministic behavior

Tests: npm test (exit 0), npm run lint (exit 0), npm run typecheck (exit 0)