### PR TITLE
fix: juster styling på aktivitetskort (#30)

### DIFF
--- a/__tests__/activityCard.component.test.tsx
+++ b/__tests__/activityCard.component.test.tsx
@@ -149,4 +149,26 @@ describe('ActivityCard completion UI', () => {
 
     expect(getByText('Feedback på: teknik')).not.toHaveStyle({ textDecorationLine: 'line-through' });
   });
+
+  it('renders NFD encoded feedback prefix without corrupting the task name', () => {
+    const { getByText } = render(
+      <ActivityCard
+        activity={{
+          ...baseActivity,
+          tasks: [
+            {
+              id: 'feedback-task-3',
+              title: 'Feedback pa\u030a: fokus',
+              completed: false,
+              feedback_template_id: 'template-3',
+            },
+          ],
+        }}
+        resolvedDate={new Date('2026-01-01T10:00:00Z')}
+        showTasks
+      />
+    );
+
+    expect(getByText('Feedback på: fokus')).toBeTruthy();
+  });
 });

--- a/components/ActivityCard.tsx
+++ b/components/ActivityCard.tsx
@@ -189,6 +189,8 @@ const isFeedbackTitle = (title?: string | null): boolean => {
   return normalized.startsWith('feedback pa');
 };
 
+const feedbackTitlePrefixRegex = /^\s*feedback\s+p(?:å|a\u030a|a)\s*[:\s-]*/i;
+
 const splitFeedbackLabelAndName = (title?: string | null): { label: string; name: string } => {
   const decodedTitle = decodeUtf8Garble(title ?? '');
   const trimmedTitle = decodedTitle.trim();
@@ -196,13 +198,10 @@ const splitFeedbackLabelAndName = (title?: string | null): { label: string; name
     return { label: 'Feedback på:', name: '' };
   }
 
-  const normalizedTitle = normalizeFeedbackTitle(trimmedTitle);
-  const marker = 'feedback pa';
-  if (!normalizedTitle.startsWith(marker)) {
+  const remainder = trimmedTitle.replace(feedbackTitlePrefixRegex, '').trim();
+  if (remainder === trimmedTitle) {
     return { label: 'Feedback på:', name: trimmedTitle };
   }
-
-  const remainder = trimmedTitle.slice(marker.length).replace(/^[:\s-]+/, '').trim();
   if (!remainder) {
     return { label: 'Feedback på:', name: '' };
   }


### PR DESCRIPTION
## Summary
Denne PR gør feedback-opgaven på aktivitetskortet tydeligere ved at splitte tekst i label + opgavenavn:

- Viser nu: **`Feedback på:`** `<opgavenavn>`
- `Feedback på:` er bold (`700`)
- Opgavenavn er normal vægt
- Gælder kun feedback-opgaven på aktivitetskortet (ingen global refactor)

## Root Cause
Feedback-opgaven blev tidligere renderet som én samlet titelstreng med én fælles style, så “type” og opgavenavn kunne ikke styles forskelligt.

## Changes
- Opdateret rendering i `components/ActivityCard.tsx`:
  - Lokal split af feedback-title til label + navn
  - Lokal style `feedbackTaskLabel` for bold label
  - Almindelige opgaver uændret
- Opdateret `__tests__/activityCard.component.test.tsx`:
  - Assert at `Feedback på:` findes
  - Assert at feedback-opgavenavn renderes korrekt i ny tekststruktur

## Test / QA
Kørt i Codex:

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅

Maestro:

- `e2e/flows/feedback_task_smoke.yaml` findes ikke i repoet ⚠️
- `npm run e2e:ios:activity-task-flow` blev forsøgt, men hang i bootstrap/dev-server step (ingen grøn gennemkørsel i denne session) ⚠️

## Risk / Edge Cases
- Defensive fallback for titler, der ikke matcher standardformat, så teksten stadig vises robust.
- Ændringen er scoped til feedback-task rendering i aktivitetskortet.