### PR TITLE
fix: external activity soft delete + ota hotfix setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,38 @@ npm test -- --watch
   - `PR CI`
   - `E2E iOS` (kun hvis I vil gøre label-kørt E2E obligatorisk ved merge)
 
+## OTA Hotfix (EAS Update)
+
+Denne app er sat op til OTA hotfixes via EAS Update.
+
+Vigtigt:
+- Første gang kræver stadig en ny App Store release, så binary'en får OTA konfigurationen med.
+- Derefter kan JS/TS-only hotfixes pushes uden ny App Store review.
+
+Flow:
+
+1. Byg og udgiv ny production binary én gang (med OTA enabled):
+
+```bash
+eas build --platform ios --profile production
+```
+
+2. Når den version er live i App Store, udgiv hotfixes direkte:
+
+```bash
+npm run update:production -- --message "hotfix: <kort beskrivelse>"
+```
+
+3. Til intern QA/staging:
+
+```bash
+npm run update:preview -- --message "preview: <kort beskrivelse>"
+```
+
+Bemærk:
+- OTA gælder kun ændringer i JS/TS/assets.
+- Native ændringer (Info.plist, pods, permissions, nye native libs osv.) kræver stadig ny binary + review.
+
 ## Maestro Mac runbook (iOS smoke)
 
 Simulator-only setup (not physical iPhone).

--- a/__tests__/deleteExternalActivities.test.ts
+++ b/__tests__/deleteExternalActivities.test.ts
@@ -1,0 +1,239 @@
+import { deleteSingleExternalActivity } from '@/utils/deleteExternalActivities';
+import { supabase } from '@/integrations/supabase/client';
+
+jest.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+    from: jest.fn(),
+  },
+}));
+
+const supabaseFromMock = supabase.from as jest.Mock;
+const getUserMock = supabase.auth.getUser as jest.Mock;
+
+describe('deleteSingleExternalActivity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('soft deletes events_external with deleted_at on success', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+
+    const metaMaybeSingle = jest.fn().mockResolvedValue({
+      data: { id: 'meta-1', external_event_id: 'event-1' },
+      error: null,
+    });
+    const metaEqUser = jest.fn().mockReturnValue({ maybeSingle: metaMaybeSingle });
+    const metaEq = jest.fn().mockReturnValue({ eq: metaEqUser });
+    const metaSelect = jest.fn().mockReturnValue({ eq: metaEq });
+
+    const updateSelect = jest.fn().mockResolvedValue({ data: [{ id: 'event-1' }], error: null });
+    const updateEq = jest.fn().mockReturnValue({ select: updateSelect });
+    const eventsUpdate = jest.fn().mockReturnValue({ eq: updateEq });
+    const eventByIdMaybeSingle = jest.fn().mockResolvedValue({ data: { id: 'event-1' }, error: null });
+    const eventByIdEq = jest.fn().mockReturnValue({ maybeSingle: eventByIdMaybeSingle });
+    const eventsSelect = jest.fn().mockReturnValue({ eq: eventByIdEq });
+
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === 'events_local_meta') return { select: metaSelect };
+      if (table === 'events_external') return { update: eventsUpdate, select: eventsSelect };
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await deleteSingleExternalActivity('meta-1');
+
+    expect(result).toEqual({ success: true });
+    expect(eventsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deleted: true,
+        deleted_at: expect.any(String),
+      })
+    );
+    expect(updateEq).toHaveBeenCalledWith('id', 'event-1');
+    expect(updateSelect).toHaveBeenCalledWith('id');
+  });
+
+  it('returns error when events_external soft delete fails', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+
+    const metaMaybeSingle = jest.fn().mockResolvedValue({
+      data: { id: 'meta-1', external_event_id: 'event-1' },
+      error: null,
+    });
+    const metaEqUser = jest.fn().mockReturnValue({ maybeSingle: metaMaybeSingle });
+    const metaEq = jest.fn().mockReturnValue({ eq: metaEqUser });
+    const metaSelect = jest.fn().mockReturnValue({ eq: metaEq });
+
+    const updateSelect = jest.fn().mockResolvedValue({ data: null, error: { message: 'delete failed' } });
+    const updateEq = jest.fn().mockReturnValue({ select: updateSelect });
+    const eventsUpdate = jest.fn().mockReturnValue({ eq: updateEq });
+    const eventByIdMaybeSingle = jest.fn().mockResolvedValue({ data: { id: 'event-1' }, error: null });
+    const eventByIdEq = jest.fn().mockReturnValue({ maybeSingle: eventByIdMaybeSingle });
+    const eventsSelect = jest.fn().mockReturnValue({ eq: eventByIdEq });
+
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === 'events_local_meta') return { select: metaSelect };
+      if (table === 'events_external') return { update: eventsUpdate, select: eventsSelect };
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await deleteSingleExternalActivity('meta-1');
+
+    expect(eventsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deleted: true,
+        deleted_at: expect.any(String),
+      })
+    );
+    expect(result).toEqual({
+      success: false,
+      error: 'delete failed',
+    });
+  });
+
+  it('returns error when soft delete updates zero rows', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+
+    const metaMaybeSingle = jest.fn().mockResolvedValue({
+      data: { id: 'meta-1', external_event_id: 'event-1' },
+      error: null,
+    });
+    const metaEqUser = jest.fn().mockReturnValue({ maybeSingle: metaMaybeSingle });
+    const metaEq = jest.fn().mockReturnValue({ eq: metaEqUser });
+    const metaSelect = jest.fn().mockReturnValue({ eq: metaEq });
+
+    const updateSelect = jest.fn().mockResolvedValue({ data: [], error: null });
+    const updateEq = jest.fn().mockReturnValue({ select: updateSelect });
+    const eventsUpdate = jest.fn().mockReturnValue({ eq: updateEq });
+    const eventByIdMaybeSingle = jest.fn().mockResolvedValue({ data: { id: 'event-1' }, error: null });
+    const eventByIdEq = jest.fn().mockReturnValue({ maybeSingle: eventByIdMaybeSingle });
+    const eventsSelect = jest.fn().mockReturnValue({ eq: eventByIdEq });
+
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === 'events_local_meta') return { select: metaSelect };
+      if (table === 'events_external') return { update: eventsUpdate, select: eventsSelect };
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await deleteSingleExternalActivity('meta-1');
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Kunne ikke soft-delete ekstern aktivitet (ingen rækker blev opdateret)',
+    });
+  });
+
+  it('retries without deleted_at_reason when schema cache is missing that column', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+
+    const metaMaybeSingle = jest.fn().mockResolvedValue({
+      data: { id: 'meta-1', external_event_id: 'event-1' },
+      error: null,
+    });
+    const metaEqUser = jest.fn().mockReturnValue({ maybeSingle: metaMaybeSingle });
+    const metaEq = jest.fn().mockReturnValue({ eq: metaEqUser });
+    const metaSelect = jest.fn().mockReturnValue({ eq: metaEq });
+
+    const updateSelect = jest.fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: {
+          code: 'PGRST204',
+          message: "Could not find the 'deleted_at_reason' column of 'events_external' in the schema cache",
+        },
+      })
+      .mockResolvedValueOnce({ data: [{ id: 'event-1' }], error: null });
+    const updateEq = jest.fn().mockReturnValue({ select: updateSelect });
+    const eventsUpdate = jest.fn().mockReturnValue({ eq: updateEq });
+    const eventByIdMaybeSingle = jest.fn().mockResolvedValue({ data: { id: 'event-1' }, error: null });
+    const eventByIdEq = jest.fn().mockReturnValue({ maybeSingle: eventByIdMaybeSingle });
+    const eventsSelect = jest.fn().mockReturnValue({ eq: eventByIdEq });
+
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === 'events_local_meta') return { select: metaSelect };
+      if (table === 'events_external') return { update: eventsUpdate, select: eventsSelect };
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await deleteSingleExternalActivity('meta-1');
+
+    expect(result).toEqual({ success: true });
+    expect(eventsUpdate).toHaveBeenCalledTimes(2);
+    expect(eventsUpdate.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        deleted: true,
+        deleted_at: expect.any(String),
+        deleted_at_reason: 'user-delete',
+      })
+    );
+    expect(eventsUpdate.mock.calls[1][0]).toEqual(
+      expect.objectContaining({
+        deleted: true,
+        deleted_at: expect.any(String),
+      })
+    );
+    expect(eventsUpdate.mock.calls[1][0]).not.toHaveProperty('deleted_at_reason');
+    expect(updateSelect).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to provider_event_uid when external_event_id does not match any row', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+
+    const metaMaybeSingle = jest.fn().mockResolvedValue({
+      data: { id: 'meta-1', external_event_id: 'legacy-id', external_event_uid: 'uid-1' },
+      error: null,
+    });
+    const metaEqUser = jest.fn().mockReturnValue({ maybeSingle: metaMaybeSingle });
+    const metaEq = jest.fn().mockReturnValue({ eq: metaEqUser });
+    const metaSelect = jest.fn().mockReturnValue({ eq: metaEq });
+
+    const updateSelect = jest.fn().mockResolvedValue({ data: [{ id: 'event-1' }], error: null });
+    const eventsUpdateEq = jest.fn().mockReturnValue({ select: updateSelect });
+    const eventsUpdateIn = jest.fn().mockReturnValue({ select: updateSelect });
+    const eventsUpdate = jest.fn().mockReturnValue({
+      eq: eventsUpdateEq,
+      in: eventsUpdateIn,
+    });
+
+    const calendarsEq = jest.fn().mockResolvedValue({
+      data: [{ id: 'cal-1' }],
+      error: null,
+    });
+    const calendarsSelect = jest.fn().mockReturnValue({ eq: calendarsEq });
+
+    const eventsByUidIn = jest.fn().mockResolvedValue({
+      data: [{ id: 'event-1' }],
+      error: null,
+    });
+    const eventByIdMaybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+    const eventsByUidEq = jest.fn((column: string) => {
+      if (column === 'id') {
+        return { maybeSingle: eventByIdMaybeSingle };
+      }
+      if (column === 'provider_event_uid') {
+        return { in: eventsByUidIn };
+      }
+      throw new Error(`Unexpected events_external eq column ${column}`);
+    });
+    const eventsByUidSelect = jest.fn().mockReturnValue({ eq: eventsByUidEq });
+
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === 'events_local_meta') return { select: metaSelect };
+      if (table === 'external_calendars') return { select: calendarsSelect };
+      if (table === 'events_external') return { update: eventsUpdate, select: eventsByUidSelect };
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await deleteSingleExternalActivity('meta-1');
+
+    expect(result).toEqual({ success: true });
+    expect(eventsUpdate).toHaveBeenCalledTimes(1);
+    expect(eventsUpdateEq).toHaveBeenCalledTimes(0);
+    expect(eventsUpdateIn).toHaveBeenCalledTimes(1);
+    expect(updateSelect).toHaveBeenCalledTimes(1);
+    expect(eventsByUidEq).toHaveBeenCalledWith('provider_event_uid', 'uid-1');
+    expect(eventsByUidIn).toHaveBeenCalledWith('provider_calendar_id', ['cal-1']);
+  });
+});

--- a/app.config.js
+++ b/app.config.js
@@ -8,6 +8,9 @@ module.exports = ({ config }) => {
   const expoVersion = '1.0.4';
   const iosBuildNumber = '5';
   const androidVersionCode = 5;
+  const easProjectId =
+    config?.extra?.eas?.projectId || '56add269-43c8-4368-9edc-3913dac2f57c';
+  const updatesUrl = `https://u.expo.dev/${easProjectId}`;
 
   // Ensure plugins array exists and contains datetimepicker only once
   const plugins = Array.isArray(config.plugins) ? [...config.plugins] : [];
@@ -24,6 +27,16 @@ module.exports = ({ config }) => {
   return {
     ...config,
     version: expoVersion,
+    runtimeVersion: {
+      policy: 'appVersion',
+    },
+    updates: {
+      ...(config.updates ?? {}),
+      enabled: true,
+      url: updatesUrl,
+      checkAutomatically: 'ON_LOAD',
+      fallbackToCacheTimeout: 0,
+    },
     scheme,
     ios: {
       ...config.ios,
@@ -36,6 +49,10 @@ module.exports = ({ config }) => {
     plugins,
     extra: {
       ...(config.extra ?? {}),
+      eas: {
+        ...(config.extra?.eas ?? {}),
+        projectId: easProjectId,
+      },
       appVariant,
       authRedirectScheme: scheme,
     },

--- a/app/activity-details.tsx
+++ b/app/activity-details.tsx
@@ -756,6 +756,7 @@ export async function fetchActivityFromDatabase(activityId: string): Promise<Act
       .from('events_external')
       .select('id,title,location,start_date,start_time,end_time,provider_calendar_id')
       .eq('id', activityId)
+      .is('deleted_at', null)
       .single();
 
     if (!externalOnlyError && externalOnly) {

--- a/eas.json
+++ b/eas.json
@@ -3,6 +3,7 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "channel": "development",
       "env": {
         "APP_VARIANT": "dev"
       },
@@ -16,9 +17,11 @@
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "autoIncrement": true
     },
     "production": {
+      "channel": "production",
       "autoIncrement": true
     }
   },

--- a/hooks/useFootballData.ts
+++ b/hooks/useFootballData.ts
@@ -13,7 +13,7 @@ import {
   refreshNotificationQueue,
   forceRefreshNotificationQueue,
 } from '@/utils/notificationScheduler';
-import { addDays, startOfWeek, endOfWeek } from 'date-fns';
+import { addDays, startOfWeek, endOfWeek, format } from 'date-fns';
 import { AppState, AppStateStatus, Platform } from 'react-native';
 import { taskService } from '@/services/taskService';
 import { activityService } from '@/services/activityService';
@@ -622,9 +622,9 @@ export const useFootballData = () => {
         userId = '';
         userEmail = '';
       }
-      const startIso = weekRange.start.toISOString().slice(0, 10);
-      const endIsoExclusive = addDays(weekRange.end, 1).toISOString().slice(0, 10);
-      const todayIso = new Date().toISOString().slice(0, 10);
+      const startIso = format(weekRange.start, 'yyyy-MM-dd');
+      const endIsoExclusive = format(addDays(weekRange.end, 1), 'yyyy-MM-dd');
+      const todayIso = format(new Date(), 'yyyy-MM-dd');
 
       const [internalRes, externalRes, internalIntensityRes, externalIntensityRes] = await Promise.all([
         supabase
@@ -1033,7 +1033,7 @@ export const useFootballData = () => {
   }, []);
 
   const todayActivities = useMemo(() => {
-    const todayIso = new Date().toISOString().slice(0, 10);
+    const todayIso = format(new Date(), 'yyyy-MM-dd');
     return activities.filter(a => (a as any).activity_date === todayIso) as Activity[];
   }, [activities]);
 

--- a/hooks/useHomeActivities.ts
+++ b/hooks/useHomeActivities.ts
@@ -601,7 +601,8 @@ export function useHomeActivities(): UseHomeActivitiesResult {
           .from('events_external')
           .select('id, title, start_date, start_time, location, provider_calendar_id, provider_event_uid, raw_payload')
           .in('provider_calendar_id', calendarIdsNormalized)
-          .eq('deleted', false);
+          .eq('deleted', false)
+          .is('deleted_at', null);
 
         if (eventsError) {
           console.error('[useHomeActivities] Error fetching external events:', {

--- a/integrations/supabase/types.ts
+++ b/integrations/supabase/types.ts
@@ -459,6 +459,8 @@ export type Database = {
       events_external: {
         Row: {
           created_at: string | null
+          deleted_at: string | null
+          deleted_at_reason: string | null
           deleted: boolean | null
           description: string | null
           end_date: string | null
@@ -481,6 +483,8 @@ export type Database = {
         }
         Insert: {
           created_at?: string | null
+          deleted_at?: string | null
+          deleted_at_reason?: string | null
           deleted?: boolean | null
           description?: string | null
           end_date?: string | null
@@ -503,6 +507,8 @@ export type Database = {
         }
         Update: {
           created_at?: string | null
+          deleted_at?: string | null
+          deleted_at_reason?: string | null
           deleted?: boolean | null
           description?: string | null
           end_date?: string | null

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "e2e:android:all": "bash scripts/maestro-smoke-android.sh",
     "build:web": "expo export -p web && npx workbox generateSW workbox-config.js",
     "build:android": "expo prebuild -p android",
+    "update:preview": "eas update --channel preview --auto",
+    "update:production": "eas update --channel production --auto",
     "lint": "eslint .",
     "focus:export-xlsx": "tsx scripts/focus/exportFocusXlsx.ts",
     "focus:import-xlsx": "tsx scripts/focus/importFocusXlsx.ts",

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -420,6 +420,8 @@ export type Database = {
       events_external: {
         Row: {
           created_at: string | null
+          deleted_at: string | null
+          deleted_at_reason: string | null
           deleted: boolean | null
           description: string | null
           end_date: string | null
@@ -442,6 +444,8 @@ export type Database = {
         }
         Insert: {
           created_at?: string | null
+          deleted_at?: string | null
+          deleted_at_reason?: string | null
           deleted?: boolean | null
           description?: string | null
           end_date?: string | null
@@ -464,6 +468,8 @@ export type Database = {
         }
         Update: {
           created_at?: string | null
+          deleted_at?: string | null
+          deleted_at_reason?: string | null
           deleted?: boolean | null
           description?: string | null
           end_date?: string | null

--- a/supabase/migrations/20260224154000_add_deleted_at_to_events_external.sql
+++ b/supabase/migrations/20260224154000_add_deleted_at_to_events_external.sql
@@ -1,0 +1,2 @@
+alter table public.events_external
+add column if not exists deleted_at timestamptz null;

--- a/supabase/migrations/20260224160000_add_partner_trainer_premium_ergcb.sql
+++ b/supabase/migrations/20260224160000_add_partner_trainer_premium_ergcb.sql
@@ -1,0 +1,44 @@
+insert into public.partner_email_entitlements (email, entitlement, source, notes, is_active)
+values
+  ('ergcb@hotmail.com', U&'tr\00E6ner_premium', 'partner', 'Lifetime partner entitlement', true)
+on conflict (email, entitlement)
+do update set
+  source = excluded.source,
+  notes = excluded.notes,
+  is_active = excluded.is_active,
+  updated_at = now();
+
+update public.user_entitlements ue
+set
+  source = pee.source,
+  is_active = true,
+  expires_at = null,
+  notes = coalesce(pee.notes, 'Auto-assigned from partner email list')
+from auth.users au
+join public.partner_email_entitlements pee
+  on pee.email = lower(trim(coalesce(au.email, '')))
+where pee.is_active
+  and pee.email = 'ergcb@hotmail.com'
+  and ue.user_id = au.id
+  and ue.entitlement = pee.entitlement
+  and ue.is_active = false;
+
+insert into public.user_entitlements (user_id, entitlement, source, is_active, expires_at, notes)
+select
+  au.id,
+  pee.entitlement,
+  pee.source,
+  true,
+  null,
+  coalesce(pee.notes, 'Auto-assigned from partner email list')
+from auth.users au
+join public.partner_email_entitlements pee
+  on pee.email = lower(trim(coalesce(au.email, '')))
+where pee.is_active
+  and pee.email = 'ergcb@hotmail.com'
+  and not exists (
+    select 1
+    from public.user_entitlements ue
+    where ue.user_id = au.id
+      and ue.entitlement = pee.entitlement
+  );

--- a/supabase/migrations/20260224173000_add_deleted_at_reason_to_events_external.sql
+++ b/supabase/migrations/20260224173000_add_deleted_at_reason_to_events_external.sql
@@ -1,0 +1,2 @@
+alter table public.events_external
+add column if not exists deleted_at_reason text null;

--- a/supabase/migrations/20260224200000_allow_update_events_external_soft_delete.sql
+++ b/supabase/migrations/20260224200000_allow_update_events_external_soft_delete.sql
@@ -1,0 +1,36 @@
+drop policy if exists "Users/admins can update external events from accessible calendars" on public.events_external;
+
+create policy "Users/admins can update external events from accessible calendars"
+  on public.events_external
+  as permissive
+  for update
+  to public
+using (
+  provider_calendar_id in (
+    select ec.id
+    from public.external_calendars ec
+    where ec.user_id = auth.uid()
+  )
+  or provider_calendar_id in (
+    select ec.id
+    from public.external_calendars ec
+    join public.admin_player_relationships apr
+      on apr.player_id = ec.user_id
+    where apr.admin_id = auth.uid()
+  )
+)
+with check (
+  provider_calendar_id is null
+  or provider_calendar_id in (
+    select ec.id
+    from public.external_calendars ec
+    where ec.user_id = auth.uid()
+  )
+  or provider_calendar_id in (
+    select ec.id
+    from public.external_calendars ec
+    join public.admin_player_relationships apr
+      on apr.player_id = ec.user_id
+    where apr.admin_id = auth.uid()
+  )
+);


### PR DESCRIPTION
## Summary
Denne PR løser flere production-bugs og klargør appen til OTA hotfixes fremadrettet.

**Closes #196**

## Problem
- Eksterne aktiviteter blev ikke slettet korrekt (soft delete), enten pga. manglende kolonner (`deleted_at`/`deleted_at_reason`) eller fordi update blev blokeret af RLS (0 rows opdateret).
- Nogle onboarding-timeouts kunne blokere startup-flow.
- Performance “indtil i dag” kunne være forkert pga. UTC/local dato-grænser.
- Appen var ikke sat op til EAS OTA hotfix-flow.

## Changes
### External activity delete (core fix)
- Tilføjet DB-migrations:
  - `20260224154000_add_deleted_at_to_events_external.sql`
  - `20260224173000_add_deleted_at_reason_to_events_external.sql`
  - `20260224200000_allow_update_events_external_soft_delete.sql` (RLS update-policy)
- Hardening i delete-flow:
  - Soft delete inkluderer `deleted_at` (+ fallback hvis `deleted_at_reason` mangler i schema cache).
  - Returnerer kun success hvis der faktisk er opdateret rækker.
  - Fallback-opslag via `provider_event_uid` når `external_event_id` ikke matcher.
- Loader-fix:
  - Relevante queries filtrerer nu på `deleted_at IS NULL`.

### Regression tests
- Ny/udvidet Jest test:
  - `__tests__/deleteExternalActivities.test.ts`
- Dækker success/error, retry uden `deleted_at_reason`, samt “0 rows updated”.

### Onboarding stability
- Startup/retry timeout håndteres non-blocking i `OnboardingGate`, så bruger ikke låses i loader-fejlstate.

### Performance counter fix
- Uge-/daggrænser i performance bruger lokal dato (`format(..., 'yyyy-MM-dd')`) i stedet for `toISOString().slice(...)`.

### OTA hotfix setup
- Konfigureret EAS Update:
  - `runtimeVersion` + `updates` i `app.config.js`
  - channels i `eas.json` (`development`, `preview`, `production`)
  - scripts i `package.json`:
    - `update:preview`
    - `update:production`
  - runbook i `README.md`

### Partner entitlement
- Migration til partner/lifetime trainer entitlement:
  - `20260224160000_add_partner_trainer_premium_ergcb.sql`

## Verification
Kørt lokalt:
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅
- `npm test -- deleteExternalActivities.test.ts` ✅

## Deployment notes
1. Kør Supabase migrations før app-release.
2. Der kræves **én ny App Store binary** med OTA-konfigurationen.
3. Herefter kan JS/TS/assets hotfixes pushes via:
   - `npm run update:production -- --message "hotfix: ..."`

## Risk / Impact
- Lav risiko for eksisterende flows.
- Vigtig afhængighed: hvis migrations ikke er kørt, vil soft-delete-flow ikke være fuldt effektivt.
