### PR TITLE
fix: Notifikation setup (#227)

### DIFF
--- a/__tests__/notificationDeepLink.test.ts
+++ b/__tests__/notificationDeepLink.test.ts
@@ -143,6 +143,20 @@ describe('notification deeplink mapping', () => {
     });
   });
 
+  it('maps overdue reminder payload to home with overdue filter', () => {
+    const route = buildNotificationRouteFromData({
+      target: 'tasks_overdue_overview',
+      url: '/(tabs)/(home)?taskFilter=overdue',
+    });
+
+    expect(route).toEqual({
+      pathname: '/(tabs)/(home)',
+      params: {
+        taskFilter: 'overdue',
+      },
+    });
+  });
+
   it('returns null when activity context is missing for task navigation', () => {
     expect(
       buildNotificationRouteFromData({

--- a/__tests__/overdueReminder.test.ts
+++ b/__tests__/overdueReminder.test.ts
@@ -1,0 +1,85 @@
+import { buildNotificationBody, selectOverdueTasks } from '@/utils/overdueReminder';
+
+describe('overdueReminder', () => {
+  const now = new Date('2026-03-01T12:00:00.000Z');
+
+  it('builds fallback body when no overdue tasks exist', () => {
+    const body = buildNotificationBody([]);
+
+    expect(body).toContain('Små skridt hver dag giver stor fremgang.');
+    expect(body).toContain('• Ingen forfaldne opgaver lige nu');
+  });
+
+  it('builds body with a single overdue task line', () => {
+    const body = buildNotificationBody([
+      {
+        id: 'task-1',
+        title: 'Sprint-test',
+        dueAt: new Date('2026-03-01T08:00:00.000Z'),
+      },
+    ]);
+
+    expect(body).toContain('• Sprint-test');
+    expect(body).not.toContain('+1 flere');
+  });
+
+  it('limits body to 5 tasks and appends +N line', () => {
+    const tasks = Array.from({ length: 7 }, (_, index) => ({
+      id: `task-${index + 1}`,
+      title: `Opgave ${index + 1}`,
+      dueAt: new Date('2026-03-01T06:00:00.000Z'),
+    }));
+
+    const body = buildNotificationBody(tasks);
+
+    expect(body).toContain('• Opgave 1');
+    expect(body).toContain('• Opgave 5');
+    expect(body).not.toContain('• Opgave 6');
+    expect(body).toContain('• +2 flere');
+  });
+
+  it('selects and sorts overdue tasks by due time then title with stable tie-break', () => {
+    const activities = [
+      {
+        id: 'activity-b',
+        activity_date: '2026-03-01',
+        activity_time: '09:00',
+        tasks: [
+          { id: 'task-z', title: 'Zulu', completed: false },
+          { id: 'task-a', title: 'Alpha', completed: false },
+        ],
+      },
+      {
+        id: 'activity-a',
+        activity_date: '2026-03-01',
+        activity_time: '07:00',
+        tasks: [
+          { id: 'task-b', title: 'Beta', completed: false },
+          { id: 'task-c', title: 'Alpha', completed: false },
+        ],
+      },
+    ];
+
+    const overdue = selectOverdueTasks(activities, now);
+
+    expect(overdue.map((item) => item.id)).toEqual(['task-c', 'task-b', 'task-a', 'task-z']);
+    expect(overdue.map((item) => item.title)).toEqual(['Alpha', 'Beta', 'Alpha', 'Zulu']);
+  });
+
+  it('returns stable output for identical task titles and due date using id tie-breaker', () => {
+    const activities = [
+      {
+        activity_date: '2026-03-01',
+        activity_time: '08:00',
+        tasks: [
+          { id: 'task-2', title: 'Samme', completed: false },
+          { id: 'task-1', title: 'Samme', completed: false },
+        ],
+      },
+    ];
+
+    const overdue = selectOverdueTasks(activities, now);
+
+    expect(overdue.map((item) => item.id)).toEqual(['task-1', 'task-2']);
+  });
+});

--- a/__tests__/overdueReminderScheduler.test.ts
+++ b/__tests__/overdueReminderScheduler.test.ts
@@ -1,0 +1,35 @@
+import { buildScheduleDates, getNextStartOccurrence } from '@/utils/overdueReminderScheduler';
+
+describe('overdueReminderScheduler', () => {
+  it('getNextStartOccurrence returns next day when start time has passed', () => {
+    const now = new Date('2026-03-01T10:30:00.000Z');
+    const nextStart = getNextStartOccurrence(8 * 60, now);
+
+    expect(nextStart.getHours()).toBe(8);
+    expect(nextStart.getMinutes()).toBe(0);
+    expect(nextStart.getDate()).toBe(now.getDate() + 1);
+    expect(nextStart.getTime()).toBeGreaterThanOrEqual(now.getTime());
+  });
+
+  it('buildScheduleDates creates only DATE times from nextStart for 24h window', () => {
+    const nextStart = new Date('2026-03-01T08:00:00.000Z');
+    const intervalMinutes = 60;
+
+    const dates = buildScheduleDates(nextStart, intervalMinutes);
+
+    expect(dates.length).toBe(25);
+    expect(dates[0].getTime()).toBeGreaterThanOrEqual(nextStart.getTime());
+
+    for (const date of dates) {
+      expect(date.getTime()).toBeGreaterThanOrEqual(nextStart.getTime());
+    }
+
+    for (let index = 1; index < dates.length; index += 1) {
+      const spacingMs = dates[index].getTime() - dates[index - 1].getTime();
+      expect(spacingMs).toBe(intervalMinutes * 60 * 1000);
+    }
+
+    const endWindow = nextStart.getTime() + 24 * 60 * 60 * 1000;
+    expect(dates[dates.length - 1].getTime()).toBeLessThanOrEqual(endWindow);
+  });
+});

--- a/__tests__/profile.settings.notifications.test.tsx
+++ b/__tests__/profile.settings.notifications.test.tsx
@@ -1,0 +1,266 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+
+import ProfileScreen from '@/app/(tabs)/profile';
+
+const mockCheckNotificationPermissions = jest.fn();
+const mockRequestNotificationPermissions = jest.fn();
+const mockOpenNotificationSettings = jest.fn();
+
+const mockLoadOverdueReminderSettings = jest.fn();
+const mockPersistOverdueReminderSettings = jest.fn();
+const mockCancelOverdueReminderNotifications = jest.fn();
+const mockRescheduleOverdueReminderNotifications = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    replace: jest.fn(),
+    push: jest.fn(),
+  }),
+  useLocalSearchParams: () => ({}),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (callback: any) => callback(),
+}));
+
+jest.mock('@/components/IconSymbol', () => {
+  const React = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return {
+    IconSymbol: () => <Text>icon</Text>,
+  };
+});
+
+jest.mock('@/components/PremiumFeatureGate', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    PremiumFeatureGate: () => <View />,
+  };
+});
+
+jest.mock('@/components/ExternalCalendarManager', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => <View />,
+  };
+});
+
+jest.mock('@/components/SubscriptionManager', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => <View />,
+  };
+});
+
+jest.mock('@/components/AppleSubscriptionManager', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => <View />,
+  };
+});
+
+jest.mock('@/components/CreatePlayerModal', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => <View />,
+  };
+});
+
+jest.mock('@/components/PlayersList', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => <View />,
+  };
+});
+
+jest.mock('@/components/TeamManagement', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => <View />,
+  };
+});
+
+jest.mock('@/components/ui/DropdownSelect', () => {
+  const React = jest.requireActual('react');
+  const { TouchableOpacity, Text } = jest.requireActual('react-native');
+  return {
+    DropdownSelect: ({ label, testIDPrefix }: { label?: string; testIDPrefix?: string }) => (
+      <TouchableOpacity testID={`${testIDPrefix}.button`}>
+        <Text>{label ?? 'dropdown'}</Text>
+      </TouchableOpacity>
+    ),
+  };
+});
+
+jest.mock('@/contexts/SubscriptionContext', () => ({
+  useSubscription: () => ({
+    subscriptionStatus: null,
+    refreshSubscription: jest.fn(),
+    createSubscription: jest.fn(),
+    loading: false,
+  }),
+}));
+
+jest.mock('@/contexts/FootballContext', () => ({
+  useFootball: () => ({
+    refreshAll: jest.fn(),
+    activities: [],
+  }),
+}));
+
+jest.mock('@/hooks/useSubscriptionFeatures', () => ({
+  useSubscriptionFeatures: () => ({
+    featureAccess: { calendarSync: true, trainerLinking: true },
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@/hooks/useUserRole', () => ({
+  forceUserRoleRefresh: jest.fn(),
+}));
+
+jest.mock('@/contexts/AppleIAPContext', () => ({
+  PRODUCT_IDS: { PLAYER_PREMIUM: 'player-premium' },
+  useAppleIAP: () => ({
+    entitlementSnapshot: null,
+    refreshSubscriptionStatus: jest.fn(),
+    loading: false,
+    iapReady: true,
+    iapUnavailableReason: null,
+    isRestoring: false,
+    products: [],
+  }),
+}));
+
+jest.mock('@/utils/subscriptionGate', () => ({
+  getSubscriptionGateState: () => ({
+    shouldShowChooseSubscription: false,
+    hasActiveSubscription: false,
+  }),
+}));
+
+jest.mock('@/utils/deleteExternalActivities', () => ({
+  deleteAllExternalActivities: jest.fn(),
+}));
+
+jest.mock('@/utils/pushTokenService', () => ({
+  syncPushTokenForCurrentUser: jest.fn(),
+}));
+
+jest.mock('@/utils/notificationService', () => ({
+  checkNotificationPermissions: (...args: any[]) => mockCheckNotificationPermissions(...args),
+  requestNotificationPermissions: (...args: any[]) => mockRequestNotificationPermissions(...args),
+  openNotificationSettings: (...args: any[]) => mockOpenNotificationSettings(...args),
+}));
+
+jest.mock('@/utils/overdueReminderScheduler', () => {
+  const actual = jest.requireActual('@/utils/overdueReminderScheduler');
+  return {
+    ...actual,
+    loadOverdueReminderSettings: (...args: any[]) => mockLoadOverdueReminderSettings(...args),
+    persistOverdueReminderSettings: (...args: any[]) => mockPersistOverdueReminderSettings(...args),
+    cancelOverdueReminderNotifications: (...args: any[]) => mockCancelOverdueReminderNotifications(...args),
+    rescheduleOverdueReminderNotifications: (...args: any[]) => mockRescheduleOverdueReminderNotifications(...args),
+  };
+});
+
+jest.mock('@/integrations/supabase/client', () => {
+  const builder: any = {
+    select: () => builder,
+    eq: () => builder,
+    single: () => Promise.resolve({ data: null, error: null }),
+    maybeSingle: () => Promise.resolve({ data: null, error: null }),
+    update: () => builder,
+    insert: () => builder,
+    upsert: () => builder,
+    delete: () => builder,
+    order: () => builder,
+    limit: () => builder,
+  };
+
+  return {
+    supabase: {
+      auth: {
+        getUser: () => Promise.resolve({ data: { user: { id: 'user-1', email: 'test@example.com' } } }),
+        onAuthStateChange: () => ({ data: { subscription: { unsubscribe: jest.fn() } } }),
+        signUp: jest.fn(),
+        signInWithPassword: jest.fn(),
+        signOut: jest.fn(),
+      },
+      from: () => builder,
+      channel: () => ({
+        on: () => ({ on: () => ({ subscribe: () => ({}) }) }),
+      }),
+      removeChannel: () => Promise.resolve(),
+    },
+  };
+});
+
+describe('profile overdue reminder settings', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockLoadOverdueReminderSettings.mockResolvedValue({
+      enabled: false,
+      startTimeMinutes: 8 * 60,
+      intervalMinutes: 120,
+      scheduledNotificationIds: [],
+    });
+    mockPersistOverdueReminderSettings.mockResolvedValue(undefined);
+    mockCancelOverdueReminderNotifications.mockResolvedValue(undefined);
+    mockRescheduleOverdueReminderNotifications.mockResolvedValue(['first-id', 'repeat-id']);
+
+    mockCheckNotificationPermissions.mockResolvedValue(true);
+    mockRequestNotificationPermissions.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('shows section and reveals time + interval rows when toggle is enabled', async () => {
+    const screen = render(<ProfileScreen />);
+
+    fireEvent.press(await screen.findByTestId('profile.settingsSection.toggle'));
+
+    expect(await screen.findByTestId('profile.overdueReminders.section')).toBeTruthy();
+
+    fireEvent(screen.getByTestId('profile.overdueReminders.toggle'), 'valueChange', true);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('profile.overdueReminders.timeRow')).toBeTruthy();
+      expect(screen.getByTestId('profile.overdueReminders.intervalRow')).toBeTruthy();
+    });
+  });
+
+  it('shows denied fallback banner and settings CTA when permission remains denied', async () => {
+    mockCheckNotificationPermissions.mockResolvedValue(false);
+    mockRequestNotificationPermissions.mockResolvedValue(false);
+
+    const screen = render(<ProfileScreen />);
+
+    fireEvent.press(await screen.findByTestId('profile.settingsSection.toggle'));
+    fireEvent(screen.getByTestId('profile.overdueReminders.toggle'), 'valueChange', true);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('profile.overdueReminders.deniedBanner')).toBeTruthy();
+      expect(screen.getByTestId('profile.overdueReminders.openSettingsCta')).toBeTruthy();
+    });
+  });
+});

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -15,6 +15,7 @@ import {
   ScrollView,
   Switch,
 } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useFocusEffect } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -37,6 +38,17 @@ import { useAppleIAP, PRODUCT_IDS } from '@/contexts/AppleIAPContext';
 import { getSubscriptionGateState } from '@/utils/subscriptionGate';
 import { checkNotificationPermissions, openNotificationSettings, requestNotificationPermissions } from '@/utils/notificationService';
 import { syncPushTokenForCurrentUser } from '@/utils/pushTokenService';
+import { DropdownSelect } from '@/components/ui/DropdownSelect';
+import {
+  DEFAULT_OVERDUE_REMINDER_SETTINGS,
+  buildHalfHourTimeOptions,
+  cancelOverdueReminderNotifications,
+  formatTimeFromMinutes,
+  loadOverdueReminderSettings,
+  persistOverdueReminderSettings,
+  rescheduleOverdueReminderNotifications,
+  type OverdueReminderSettings,
+} from '@/utils/overdueReminderScheduler';
 
 // Conditionally import GlassView only on native platforms
 let GlassView: any = View;
@@ -96,6 +108,16 @@ const ACCOUNT_DELETION_REVIEW_PATH = 'Profil -> Indstillinger -> Konto -> Slet k
 const PROFILE_EDIT_COLLAPSE_MESSAGE = 'Tryk på Annuller eller Gem, før du kan lukke sektionen.';
 
 const authRedirectUrl = 'footballcoach://auth/callback';
+const OVERDUE_TIME_OPTIONS = buildHalfHourTimeOptions();
+const OVERDUE_INTERVAL_OPTIONS = Array.from({ length: 24 }, (_, index) => {
+  const hour = index + 1;
+  return {
+    label: `${hour}t`,
+    value: hour * 60,
+  };
+});
+const OVERDUE_INTERVAL_HOURS = Array.from({ length: 24 }, (_, index) => index + 1);
+const OVERDUE_INTERVAL_WHEEL_ITEM_HEIGHT = 44;
 
 const styles = StyleSheet.create({
   safeArea: { flex: 1 },
@@ -224,6 +246,24 @@ const styles = StyleSheet.create({
   settingsRowContent: { flex: 1 },
   settingsRowTitle: { fontSize: 16, fontWeight: '700' },
   settingsRowSubtitle: { fontSize: 13, lineHeight: 18 },
+  overdueSettingsSection: { marginTop: 8, gap: 10 },
+  deniedBanner: { borderRadius: 12, padding: 12, gap: 8 },
+  deniedBannerTitle: { fontSize: 14, fontWeight: '700' },
+  deniedBannerText: { fontSize: 13, lineHeight: 18 },
+  deniedBannerButton: { alignSelf: 'flex-start', borderRadius: 10, paddingHorizontal: 12, paddingVertical: 8 },
+  deniedBannerButtonText: { fontSize: 13, fontWeight: '700', color: '#fff' },
+  pickerButton: { borderRadius: 12, paddingHorizontal: 12, paddingVertical: 10, borderWidth: 1, borderColor: 'rgba(0,0,0,0.08)' },
+  pickerButtonText: { fontSize: 15, fontWeight: '600' },
+  iosPickerContainer: { borderRadius: 12, marginBottom: 12, overflow: 'hidden', alignItems: 'center' },
+  iosPicker: { height: 200, width: 320, alignSelf: 'center' },
+  intervalWheelContainer: { borderRadius: 12, overflow: 'hidden' },
+  intervalWheel: { height: OVERDUE_INTERVAL_WHEEL_ITEM_HEIGHT * 5 },
+  intervalWheelContent: { paddingVertical: OVERDUE_INTERVAL_WHEEL_ITEM_HEIGHT * 2 },
+  intervalWheelItem: { height: OVERDUE_INTERVAL_WHEEL_ITEM_HEIGHT, alignItems: 'center', justifyContent: 'center' },
+  intervalWheelItemText: { fontSize: 24, lineHeight: 28, fontWeight: '400', letterSpacing: -0.2 },
+  intervalWheelItemTextSelected: { fontWeight: '400' },
+  doneButton: { borderRadius: 10, paddingVertical: 10, alignItems: 'center' },
+  doneButtonText: { color: '#fff', fontWeight: '700' },
   addPlayerButton: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -407,6 +447,7 @@ export default function ProfileScreen() {
   const routeAuthMode = extractFirstParamValue(params.authMode);
   const routeOpenTrainerRequests = extractFirstParamValue(params.openTrainerRequests);
   const routeOpenTeamPlayers = extractFirstParamValue(params.openTeamPlayers);
+  const { refreshAll, activities } = useFootball();
   const [manualUpgradeTarget, setManualUpgradeTarget] = useState<UpgradeTarget | null>(null);
   const hasAutoOpenedUpgradeTargetRef = useRef<UpgradeTarget | null>(null);
 
@@ -418,6 +459,15 @@ export default function ProfileScreen() {
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
   const [notificationsEnabled, setNotificationsEnabled] = useState<boolean>(false);
   const [notificationsUpdating, setNotificationsUpdating] = useState(false);
+  const [overdueReminderSettings, setOverdueReminderSettings] = useState<OverdueReminderSettings>(
+    DEFAULT_OVERDUE_REMINDER_SETTINGS
+  );
+  const [showOverdueStartTimePicker, setShowOverdueStartTimePicker] = useState(false);
+  const [showOverdueIntervalPicker, setShowOverdueIntervalPicker] = useState(false);
+  const overdueIntervalListRef = useRef<ScrollView | null>(null);
+  const overdueScheduledIdsRef = useRef<string[]>(DEFAULT_OVERDUE_REMINDER_SETTINGS.scheduledNotificationIds);
+  const [overdueSettingsLoaded, setOverdueSettingsLoaded] = useState(false);
+  const [overduePermissionDenied, setOverduePermissionDenied] = useState(false);
   const [showCreatePlayerModal, setShowCreatePlayerModal] = useState(false);
   const [playersRefreshTrigger, setPlayersRefreshTrigger] = useState(0);
   const [isAcceptingTrainerRequest, setIsAcceptingTrainerRequest] = useState(false);
@@ -503,6 +553,109 @@ export default function ProfileScreen() {
     refreshNotificationPermission();
   }, [user, focusNonce, refreshNotificationPermission]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadSettings = async () => {
+      const persisted = await loadOverdueReminderSettings();
+      if (cancelled) return;
+      overdueScheduledIdsRef.current = persisted.scheduledNotificationIds;
+      setOverdueReminderSettings(persisted);
+      setOverdueSettingsLoaded(true);
+    };
+
+    void loadSettings();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!overdueSettingsLoaded) return;
+    void persistOverdueReminderSettings(overdueReminderSettings);
+  }, [overdueReminderSettings, overdueSettingsLoaded]);
+
+  useEffect(() => {
+    overdueScheduledIdsRef.current = overdueReminderSettings.scheduledNotificationIds;
+  }, [overdueReminderSettings.scheduledNotificationIds]);
+
+  useEffect(() => {
+    if (!overdueSettingsLoaded) return;
+    let cancelled = false;
+
+    const run = async () => {
+      const previousIds = overdueScheduledIdsRef.current;
+      const settingsForSchedule: OverdueReminderSettings = {
+        enabled: overdueReminderSettings.enabled,
+        startTimeMinutes: overdueReminderSettings.startTimeMinutes,
+        intervalMinutes: overdueReminderSettings.intervalMinutes,
+        scheduledNotificationIds: previousIds,
+      };
+
+      if (!settingsForSchedule.enabled) {
+        await cancelOverdueReminderNotifications(previousIds);
+        if (cancelled) return;
+        if (previousIds.length > 0) {
+          overdueScheduledIdsRef.current = [];
+          setOverdueReminderSettings(prev => ({ ...prev, scheduledNotificationIds: [] }));
+        }
+        return;
+      }
+
+      const currentPermission = await checkNotificationPermissions();
+      const granted = currentPermission ? true : await requestNotificationPermissions();
+
+      if (!granted) {
+        await cancelOverdueReminderNotifications(previousIds);
+        if (cancelled) return;
+        setOverduePermissionDenied(true);
+        overdueScheduledIdsRef.current = [];
+        setOverdueReminderSettings(prev => ({
+          ...prev,
+          enabled: false,
+          scheduledNotificationIds: [],
+        }));
+        return;
+      }
+
+      if (cancelled) return;
+      setOverduePermissionDenied(false);
+
+      const scheduledIds = await rescheduleOverdueReminderNotifications({
+        previousNotificationIds: previousIds,
+        settings: settingsForSchedule,
+        activities: Array.isArray(activities) ? activities : [],
+      });
+
+      if (cancelled) return;
+
+      const hasChanged =
+        scheduledIds.length !== previousIds.length ||
+        scheduledIds.some((id, index) => id !== previousIds[index]);
+
+      if (hasChanged) {
+        overdueScheduledIdsRef.current = scheduledIds;
+        setOverdueReminderSettings(prev => ({
+          ...prev,
+          scheduledNotificationIds: scheduledIds,
+        }));
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    overdueReminderSettings.enabled,
+    overdueReminderSettings.startTimeMinutes,
+    overdueReminderSettings.intervalMinutes,
+    overdueSettingsLoaded,
+    activities,
+  ]);
+
   const handleNotificationsToggle = useCallback(
     async (nextValue: boolean) => {
       if (notificationsUpdating) return;
@@ -537,6 +690,65 @@ export default function ProfileScreen() {
     [notificationsUpdating]
   );
 
+  const handleOverdueReminderToggle = useCallback((nextValue: boolean) => {
+    setOverduePermissionDenied(false);
+    setOverdueReminderSettings(prev => ({
+      ...prev,
+      enabled: nextValue,
+    }));
+  }, []);
+
+  const handleOverdueStartTimeChange = useCallback((startTimeMinutes: number) => {
+    setOverdueReminderSettings(prev => ({
+      ...prev,
+      startTimeMinutes,
+    }));
+  }, []);
+
+  const handleOverdueIntervalChange = useCallback((intervalMinutes: number) => {
+    setOverdueReminderSettings(prev => ({
+      ...prev,
+      intervalMinutes,
+    }));
+  }, []);
+
+  const selectedOverdueIntervalHours = Math.max(1, Math.min(24, Math.round(overdueReminderSettings.intervalMinutes / 60)));
+
+  const getOverdueStartTimeAsDate = useCallback(() => {
+    const date = new Date();
+    const hours = Math.floor(overdueReminderSettings.startTimeMinutes / 60);
+    const minutes = overdueReminderSettings.startTimeMinutes % 60;
+    date.setHours(hours, minutes, 0, 0);
+    return date;
+  }, [overdueReminderSettings.startTimeMinutes]);
+
+  const handleOverdueStartTimePickerChange = useCallback(
+    (_event: any, selectedDate?: Date) => {
+      if (Platform.OS !== 'ios') {
+        setShowOverdueStartTimePicker(false);
+      }
+      if (!selectedDate) return;
+
+      const nextMinutes = selectedDate.getHours() * 60 + selectedDate.getMinutes();
+      handleOverdueStartTimeChange(nextMinutes);
+    },
+    [handleOverdueStartTimeChange]
+  );
+
+  useEffect(() => {
+    if (!showOverdueIntervalPicker || Platform.OS !== 'ios') return;
+
+    const targetIndex = selectedOverdueIntervalHours - 1;
+    const timer = setTimeout(() => {
+      overdueIntervalListRef.current?.scrollTo({
+        y: targetIndex * OVERDUE_INTERVAL_WHEEL_ITEM_HEIGHT,
+        animated: false,
+      });
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [showOverdueIntervalPicker, selectedOverdueIntervalHours]);
+
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
 
@@ -547,7 +759,6 @@ export default function ProfileScreen() {
     createSubscription,
     loading: subscriptionLoading,
   } = useSubscription();
-  const { refreshAll } = useFootball();
   const {
     entitlementSnapshot,
     refreshSubscriptionStatus,
@@ -1992,6 +2203,205 @@ export default function ProfileScreen() {
                     disabled={notificationsUpdating}
                     trackColor={{ false: '#c7c7cc', true: colors.primary }}
                   />
+                </View>
+                <View
+                  style={[styles.settingsRow, { backgroundColor: nestedCardBgColor, alignItems: 'flex-start' }]}
+                  testID="profile.overdueReminders.section"
+                >
+                  <IconSymbol
+                    ios_icon_name="clock.badge.exclamationmark.fill"
+                    android_material_icon_name="schedule"
+                    size={22}
+                    color={colors.primary}
+                  />
+                  <View style={styles.settingsRowContent}>
+                    <Text style={[styles.settingsRowTitle, { color: textColor }]}>Påmindelser om forfaldne opgaver</Text>
+                    <Text style={[styles.settingsRowSubtitle, { color: textSecondaryColor }]}>
+                      Modtag påmindelser om forfaldne opgaver efter valgt starttid og interval.
+                    </Text>
+                    <View style={styles.overdueSettingsSection}>
+                      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                        <Text style={[styles.settingsRowSubtitle, { color: textSecondaryColor, flex: 1 }]}>
+                          Aktivér påmindelser
+                        </Text>
+                        <Switch
+                          testID="profile.overdueReminders.toggle"
+                          value={overdueReminderSettings.enabled}
+                          onValueChange={handleOverdueReminderToggle}
+                          trackColor={{ false: '#c7c7cc', true: colors.primary }}
+                        />
+                      </View>
+                      {overdueReminderSettings.enabled && (
+                        <View style={{ gap: 10 }}>
+                          <View testID="profile.overdueReminders.timeRow">
+                            {Platform.OS === 'ios' ? (
+                              <View style={{ gap: 8 }}>
+                                <TouchableOpacity
+                                  style={[styles.pickerButton, { backgroundColor: nestedCardBgColor }]}
+                                  onPress={() => setShowOverdueStartTimePicker(true)}
+                                  activeOpacity={0.7}
+                                  testID="profile.overdueReminders.timeButton"
+                                >
+                                  <Text style={[styles.settingsRowSubtitle, { color: textSecondaryColor, marginBottom: 2 }]}>
+                                    Starttidspunkt
+                                  </Text>
+                                  <Text style={[styles.pickerButtonText, { color: textColor }]}>
+                                    {formatTimeFromMinutes(overdueReminderSettings.startTimeMinutes)}
+                                  </Text>
+                                </TouchableOpacity>
+
+                                {showOverdueStartTimePicker ? (
+                                  <View
+                                    style={[
+                                      styles.iosPickerContainer,
+                                      { backgroundColor: isDark ? '#2a2a2a' : '#FFFFFF' },
+                                    ]}
+                                  >
+                                    <DateTimePicker
+                                      value={getOverdueStartTimeAsDate()}
+                                      mode="time"
+                                      display="spinner"
+                                      onChange={handleOverdueStartTimePickerChange}
+                                      is24Hour={true}
+                                      themeVariant={isDark ? 'dark' : 'light'}
+                                      textColor={isDark ? '#FFFFFF' : '#000000'}
+                                      style={styles.iosPicker}
+                                    />
+                                  </View>
+                                ) : null}
+
+                                {showOverdueStartTimePicker ? (
+                                  <TouchableOpacity
+                                    style={[styles.doneButton, { backgroundColor: colors.primary }]}
+                                    onPress={() => setShowOverdueStartTimePicker(false)}
+                                    activeOpacity={0.7}
+                                    testID="profile.overdueReminders.timeDone"
+                                  >
+                                    <Text style={styles.doneButtonText}>Færdig</Text>
+                                  </TouchableOpacity>
+                                ) : null}
+                              </View>
+                            ) : (
+                              <DropdownSelect
+                                testIDPrefix="profile.overdueReminders.time"
+                                options={OVERDUE_TIME_OPTIONS}
+                                selectedValue={overdueReminderSettings.startTimeMinutes}
+                                onSelect={(value) => {
+                                  handleOverdueStartTimeChange(Number(value));
+                                }}
+                                label="Starttidspunkt"
+                              />
+                            )}
+                          </View>
+                          <View testID="profile.overdueReminders.intervalRow">
+                            {Platform.OS === 'ios' ? (
+                              <View style={{ gap: 8 }}>
+                                <TouchableOpacity
+                                  style={[styles.pickerButton, { backgroundColor: nestedCardBgColor }]}
+                                  onPress={() => setShowOverdueIntervalPicker(true)}
+                                  activeOpacity={0.7}
+                                  testID="profile.overdueReminders.intervalButton"
+                                >
+                                  <Text style={[styles.settingsRowSubtitle, { color: textSecondaryColor, marginBottom: 2 }]}>
+                                    Interval
+                                  </Text>
+                                  <Text style={[styles.pickerButtonText, { color: textColor }]}>
+                                    {selectedOverdueIntervalHours}t
+                                  </Text>
+                                </TouchableOpacity>
+
+                                {showOverdueIntervalPicker ? (
+                                  <View
+                                    style={[
+                                      styles.intervalWheelContainer,
+                                      { backgroundColor: isDark ? '#2a2a2a' : '#FFFFFF' },
+                                    ]}
+                                  >
+                                    <ScrollView
+                                      ref={overdueIntervalListRef}
+                                      style={styles.intervalWheel}
+                                      contentContainerStyle={styles.intervalWheelContent}
+                                      showsVerticalScrollIndicator={false}
+                                      snapToInterval={OVERDUE_INTERVAL_WHEEL_ITEM_HEIGHT}
+                                      decelerationRate="fast"
+                                      onMomentumScrollEnd={(event) => {
+                                        const offsetY = event.nativeEvent.contentOffset.y;
+                                        const index = Math.round(offsetY / OVERDUE_INTERVAL_WHEEL_ITEM_HEIGHT);
+                                        const clampedIndex = Math.max(0, Math.min(OVERDUE_INTERVAL_HOURS.length - 1, index));
+                                        const intervalHours = OVERDUE_INTERVAL_HOURS[clampedIndex];
+                                        handleOverdueIntervalChange(intervalHours * 60);
+                                      }}
+                                    >
+                                      {OVERDUE_INTERVAL_HOURS.map((item) => {
+                                        const isSelected = item === selectedOverdueIntervalHours;
+                                        return (
+                                          <View key={`interval-hour-${item}`} style={styles.intervalWheelItem}>
+                                            <Text
+                                              allowFontScaling={false}
+                                              style={[
+                                                styles.intervalWheelItemText,
+                                                { color: isSelected ? textColor : textSecondaryColor },
+                                                isSelected ? styles.intervalWheelItemTextSelected : null,
+                                              ]}
+                                            >
+                                              {item}
+                                            </Text>
+                                          </View>
+                                        );
+                                      })}
+                                    </ScrollView>
+                                  </View>
+                                ) : null}
+
+                                {showOverdueIntervalPicker ? (
+                                  <TouchableOpacity
+                                    style={[styles.doneButton, { backgroundColor: colors.primary }]}
+                                    onPress={() => setShowOverdueIntervalPicker(false)}
+                                    activeOpacity={0.7}
+                                    testID="profile.overdueReminders.intervalDone"
+                                  >
+                                    <Text style={styles.doneButtonText}>Færdig</Text>
+                                  </TouchableOpacity>
+                                ) : null}
+                              </View>
+                            ) : (
+                              <DropdownSelect
+                                testIDPrefix="profile.overdueReminders.interval"
+                                options={OVERDUE_INTERVAL_OPTIONS}
+                                selectedValue={overdueReminderSettings.intervalMinutes}
+                                onSelect={(value) => {
+                                  handleOverdueIntervalChange(Number(value));
+                                }}
+                                label="Interval"
+                              />
+                            )}
+                          </View>
+                        </View>
+                      )}
+                      {overduePermissionDenied && (
+                        <View
+                          style={[styles.deniedBanner, { backgroundColor: isDark ? '#3b2626' : '#fdecec' }]}
+                          testID="profile.overdueReminders.deniedBanner"
+                        >
+                          <Text style={[styles.deniedBannerTitle, { color: isDark ? '#ffb3b3' : '#a12020' }]}>
+                            Notifikationstilladelse mangler
+                          </Text>
+                          <Text style={[styles.deniedBannerText, { color: textSecondaryColor }]}>
+                            Aktivér notifikationer i systemindstillinger for at bruge påmindelser om forfaldne opgaver.
+                          </Text>
+                          <TouchableOpacity
+                            style={[styles.deniedBannerButton, { backgroundColor: colors.primary }]}
+                            onPress={() => {
+                              void openNotificationSettings();
+                            }}
+                            testID="profile.overdueReminders.openSettingsCta"
+                          >
+                            <Text style={styles.deniedBannerButtonText}>Åbn indstillinger</Text>
+                          </TouchableOpacity>
+                        </View>
+                      )}
+                    </View>
+                  </View>
                 </View>
                 {/* Review note (App Store): Indstillinger -> Konto -> Slet konto */}
                 <TouchableOpacity

--- a/e2e/flows/notifications_permission_smoke.yaml
+++ b/e2e/flows/notifications_permission_smoke.yaml
@@ -53,6 +53,19 @@ tags:
     timeout: 15000
 - assertVisible:
     id: '^profile\.notificationsToggle$'
+- assertVisible:
+    id: '^profile\.overdueReminders\.section$'
+- assertVisible:
+    id: '^profile\.overdueReminders\.toggle$'
+- tapOn:
+    id: '^profile\.overdueReminders\.toggle$'
+- runFlow:
+    when:
+      visible:
+        id: '^profile\.overdueReminders\.deniedBanner$'
+    commands:
+      - assertVisible:
+          id: '^profile\.overdueReminders\.openSettingsCta$'
 - extendedWaitUntil:
     visible: '^(Deaktiveret|Disabled)$'
     timeout: 15000
@@ -125,6 +138,10 @@ tags:
     timeout: 15000
 - assertVisible:
     id: '^profile\.notificationsToggle$'
+- assertVisible:
+    id: '^profile\.overdueReminders\.section$'
+- assertVisible:
+    id: '^profile\.overdueReminders\.toggle$'
 - extendedWaitUntil:
     visible: '^(Aktiveret|Enabled)$'
     timeout: 15000

--- a/utils/notificationDeepLink.ts
+++ b/utils/notificationDeepLink.ts
@@ -1,7 +1,7 @@
 import type * as Notifications from 'expo-notifications';
 
 export type NotificationRoute = {
-  pathname: '/activity-details' | '/(tabs)/profile';
+  pathname: '/activity-details' | '/(tabs)/profile' | '/(tabs)/(home)';
   params: Record<string, string>;
 };
 
@@ -143,6 +143,9 @@ export function buildNotificationRouteFromData(rawData: Record<string, unknown>)
   const sources = collectDataSources(rawData);
   const target = getFirstString(sources, ['target'])?.toLowerCase() ?? '';
   const requestId = getFirstString(sources, ['requestId', 'request_id']);
+  const queryParams = parseQueryFromUrl(
+    getFirstString(sources, ['url', 'deepLink', 'deep_link', 'link']),
+  );
 
   if (target === 'profile_trainer_requests') {
     const params: Record<string, string> = { openTrainerRequests: '1' };
@@ -156,9 +159,14 @@ export function buildNotificationRouteFromData(rawData: Record<string, unknown>)
     return { pathname: '/(tabs)/profile', params };
   }
 
-  const queryParams = parseQueryFromUrl(
-    getFirstString(sources, ['url', 'deepLink', 'deep_link', 'link']),
-  );
+  const taskFilter = getFirstString([queryParams], ['taskFilter', 'task_filter', 'filter']);
+  if (target === 'tasks_overdue_overview' || taskFilter === 'overdue') {
+    return {
+      pathname: '/(tabs)/(home)',
+      params: { taskFilter: 'overdue' },
+    };
+  }
+
   const activityId = normalizeActivityId(sources, queryParams);
   if (!activityId) return null;
 

--- a/utils/overdueReminder.ts
+++ b/utils/overdueReminder.ts
@@ -1,0 +1,73 @@
+import { resolveActivityDateTime } from '@/utils/performanceHistory';
+
+const MOTIVATION_LINE = 'Små skridt hver dag giver stor fremgang.';
+
+export type OverdueReminderTask = {
+  id: string;
+  title: string;
+  dueAt: Date;
+};
+
+function normalizeTaskTitle(task: any): string {
+  const directTitle = typeof task?.title === 'string' ? task.title.trim() : '';
+  if (directTitle.length > 0) return directTitle;
+
+  const description = typeof task?.description === 'string' ? task.description.trim() : '';
+  if (description.length > 0) return description;
+
+  return 'Opgave uden titel';
+}
+
+export function selectOverdueTasks(activities: any[] | null | undefined, now: Date = new Date()): OverdueReminderTask[] {
+  const safeActivities = Array.isArray(activities) ? activities : [];
+  const nowMs = now.getTime();
+
+  const overdue = safeActivities.flatMap((activity, activityIndex) => {
+    const dueAt = resolveActivityDateTime(activity);
+    if (!dueAt) return [];
+    if (dueAt.getTime() >= nowMs) return [];
+
+    const tasks = Array.isArray(activity?.tasks) ? activity.tasks : [];
+    return tasks
+      .filter((task: any) => task && task.completed !== true)
+      .map((task: any, taskIndex: number) => {
+        const taskId = String(task?.id ?? `task-${activityIndex}-${taskIndex}`);
+        return {
+          id: taskId,
+          title: normalizeTaskTitle(task),
+          dueAt,
+        };
+      });
+  });
+
+  return overdue.sort((a, b) => {
+    const dueDiff = a.dueAt.getTime() - b.dueAt.getTime();
+    if (dueDiff !== 0) return dueDiff;
+
+    const titleDiff = a.title.localeCompare(b.title, 'da');
+    if (titleDiff !== 0) return titleDiff;
+
+    return a.id.localeCompare(b.id, 'da');
+  });
+}
+
+export function buildNotificationBody(overdueTasks: OverdueReminderTask[]): string {
+  if (!overdueTasks.length) {
+    return `${MOTIVATION_LINE}\n• Ingen forfaldne opgaver lige nu`;
+  }
+
+  const maxItems = 5;
+  const visible = overdueTasks.slice(0, maxItems);
+  const remaining = overdueTasks.length - visible.length;
+
+  const lines = visible.map(task => `• ${task.title}`);
+  if (remaining > 0) {
+    lines.push(`• +${remaining} flere`);
+  }
+
+  return `${MOTIVATION_LINE}\n${lines.join('\n')}`;
+}
+
+export function getOverdueNotificationTitle(): string {
+  return 'Forfaldne opgaver';
+}

--- a/utils/overdueReminderScheduler.ts
+++ b/utils/overdueReminderScheduler.ts
@@ -1,0 +1,196 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+
+import { buildNotificationBody, getOverdueNotificationTitle, selectOverdueTasks } from '@/utils/overdueReminder';
+
+const STORAGE_KEY = '@overdue_reminder_settings_v1';
+
+export type OverdueReminderSettings = {
+  enabled: boolean;
+  startTimeMinutes: number;
+  intervalMinutes: number;
+  scheduledNotificationIds: string[];
+};
+
+export const OVERDUE_INTERVAL_OPTIONS_MINUTES = [60, 120, 240, 480, 1440] as const;
+
+export const DEFAULT_OVERDUE_REMINDER_SETTINGS: OverdueReminderSettings = {
+  enabled: false,
+  startTimeMinutes: 8 * 60,
+  intervalMinutes: 120,
+  scheduledNotificationIds: [],
+};
+
+function sanitizeNumber(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export async function loadOverdueReminderSettings(): Promise<OverdueReminderSettings> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_OVERDUE_REMINDER_SETTINGS;
+
+    const parsed = JSON.parse(raw) as Partial<OverdueReminderSettings>;
+    return {
+      enabled: parsed.enabled === true,
+      startTimeMinutes: sanitizeNumber(parsed.startTimeMinutes, DEFAULT_OVERDUE_REMINDER_SETTINGS.startTimeMinutes),
+      intervalMinutes: sanitizeNumber(parsed.intervalMinutes, DEFAULT_OVERDUE_REMINDER_SETTINGS.intervalMinutes),
+      scheduledNotificationIds: Array.isArray(parsed.scheduledNotificationIds)
+        ? parsed.scheduledNotificationIds.filter((value): value is string => typeof value === 'string' && value.length > 0)
+        : [],
+    };
+  } catch {
+    return DEFAULT_OVERDUE_REMINDER_SETTINGS;
+  }
+}
+
+export async function persistOverdueReminderSettings(settings: OverdueReminderSettings): Promise<void> {
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+}
+
+export async function cancelOverdueReminderNotifications(notificationIds: string[]): Promise<void> {
+  const uniqueIds = Array.from(new Set((notificationIds || []).filter(Boolean)));
+  await Promise.all(
+    uniqueIds.map(async (id) => {
+      try {
+        await Notifications.cancelScheduledNotificationAsync(id);
+      } catch {
+        // Ignore stale ids.
+      }
+    }),
+  );
+}
+
+export function getNextStartOccurrence(startTimeMinutes: number, now: Date = new Date()): Date {
+  const hours = Math.floor(startTimeMinutes / 60);
+  const minutes = startTimeMinutes % 60;
+
+  const next = new Date(now);
+  next.setSeconds(0, 0);
+  next.setHours(hours, minutes, 0, 0);
+
+  if (next.getTime() <= now.getTime()) {
+    next.setDate(next.getDate() + 1);
+  }
+
+  return next;
+}
+
+function buildContent(activities: any[], scheduledDate?: Date): Notifications.NotificationContentInput {
+  const overdueTasks = selectOverdueTasks(activities, scheduledDate);
+  return {
+    title: getOverdueNotificationTitle(),
+    body: buildNotificationBody(overdueTasks),
+    sound: 'default',
+    data: {
+      type: 'overdue-reminder',
+      url: '/(tabs)/(home)?taskFilter=overdue',
+      target: 'tasks_overdue_overview',
+      generatedAt: new Date().toISOString(),
+      ...(scheduledDate ? { scheduledFor: scheduledDate.toISOString() } : null),
+    },
+  };
+}
+
+export function buildScheduleDates(nextStart: Date, intervalMinutes: number): Date[] {
+  const safeIntervalMinutes = Math.max(1, Math.round(intervalMinutes));
+  const intervalMs = safeIntervalMinutes * 60 * 1000;
+  const windowEnd = nextStart.getTime() + 24 * 60 * 60 * 1000;
+
+  const dates: Date[] = [];
+  let current = new Date(nextStart);
+
+  while (current.getTime() <= windowEnd) {
+    dates.push(new Date(current));
+    current = new Date(current.getTime() + intervalMs);
+  }
+
+  return dates;
+}
+
+export async function scheduleOverdueReminderNotifications(params: {
+  settings: OverdueReminderSettings;
+  activities: any[];
+  now?: Date;
+}): Promise<string[]> {
+  const { settings, activities, now = new Date() } = params;
+
+  const nextStart = getNextStartOccurrence(settings.startTimeMinutes, now);
+  const scheduleDates = buildScheduleDates(nextStart, settings.intervalMinutes);
+  const androidChannel = Platform.OS === 'android' ? { channelId: 'task-reminders' } : {};
+  const notificationIds: string[] = [];
+
+  for (const scheduledDate of scheduleDates) {
+    const content = buildContent(activities, scheduledDate);
+    const notificationId = await Notifications.scheduleNotificationAsync({
+      content,
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.DATE,
+        date: scheduledDate,
+        ...androidChannel,
+      },
+    });
+    notificationIds.push(notificationId);
+  }
+
+  return notificationIds;
+}
+
+export async function rescheduleOverdueReminderNotifications(params: {
+  previousNotificationIds: string[];
+  settings: OverdueReminderSettings;
+  activities: any[];
+  now?: Date;
+}): Promise<string[]> {
+  const { previousNotificationIds, settings, activities, now } = params;
+  await cancelOverdueReminderNotifications(previousNotificationIds);
+
+  if (!settings.enabled) {
+    return [];
+  }
+
+  return scheduleOverdueReminderNotifications({
+    settings,
+    activities,
+    now,
+  });
+}
+
+export function formatTimeFromMinutes(totalMinutes: number): string {
+  const normalized = ((totalMinutes % (24 * 60)) + (24 * 60)) % (24 * 60);
+  const hours = Math.floor(normalized / 60);
+  const minutes = normalized % 60;
+  const hh = String(hours).padStart(2, '0');
+  const mm = String(minutes).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+export function buildHalfHourTimeOptions(): { label: string; value: number }[] {
+  const options: { label: string; value: number }[] = [];
+  for (let minutes = 0; minutes < 24 * 60; minutes += 30) {
+    options.push({
+      label: formatTimeFromMinutes(minutes),
+      value: minutes,
+    });
+  }
+  return options;
+}
+
+export function buildIntervalOptions(): { label: string; value: number }[] {
+  return OVERDUE_INTERVAL_OPTIONS_MINUTES.map((minutes) => {
+    if (minutes % 60 === 0) {
+      const hours = minutes / 60;
+      return {
+        label: `${hours}t`,
+        value: minutes,
+      };
+    }
+
+    return {
+      label: `${minutes} min`,
+      value: minutes,
+    };
+  });
+}


### PR DESCRIPTION
## Formål
Løser **#227 – Notifikation setup (overdue reminders)** ved at tilføje en ny indstilling under **Profil → Indstillinger** for “Påmindelser om forfaldne opgaver”, inkl. planlægning, persistence, permission fallback, deep link og testdækning.

## Hvad er ændret

### UI / Settings
- Ny sektion: **Påmindelser om forfaldne opgaver**
- Brugeren kan:
  - aktivere/deaktivere påmindelser
  - vælge **starttidspunkt**
  - vælge **interval**
- Opdateret brødtekst:
  - `Modtag påmindelser om forfaldne opgaver efter valgt starttid og interval.`
- iOS:
  - **Starttidspunkt** bruger native `DateTimePicker` (spinner)
  - **Interval** bruger custom 1-kolonne hjul med værdier **1–24** (timer)
- Permission denied fallback:
  - Inline banner + CTA til OS-indstillinger

### Scheduling / Guardrails
- Ny overdue scheduler med local persistence i AsyncStorage:
  - `enabled`
  - `startTimeMinutes`
  - `intervalMinutes`
  - `scheduledNotificationIds`
- Ved ændringer i enabled/start/interval:
  - gamle schedules annulleres
  - nye schedules oprettes
- OnPress/onValueChange laver kun state-opdatering; scheduling sker i `useEffect` efter render.

### Overdue-notifikation logik
- Ny helper til overdue-selektion + body-building:
  - motiverende linje + liste over overdue opgaver
  - max 5 linjer + `+N flere`
  - fallback med “Ingen forfaldne opgaver lige nu”
- Stabil sortering i output.

### Deep link
- Notifikationsdata mapper nu overdue reminder til app-route:
  - `/(tabs)/(home)?taskFilter=overdue`

### Maestro
- `notifications_permission_smoke.yaml` opdateret:
  - validerer ny overdue sektion
  - forsøger denied fallback verificering

## Vigtig fix efterfølgende
For at sikre at reminder **aldrig kan trigge før starttidspunkt**:
- `TIME_INTERVAL` repeat er fjernet.
- Der planlægges nu kun `DATE` notifikationer i et 24-timers vindue:
  - `nextStart`, `nextStart + interval`, osv. til `<= nextStart + 24h`.
- Ny ren helper: `buildScheduleDates(...)`.

## Tests
Tilføjet/opdateret:
- `__tests__/overdueReminder.test.ts`
- `__tests__/overdueReminderScheduler.test.ts`
- `__tests__/profile.settings.notifications.test.tsx`
- `__tests__/notificationDeepLink.test.ts` (overdue route case)

Kørt:
- `npm run typecheck` ✅
- `npm run lint` ✅
- Relevante tests (pga. repo OOM):
  - `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --runInBand --runTestsByPath __tests__/overdueReminderScheduler.test.ts __tests__/overdueReminder.test.ts` ✅
  - `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --runInBand --runTestsByPath __tests__/profile.settings.notifications.test.tsx` ✅

## Risici / noter
- iOS interval-hjul er custom (single-column) for at opnå 1–24 talrække.
- Visual tuning af hjulets typografi/størrelse er justeret for at matche native bedre.