### PR TITLE
chore(release): bump to 1.0.4 and update release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,35 @@
 # Release Notes
+## 1.0.4
+- Forbedret stabilitet og hurtigere opstart (fix af "uendelig loader").
+- Notifikationer åbner nu korrekt den relevante opgave (deep link fix).
+- Flere rettelser i opgaver og bibliotek (bl.a. tællere, notefelt, skabeloner/arkiv).
+- Diverse mindre fejlrettelser og forbedringer.
+- Bugfixes inkluderer:
+  - Notefelt starter tomt.
+  - Opgaveskabeloner og arkiv-flow.
+  - Tilføj opgave på aktivitet samt "sæt intensitet ved opret aktivitet".
+  - Tæller i bibliotek.
+  - Intensitet tilføjet til kategori.
+  - Slet opgaver ved soft delete.
+  - Typecheck/lint issues.
+- CI/Test-løft:
+  - Automatisk testkørsel på PR.
+  - Jest + RNTL foundation.
+  - TestIDs på kritiske flows.
+  - Unit tests for core logic.
+  - Screen/component tests.
+  - API mocking harness.
+  - E2E smoke og udvidelse til 8 golden paths.
+- Golden flow release-check (Maestro):
+  - Auth.
+  - Paywall gating.
+  - Activity completion.
+  - Feedback task.
+  - Library add-to-tasks.
+  - Notifications allow/deny + fallback.
+  - Role-based UI.
+  - Error/retry.
+
 ## 1.0.3
 - Emailbekræftelse ved oprettelse (#126)
 - Notifikationer: iPhone + åbner opgave/deeplink korrekt (#89, #145)

--- a/app.config.js
+++ b/app.config.js
@@ -5,9 +5,9 @@ module.exports = ({ config }) => {
   const appVariant = process.env.APP_VARIANT === 'dev' ? 'dev' : 'prod';
   const pickFirst = value => (Array.isArray(value) ? value[0] : value);
   const scheme = pickFirst(config.scheme) || 'footballcoach';
-  const expoVersion = '1.0.3';
-  const iosBuildNumber = '4';
-  const androidVersionCode = 4;
+  const expoVersion = '1.0.4';
+  const iosBuildNumber = '5';
+  const androidVersionCode = 5;
 
   // Ensure plugins array exists and contains datetimepicker only once
   const plugins = Array.isArray(config.plugins) ? [...config.plugins] : [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Natively",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "expo-router/entry",
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start --clear --tunnel",


### PR DESCRIPTION
## Formål
Patch release `1.0.4` med fokus på bugfixes, stabilitet og test/CI-løft.

## Ændringer i denne PR
- Opdateret Expo app-version til `1.0.4`.
- Increment af `ios.buildNumber` (+1).
- Increment af `android.versionCode` (+1).
- Opdateret `package.json` version til `1.0.4`.
- Opdateret release notes med ny sektion for `1.0.4`.

## Release 1.0.4 – highlights
- Fix: Notefelt starter tomt.
- Fix: Opgaveskabeloner og arkiv.
- Fix: Tilføj opgave på aktivitet + “sæt intensitet ved opret aktivitet”.
- Fix: Tæller i bibliotek.
- Fix: Notifikation deep link til korrekt opgave (løser “tom skal” problem).
- Fix: Intensitet tilføjet til kategori.
- Fix: Slet opgaver ved soft delete.
- Fix: Uendelig app-loader.
- Fix: Typecheck/lint issues.
- CI: Automatisk testkørsel på PR.
- Test: Jest + RNTL foundation, testIDs på kritiske flows, unit tests, screen/component tests, API mocking harness.
- E2E: Smoke tests + udvidelse til 8 golden paths (Maestro).

## Golden flows (release-check)
- Auth
- Paywall gating
- Activity completion
- Feedback task
- Library add-to-tasks
- Notifications allow/deny + fallback
- Role-based UI
- Error/retry

## Validering
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (`23/23` suites, `112/112` tests)

## Risiko/impact
- Lav risiko: ingen feature-refactor i denne PR.
- Primært versionering + dokumentation af release-indhold.
