### PR TITLE
fix: update performance collapses and home week card visuals

### DIFF
--- a/__tests__/performance.screen.test.tsx
+++ b/__tests__/performance.screen.test.tsx
@@ -77,12 +77,22 @@ describe('PerformanceScreen', () => {
     jest.useRealTimers();
   });
 
-  it('renders performance task counts including intensity-adjusted totals', () => {
-    const { getByTestId, getByText } = render(<PerformanceScreen />);
+  it('shows collapsible pokaler and udvikling sections', () => {
+    const { getByTestId, getByText, queryByTestId, queryByText } = render(<PerformanceScreen />);
 
-    expect(getByTestId('performance.statTasks.today')).toBeTruthy();
-    expect(getByText('3 / 5')).toBeTruthy();
-    expect(getByText('5 / 8')).toBeTruthy();
+    expect(getByText('Pokaler')).toBeTruthy();
+    expect(getByText('Udvikling')).toBeTruthy();
+    expect(getByText('Guld pokaler')).toBeTruthy();
+    expect(getByTestId('mock.progressionSection')).toBeTruthy();
+
+    fireEvent.press(getByTestId('performance.trophies.toggle'));
+    expect(queryByText('Guld pokaler')).toBeNull();
+
+    fireEvent.press(getByTestId('performance.trophies.toggle'));
+    expect(getByText('Guld pokaler')).toBeTruthy();
+
+    fireEvent.press(getByTestId('performance.progression.toggle'));
+    expect(queryByTestId('mock.progressionSection')).toBeNull();
   });
 
   it('shows historik and excludes current week activities', () => {
@@ -109,9 +119,10 @@ describe('PerformanceScreen', () => {
       ],
     });
 
-    const { getByText, getAllByTestId, queryByText } = render(<PerformanceScreen />);
+    const { getByText, getAllByTestId, getByTestId, queryByText } = render(<PerformanceScreen />);
 
     expect(getByText('Historik')).toBeTruthy();
+    fireEvent.press(getByTestId('performance.history.toggle'));
     expect(getAllByTestId('mock.weeklySummaryCard')).toHaveLength(1);
 
     fireEvent.press(getByText('mock.weeklySummaryCard'));

--- a/app/(tabs)/(home)/index.ios.tsx
+++ b/app/(tabs)/(home)/index.ios.tsx
@@ -219,7 +219,8 @@ type ThisWeekPremiumCardProps = {
 
 const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
 const THIS_WEEK_PREMIUM_BG = require('../../../assets/images/home_this_week_premium_bg.png');
-const THIS_WEEK_CARD_RADIUS = 24;
+const THIS_WEEK_CARD_RADIUS = 28;
+const THIS_WEEK_BG_CROP_RADIUS = THIS_WEEK_CARD_RADIUS;
 
 const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
   weekLabel,
@@ -290,6 +291,7 @@ const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
             resizeMode="stretch"
           />
           <View pointerEvents="none" style={thisWeekPremiumCardStyles.cardImageOverlay} />
+          <View pointerEvents="none" style={thisWeekPremiumCardStyles.cardBorderOverlay} />
 
           <View style={thisWeekPremiumCardStyles.cardContent}>
         <View style={thisWeekPremiumCardStyles.headerRow}>
@@ -449,44 +451,6 @@ const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
         </View>
 
         <View style={thisWeekPremiumCardStyles.chipsRow}>
-          <View
-            testID="home.thisWeekPremiumCard.chip.tasks"
-            style={[thisWeekPremiumCardStyles.chip, thisWeekPremiumCardStyles.chipTasks]}
-          >
-            <LinearGradient
-              pointerEvents="none"
-              colors={['rgba(175,228,255,0.18)', 'rgba(175,228,255,0.15)', 'rgba(255,255,255,0.11)', 'rgba(255,210,122,0.15)', 'rgba(255,210,122,0.18)']}
-              locations={[0, 0.28, 0.50, 0.72, 1]}
-              start={{ x: 0.0, y: 0.12 }}
-              end={{ x: 1.0, y: 0.88 }}
-              style={[thisWeekPremiumCardStyles.chipGradientTint, thisWeekPremiumCardStyles.chipGradientTintTasks]}
-            />
-            <IconSymbol ios_icon_name="checkmark.circle" android_material_icon_name="check_circle" size={12} color="rgba(255,255,255,0.92)" />
-            <Text numberOfLines={1} ellipsizeMode="tail" style={thisWeekPremiumCardStyles.chipText}>
-              {tasksLabel}
-            </Text>
-          </View>
-
-          <View
-            testID="home.thisWeekPremiumCard.chip.planned"
-            style={[thisWeekPremiumCardStyles.chip, thisWeekPremiumCardStyles.chipPlanned]}
-          >
-            <LinearGradient
-              pointerEvents="none"
-              colors={['rgba(166,224,255,0.14)', 'rgba(255,255,255,0.10)', 'rgba(255,216,132,0.14)', 'rgba(255,216,132,0.18)', 'rgba(255,216,132,0.22)']}
-              locations={[0, 0.34, 0.56, 0.78, 1]}
-              start={{ x: 0.08, y: 0.30 }}
-              end={{ x: 0.92, y: 0.70 }}
-              style={[thisWeekPremiumCardStyles.chipGradientTint, thisWeekPremiumCardStyles.chipGradientTintPlanned]}
-            />
-            <IconSymbol ios_icon_name="clock" android_material_icon_name="schedule" size={12} color="rgba(255,255,255,0.92)" />
-            <Text numberOfLines={1} ellipsizeMode="tail" style={thisWeekPremiumCardStyles.chipText}>
-              {plannedLabel}
-            </Text>
-          </View>
-        </View>
-
-        <View style={thisWeekPremiumCardStyles.chipsRow2}>
           {activitiesLabel ? (
             <View
               testID="home.thisWeekPremiumCard.chip.activities"
@@ -500,7 +464,7 @@ const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
                 end={{ x: 0.08, y: 0.90 }}
                 style={[thisWeekPremiumCardStyles.chipGradientTint, thisWeekPremiumCardStyles.chipGradientTintActivities]}
               />
-              <IconSymbol ios_icon_name="calendar" android_material_icon_name="calendar_today" size={12} color="rgba(255,255,255,0.92)" />
+              <IconSymbol ios_icon_name="calendar" android_material_icon_name="calendar_today" size={14} color="rgba(255,255,255,0.92)" />
               <Text numberOfLines={1} ellipsizeMode="tail" style={thisWeekPremiumCardStyles.chipText}>
                 {activitiesLabel}
               </Text>
@@ -508,6 +472,45 @@ const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
           ) : (
             <View style={{ flex: 1 }} />
           )}
+
+          <View
+            testID="home.thisWeekPremiumCard.chip.tasks"
+            style={[thisWeekPremiumCardStyles.chip, thisWeekPremiumCardStyles.chipTasks]}
+          >
+            <LinearGradient
+              pointerEvents="none"
+              colors={['rgba(175,228,255,0.18)', 'rgba(175,228,255,0.15)', 'rgba(255,255,255,0.11)', 'rgba(255,210,122,0.15)', 'rgba(255,210,122,0.18)']}
+              locations={[0, 0.28, 0.50, 0.72, 1]}
+              start={{ x: 0.0, y: 0.12 }}
+              end={{ x: 1.0, y: 0.88 }}
+              style={[thisWeekPremiumCardStyles.chipGradientTint, thisWeekPremiumCardStyles.chipGradientTintTasks]}
+            />
+            <IconSymbol ios_icon_name="checkmark.circle" android_material_icon_name="check_circle" size={14} color="rgba(255,255,255,0.92)" />
+            <Text numberOfLines={1} ellipsizeMode="tail" style={thisWeekPremiumCardStyles.chipText}>
+              {tasksLabel}
+            </Text>
+          </View>
+
+        </View>
+
+        <View style={thisWeekPremiumCardStyles.chipsRow2}>
+          <View
+            testID="home.thisWeekPremiumCard.chip.planned"
+            style={[thisWeekPremiumCardStyles.chip, thisWeekPremiumCardStyles.chipPlanned]}
+          >
+            <LinearGradient
+              pointerEvents="none"
+              colors={['rgba(166,224,255,0.14)', 'rgba(255,255,255,0.10)', 'rgba(255,216,132,0.14)', 'rgba(255,216,132,0.18)', 'rgba(255,216,132,0.22)']}
+              locations={[0, 0.34, 0.56, 0.78, 1]}
+              start={{ x: 0.08, y: 0.30 }}
+              end={{ x: 0.92, y: 0.70 }}
+              style={[thisWeekPremiumCardStyles.chipGradientTint, thisWeekPremiumCardStyles.chipGradientTintPlanned]}
+            />
+            <IconSymbol ios_icon_name="clock" android_material_icon_name="schedule" size={14} color="rgba(255,255,255,0.92)" />
+            <Text numberOfLines={1} ellipsizeMode="tail" style={thisWeekPremiumCardStyles.chipText}>
+              {plannedLabel}
+            </Text>
+          </View>
 
           <View
             testID="home.thisWeekPremiumCard.badge.today"
@@ -531,7 +534,7 @@ const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
               accessibilityState={{ checked: isTodayOnly }}
               style={thisWeekPremiumCardStyles.todayPressable}
             >
-              <IconSymbol ios_icon_name="sun.max" android_material_icon_name="wb_sunny" size={12} color="rgba(255,255,255,0.92)" />
+              <IconSymbol ios_icon_name="sun.max" android_material_icon_name="wb_sunny" size={14} color="rgba(255,255,255,0.92)" />
               <Text numberOfLines={1} style={thisWeekPremiumCardStyles.todayText}>
                 {isTodayOnly ? 'I dag' : 'Uge'}
               </Text>
@@ -577,22 +580,39 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
   },
   cardBackground: {
     ...StyleSheet.absoluteFillObject,
-    left: 0,
-    right: 0,
-    width: '100%',
-    height: '100%',
-    borderRadius: THIS_WEEK_CARD_RADIUS,
+    top: -1,
+    left: -1,
+    right: -1,
+    bottom: -1,
+    borderRadius: THIS_WEEK_BG_CROP_RADIUS,
+    overflow: 'hidden',
   },
   cardImage: {
-    borderRadius: THIS_WEEK_CARD_RADIUS,
+    borderRadius: THIS_WEEK_BG_CROP_RADIUS,
   },
   cardImageOverlay: {
     ...StyleSheet.absoluteFillObject,
+    top: -1,
+    left: -1,
+    right: -1,
+    bottom: -1,
+    borderRadius: THIS_WEEK_BG_CROP_RADIUS,
     backgroundColor: 'rgba(0, 0, 0, 0.12)',
+  },
+  cardBorderOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: THIS_WEEK_CARD_RADIUS,
+    borderWidth: 1.2,
+    borderTopColor: 'rgba(174, 230, 255, 0.72)',
+    borderLeftColor: 'rgba(174, 230, 255, 0.60)',
+    borderRightColor: 'rgba(255, 214, 128, 0.62)',
+    borderBottomColor: 'rgba(255, 214, 128, 0.78)',
+    zIndex: 3,
   },
   cardContent: {
     paddingHorizontal: 18,
-    paddingVertical: 10,
+    paddingTop: 10,
+    paddingBottom: 16,
   },
   headerRow: {
     flexDirection: 'row',
@@ -676,7 +696,7 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
     height: 122,
     alignItems: 'center',
     justifyContent: 'center',
-    transform: [{ translateY: -11 }],
+    transform: [{ translateY: 0 }],
     marginLeft: -7,
     shadowOpacity: 0.55,
     shadowRadius: 22,
@@ -697,7 +717,7 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
     position: 'relative',
     width: 96,
     height: 80,
-    transform: [{ translateY: -24 }],
+    transform: [{ translateY: -13 }],
     alignSelf: 'flex-end',
   },
   trophySparkles: {
@@ -728,7 +748,7 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
     borderRadius: 999,
     backgroundColor: 'rgba(255,255,255,0.16)',
     overflow: 'hidden',
-    marginTop: -38,
+    marginTop: -27,
     width: '108%',
     alignSelf: 'flex-end',
   },
@@ -740,22 +760,22 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
   chipsRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    gap: 12,
-    marginTop: -6,
+    gap: 10,
+    marginTop: 14,
   },
   chipsRow2: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    gap: 12,
-    marginTop: 4,
+    gap: 10,
+    marginTop: 10,
     alignItems: 'center',
   },
   chip: {
     width: '48%',
     flexDirection: 'row',
     alignItems: 'center',
-    minHeight: 18,
-    paddingVertical: 5,
+    height: 32,
+    paddingVertical: 0,
     paddingHorizontal: 12,
     borderRadius: 999,
     backgroundColor: 'rgba(255,255,255,0.10)',
@@ -764,7 +784,7 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
     borderLeftColor: 'rgba(175, 228, 255, 0.44)',
     borderRightColor: 'rgba(255, 210, 122, 0.44)',
     borderBottomColor: 'rgba(255, 210, 122, 0.58)',
-    gap: 6,
+    gap: 8,
     shadowColor: '#84D9FF',
     shadowOpacity: 0.14,
     shadowRadius: 6,
@@ -811,7 +831,7 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
   },
   chipText: {
     color: 'rgba(255,255,255,0.88)',
-    fontSize: 10,
+    fontSize: 13,
     fontWeight: '600',
     flexShrink: 1,
   },
@@ -848,15 +868,15 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    minHeight: 18,
-    paddingVertical: 5,
+    height: 32,
+    paddingVertical: 0,
     paddingHorizontal: 12,
     borderRadius: 999,
-    gap: 6,
+    gap: 8,
   },
   todayText: {
     color: 'rgba(255,255,255,0.85)',
-    fontSize: 10,
+    fontSize: 13,
     fontWeight: '700',
   },
 });

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -181,7 +181,8 @@ type ThisWeekPremiumCardProps = {
 
 const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
 const THIS_WEEK_PREMIUM_BG = require('../../../assets/images/home_this_week_premium_bg.png');
-const THIS_WEEK_CARD_RADIUS = 24;
+const THIS_WEEK_CARD_RADIUS = 28;
+const THIS_WEEK_BG_CROP_RADIUS = THIS_WEEK_CARD_RADIUS;
 
 const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
   weekLabel,
@@ -254,6 +255,7 @@ const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
             resizeMode="stretch"
           />
           <View pointerEvents="none" style={thisWeekPremiumCardStyles.cardImageOverlay} />
+          <View pointerEvents="none" style={thisWeekPremiumCardStyles.cardBorderOverlay} />
 
           <View style={thisWeekPremiumCardStyles.cardContent}>
         <View style={thisWeekPremiumCardStyles.headerRow}>
@@ -414,44 +416,6 @@ const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
         </View>
 
         <View style={thisWeekPremiumCardStyles.chipsRow}>
-          <View
-            testID="home.thisWeekPremiumCard.chip.tasks"
-            style={[thisWeekPremiumCardStyles.chip, thisWeekPremiumCardStyles.chipTasks]}
-          >
-            <LinearGradient
-              pointerEvents="none"
-              colors={['rgba(175,228,255,0.18)', 'rgba(175,228,255,0.15)', 'rgba(255,255,255,0.11)', 'rgba(255,210,122,0.15)', 'rgba(255,210,122,0.18)']}
-              locations={[0, 0.28, 0.50, 0.72, 1]}
-              start={{ x: 0.0, y: 0.12 }}
-              end={{ x: 1.0, y: 0.88 }}
-              style={[thisWeekPremiumCardStyles.chipGradientTint, thisWeekPremiumCardStyles.chipGradientTintTasks]}
-            />
-            <IconSymbol ios_icon_name="checkmark.circle" android_material_icon_name="check_circle" size={12} color="rgba(255,255,255,0.92)" />
-            <Text numberOfLines={1} ellipsizeMode="tail" style={thisWeekPremiumCardStyles.chipText}>
-              {tasksLabel}
-            </Text>
-          </View>
-
-          <View
-            testID="home.thisWeekPremiumCard.chip.planned"
-            style={[thisWeekPremiumCardStyles.chip, thisWeekPremiumCardStyles.chipPlanned]}
-          >
-            <LinearGradient
-              pointerEvents="none"
-              colors={['rgba(166,224,255,0.14)', 'rgba(255,255,255,0.10)', 'rgba(255,216,132,0.14)', 'rgba(255,216,132,0.18)', 'rgba(255,216,132,0.22)']}
-              locations={[0, 0.34, 0.56, 0.78, 1]}
-              start={{ x: 0.08, y: 0.30 }}
-              end={{ x: 0.92, y: 0.70 }}
-              style={[thisWeekPremiumCardStyles.chipGradientTint, thisWeekPremiumCardStyles.chipGradientTintPlanned]}
-            />
-            <IconSymbol ios_icon_name="clock" android_material_icon_name="schedule" size={12} color="rgba(255,255,255,0.92)" />
-            <Text numberOfLines={1} ellipsizeMode="tail" style={thisWeekPremiumCardStyles.chipText}>
-              {plannedLabel}
-            </Text>
-          </View>
-        </View>
-
-        <View style={thisWeekPremiumCardStyles.chipsRow2}>
           {activitiesLabel ? (
             <View
               testID="home.thisWeekPremiumCard.chip.activities"
@@ -465,7 +429,7 @@ const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
                 end={{ x: 0.08, y: 0.90 }}
                 style={[thisWeekPremiumCardStyles.chipGradientTint, thisWeekPremiumCardStyles.chipGradientTintActivities]}
               />
-              <IconSymbol ios_icon_name="calendar" android_material_icon_name="calendar_today" size={12} color="rgba(255,255,255,0.92)" />
+              <IconSymbol ios_icon_name="calendar" android_material_icon_name="calendar_today" size={14} color="rgba(255,255,255,0.92)" />
               <Text numberOfLines={1} ellipsizeMode="tail" style={thisWeekPremiumCardStyles.chipText}>
                 {activitiesLabel}
               </Text>
@@ -473,6 +437,45 @@ const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
           ) : (
             <View style={{ flex: 1 }} />
           )}
+
+          <View
+            testID="home.thisWeekPremiumCard.chip.tasks"
+            style={[thisWeekPremiumCardStyles.chip, thisWeekPremiumCardStyles.chipTasks]}
+          >
+            <LinearGradient
+              pointerEvents="none"
+              colors={['rgba(175,228,255,0.18)', 'rgba(175,228,255,0.15)', 'rgba(255,255,255,0.11)', 'rgba(255,210,122,0.15)', 'rgba(255,210,122,0.18)']}
+              locations={[0, 0.28, 0.50, 0.72, 1]}
+              start={{ x: 0.0, y: 0.12 }}
+              end={{ x: 1.0, y: 0.88 }}
+              style={[thisWeekPremiumCardStyles.chipGradientTint, thisWeekPremiumCardStyles.chipGradientTintTasks]}
+            />
+            <IconSymbol ios_icon_name="checkmark.circle" android_material_icon_name="check_circle" size={14} color="rgba(255,255,255,0.92)" />
+            <Text numberOfLines={1} ellipsizeMode="tail" style={thisWeekPremiumCardStyles.chipText}>
+              {tasksLabel}
+            </Text>
+          </View>
+
+        </View>
+
+        <View style={thisWeekPremiumCardStyles.chipsRow2}>
+          <View
+            testID="home.thisWeekPremiumCard.chip.planned"
+            style={[thisWeekPremiumCardStyles.chip, thisWeekPremiumCardStyles.chipPlanned]}
+          >
+            <LinearGradient
+              pointerEvents="none"
+              colors={['rgba(166,224,255,0.14)', 'rgba(255,255,255,0.10)', 'rgba(255,216,132,0.14)', 'rgba(255,216,132,0.18)', 'rgba(255,216,132,0.22)']}
+              locations={[0, 0.34, 0.56, 0.78, 1]}
+              start={{ x: 0.08, y: 0.30 }}
+              end={{ x: 0.92, y: 0.70 }}
+              style={[thisWeekPremiumCardStyles.chipGradientTint, thisWeekPremiumCardStyles.chipGradientTintPlanned]}
+            />
+            <IconSymbol ios_icon_name="clock" android_material_icon_name="schedule" size={14} color="rgba(255,255,255,0.92)" />
+            <Text numberOfLines={1} ellipsizeMode="tail" style={thisWeekPremiumCardStyles.chipText}>
+              {plannedLabel}
+            </Text>
+          </View>
 
           <View
             testID="home.thisWeekPremiumCard.badge.today"
@@ -496,7 +499,7 @@ const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
               accessibilityState={{ checked: isTodayOnly }}
               style={thisWeekPremiumCardStyles.todayPressable}
             >
-              <IconSymbol ios_icon_name="sun.max" android_material_icon_name="wb_sunny" size={12} color="rgba(255,255,255,0.92)" />
+              <IconSymbol ios_icon_name="sun.max" android_material_icon_name="wb_sunny" size={14} color="rgba(255,255,255,0.92)" />
               <Text numberOfLines={1} style={thisWeekPremiumCardStyles.todayText}>
                 {isTodayOnly ? 'I dag' : 'Uge'}
               </Text>
@@ -542,22 +545,39 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
   },
   cardBackground: {
     ...StyleSheet.absoluteFillObject,
-    left: 0,
-    right: 0,
-    width: '100%',
-    height: '100%',
-    borderRadius: THIS_WEEK_CARD_RADIUS,
+    top: -1,
+    left: -1,
+    right: -1,
+    bottom: -1,
+    borderRadius: THIS_WEEK_BG_CROP_RADIUS,
+    overflow: 'hidden',
   },
   cardImage: {
-    borderRadius: THIS_WEEK_CARD_RADIUS,
+    borderRadius: THIS_WEEK_BG_CROP_RADIUS,
   },
   cardImageOverlay: {
     ...StyleSheet.absoluteFillObject,
+    top: -1,
+    left: -1,
+    right: -1,
+    bottom: -1,
+    borderRadius: THIS_WEEK_BG_CROP_RADIUS,
     backgroundColor: 'rgba(0, 0, 0, 0.12)',
+  },
+  cardBorderOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: THIS_WEEK_CARD_RADIUS,
+    borderWidth: 1.2,
+    borderTopColor: 'rgba(174, 230, 255, 0.72)',
+    borderLeftColor: 'rgba(174, 230, 255, 0.60)',
+    borderRightColor: 'rgba(255, 214, 128, 0.62)',
+    borderBottomColor: 'rgba(255, 214, 128, 0.78)',
+    zIndex: 3,
   },
   cardContent: {
     paddingHorizontal: 18,
-    paddingVertical: 10,
+    paddingTop: 10,
+    paddingBottom: 16,
   },
   headerRow: {
     flexDirection: 'row',
@@ -641,7 +661,7 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
     height: 122,
     alignItems: 'center',
     justifyContent: 'center',
-    transform: [{ translateY: -11 }],
+    transform: [{ translateY: 0 }],
     marginLeft: -7,
     shadowOpacity: 0.55,
     shadowRadius: 22,
@@ -662,7 +682,7 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
     position: 'relative',
     width: 96,
     height: 80,
-    transform: [{ translateY: -24 }],
+    transform: [{ translateY: -13 }],
     alignSelf: 'flex-end',
   },
   trophySparkles: {
@@ -693,7 +713,7 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
     borderRadius: 999,
     backgroundColor: 'rgba(255,255,255,0.16)',
     overflow: 'hidden',
-    marginTop: -38,
+    marginTop: -27,
     width: '108%',
     alignSelf: 'flex-end',
   },
@@ -705,22 +725,22 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
   chipsRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    gap: 12,
-    marginTop: -6,
+    gap: 10,
+    marginTop: 14,
   },
   chipsRow2: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    gap: 12,
-    marginTop: 4,
+    gap: 10,
+    marginTop: 10,
     alignItems: 'center',
   },
   chip: {
     width: '48%',
     flexDirection: 'row',
     alignItems: 'center',
-    minHeight: 18,
-    paddingVertical: 5,
+    height: 32,
+    paddingVertical: 0,
     paddingHorizontal: 12,
     borderRadius: 999,
     backgroundColor: 'rgba(255,255,255,0.10)',
@@ -729,7 +749,7 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
     borderLeftColor: 'rgba(175, 228, 255, 0.44)',
     borderRightColor: 'rgba(255, 210, 122, 0.44)',
     borderBottomColor: 'rgba(255, 210, 122, 0.58)',
-    gap: 6,
+    gap: 8,
     shadowColor: '#84D9FF',
     shadowOpacity: 0.14,
     shadowRadius: 6,
@@ -776,7 +796,7 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
   },
   chipText: {
     color: 'rgba(255,255,255,0.88)',
-    fontSize: 10,
+    fontSize: 13,
     fontWeight: '600',
     flexShrink: 1,
   },
@@ -813,15 +833,15 @@ const thisWeekPremiumCardStyles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    minHeight: 18,
-    paddingVertical: 5,
+    height: 32,
+    paddingVertical: 0,
     paddingHorizontal: 12,
     borderRadius: 999,
-    gap: 6,
+    gap: 8,
   },
   todayText: {
     color: 'rgba(255,255,255,0.85)',
-    fontSize: 10,
+    fontSize: 13,
     fontWeight: '700',
   },
 });

--- a/app/(tabs)/performance.tsx
+++ b/app/(tabs)/performance.tsx
@@ -47,7 +47,6 @@ function buildHistoryActivityKey(activity: any, weekKey: string, index: number):
 export default function PerformanceScreen() {
   const {
     trophies,
-    currentWeekStats,
     externalCalendars,
     fetchExternalCalendarEvents,
     categories,
@@ -58,7 +57,9 @@ export default function PerformanceScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [expandedTrophy, setExpandedTrophy] = useState<'gold' | 'silver' | 'bronze' | null>(null);
   const [expandedHistoryWeeks, setExpandedHistoryWeeks] = useState<Record<string, boolean>>({});
-  const [isHistorySectionExpanded, setIsHistorySectionExpanded] = useState(true);
+  const [isTrophySectionExpanded, setIsTrophySectionExpanded] = useState(true);
+  const [isProgressionSectionExpanded, setIsProgressionSectionExpanded] = useState(true);
+  const [isHistorySectionExpanded, setIsHistorySectionExpanded] = useState(false);
 
   const palette = useMemo(() => {
     const fromHelper =
@@ -138,25 +139,6 @@ export default function PerformanceScreen() {
     return items;
   }, [expandedHistoryWeeks, historyWeeks]);
 
-  const safeWeekStats = currentWeekStats ?? {
-    totalTasksForWeek: 0,
-    completedTasksForWeek: 0,
-  };
-
-  const totalTasksForWeek = safeWeekStats.totalTasksForWeek;
-  const completedTasksForWeek = safeWeekStats.completedTasksForWeek;
-  const weekPercentage =
-    totalTasksForWeek > 0 ? Math.round((completedTasksForWeek / totalTasksForWeek) * 100) : 0;
-
-  const currentPercentage =
-    currentWeekStats && currentWeekStats.percentage !== undefined ? currentWeekStats.percentage : 0;
-  const completedTasks =
-    currentWeekStats && currentWeekStats.completedTasks !== undefined
-      ? currentWeekStats.completedTasks
-      : 0;
-  const totalTasks =
-    currentWeekStats && currentWeekStats.totalTasks !== undefined ? currentWeekStats.totalTasks : 0;
-
   const currentWeek = getWeek(new Date());
   const currentYear = new Date().getFullYear();
 
@@ -190,30 +172,6 @@ export default function PerformanceScreen() {
     return grouped;
   }, [trophies, currentWeek, currentYear]);
 
-  const getTrophyEmoji = (type: 'gold' | 'silver' | 'bronze') => {
-    switch (type) {
-      case 'gold':
-        return '🥇';
-      case 'silver':
-        return '🥈';
-      case 'bronze':
-        return '🥉';
-    }
-  };
-
-  const getCoachingMessage = (percentage: number) => {
-    if (percentage >= 80) {
-      return 'Fantastisk! Du er helt på toppen indtil nu! Fortsæt det gode arbejde! 🌟';
-    }
-    if (percentage >= 60) {
-      return 'Rigtig godt! Du klarer dig godt indtil nu. Bliv ved! 💪';
-    }
-    if (percentage >= 40) {
-      return 'Du er på vej! Der er stadig tid til at forbedre dig. 🔥';
-    }
-    return 'Kom igen! Fokuser på dine opgaver for at komme tilbage på sporet. ⚽';
-  };
-
   const goldTrophies = trophyWeeksByType.gold.length;
   const silverTrophies = trophyWeeksByType.silver.length;
   const bronzeTrophies = trophyWeeksByType.bronze.length;
@@ -241,146 +199,228 @@ export default function PerformanceScreen() {
         <Text style={[styles.headerSubtitle, { color: textSecondaryColor }]}>Se hvordan du klarer dig over tid</Text>
       </View>
 
-      <View
-        style={[styles.currentWeekCard, { backgroundColor: palette.accent }]}
-        testID="performance.currentWeekCard"
-      >
-        <View style={styles.currentWeekHeader}>
-          <Text style={styles.currentWeekTitle}>Denne uge</Text>
-          <Text style={styles.trophyBadge}>
-            {getTrophyEmoji(currentPercentage >= 80 ? 'gold' : currentPercentage >= 60 ? 'silver' : 'bronze')}
-          </Text>
-        </View>
-        <Text style={styles.currentWeekSubtitle}>
-          Uge {currentWeek}, {currentYear}
-        </Text>
+      <View style={styles.historySection}>
+        <Pressable
+          style={({ pressed }) => [styles.historyHeaderPressable, pressed && styles.historyHeaderPressed]}
+          onPress={() => setIsTrophySectionExpanded((prev) => !prev)}
+          testID="performance.trophies.toggle"
+        >
+          <View style={styles.historyHeaderShadow}>
+            <LinearGradient
+              colors={
+                isDark
+                  ? ['rgba(43, 76, 92, 0.62)', 'rgba(29, 52, 69, 0.62)', 'rgba(25, 43, 56, 0.62)']
+                  : ['rgba(255, 255, 255, 0.62)', 'rgba(234, 243, 238, 0.62)', 'rgba(221, 239, 227, 0.62)']
+              }
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 1 }}
+              style={[styles.historyHeaderCard, { borderColor: isDark ? 'rgba(191, 220, 203, 0.20)' : 'rgba(76, 175, 80, 0.22)' }]}
+            >
+              <LinearGradient
+                colors={
+                  isDark
+                    ? ['rgba(255, 255, 255, 0.10)', 'rgba(255, 255, 255, 0.00)']
+                    : ['rgba(255, 255, 255, 0.55)', 'rgba(255, 255, 255, 0.00)']
+                }
+                start={{ x: 0, y: 0 }}
+                end={{ x: 0.8, y: 0.8 }}
+                style={styles.historyHeaderSheen}
+              />
 
-        <View style={styles.statsRow}>
-          <View style={styles.statBox} testID="performance.statBox.today">
-            <Text style={styles.statLabel}>Indtil i dag</Text>
-            <Text style={styles.statPercentage} testID="performance.statPercentage.today">
-              {currentPercentage}%
-            </Text>
-            <Text style={styles.statTasks} testID="performance.statTasks.today">
-              {completedTasks} / {totalTasks}
-            </Text>
-            <View style={styles.progressBarContainer}>
-              <View style={[styles.progressBar, { width: `${currentPercentage}%` }]} />
-            </View>
+              <View style={styles.historyHeader}>
+                <View style={styles.historyTitleBlock}>
+                  <Text style={[styles.historyTitle, { color: isDark ? '#E6F5EC' : '#1D3A2A' }]}>Pokaler</Text>
+                  <Text style={[styles.historySubtitle, { color: isDark ? '#B5D8C2' : '#2C5A40' }]}>
+                    Se dine pokaler for tidligere uger
+                  </Text>
+                </View>
+                <View style={styles.historyChevronShadow}>
+                  <LinearGradient
+                    colors={isDark ? ['#3CC06A', '#1F8A43'] : ['#4CC46E', '#279B4A']}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 1 }}
+                    style={styles.historyChevronButton}
+                  >
+                    <IconSymbol
+                      ios_icon_name={isTrophySectionExpanded ? 'chevron.up' : 'chevron.down'}
+                      android_material_icon_name={isTrophySectionExpanded ? 'keyboard-arrow-up' : 'keyboard-arrow-down'}
+                      size={20}
+                      color="#FFFFFF"
+                    />
+                    <LinearGradient
+                      colors={['rgba(255,255,255,0.35)', 'rgba(255,255,255,0.00)']}
+                      start={{ x: 0, y: 0 }}
+                      end={{ x: 1, y: 1 }}
+                      style={styles.historyChevronSheen}
+                    />
+                  </LinearGradient>
+                </View>
+              </View>
+            </LinearGradient>
           </View>
-
-          <View style={styles.statBox}>
-            <Text style={styles.statLabel}>Hele ugen</Text>
-            <Text style={styles.statPercentage}>{weekPercentage}%</Text>
-            <Text style={styles.statTasks}>
-              {completedTasksForWeek} / {totalTasksForWeek}
-            </Text>
-            <View style={styles.progressBarContainer}>
-              <View style={[styles.progressBar, { width: `${weekPercentage}%` }]} />
-            </View>
-          </View>
-        </View>
-
-        <View style={styles.coachingBox}>
-          <Text style={styles.coachingTitle}>💬 Coaching</Text>
-          <Text style={styles.coachingText}>{getCoachingMessage(currentPercentage)}</Text>
-        </View>
+        </Pressable>
       </View>
 
-      <Pressable
-        onPress={() => toggleExpandedTrophy('gold')}
-        style={[styles.trophiesCard, { backgroundColor: palette.gold }]}
-      >
-        <View style={styles.trophiesHeader}>
-          <View style={styles.trophiesContent}>
-            <Text style={styles.trophiesTitle}>Guld pokaler</Text>
-            <Text style={styles.trophiesCount}>{goldTrophies}</Text>
-          </View>
-          <View style={styles.trophiesMeta}>
-            <Text style={styles.trophiesEmoji}>🥇</Text>
-            <Text style={styles.expandHint}>{expandedTrophy === 'gold' ? 'Skjul' : 'Vis uger'}</Text>
-          </View>
-        </View>
-        {expandedTrophy === 'gold' && (
-          <FlatList
-            data={trophyWeeksByType.gold}
-            scrollEnabled={false}
-            keyExtractor={(item, index) => `gold-${item.year}-${item.week}-${index}`}
-            contentContainerStyle={styles.expandedList}
-            ListEmptyComponent={<Text style={styles.emptyWeekText}>Ingen guld-uger endnu</Text>}
-            renderItem={({ item }) => (
-              <View style={styles.weekRow}>
-                <Text style={styles.weekLabel}>Uge {item.week}, {item.year}</Text>
-                <Text style={styles.weekValue}>{item.completedTasks} / {item.totalTasks}</Text>
+      {isTrophySectionExpanded ? (
+        <>
+          <Pressable
+            onPress={() => toggleExpandedTrophy('gold')}
+            style={[styles.trophiesCard, { backgroundColor: palette.gold }]}
+          >
+            <View style={styles.trophiesHeader}>
+              <View style={styles.trophiesContent}>
+                <Text style={styles.trophiesTitle}>Guld pokaler</Text>
+                <Text style={styles.trophiesCount}>{goldTrophies}</Text>
               </View>
-            )}
-          />
-        )}
-      </Pressable>
-
-      <Pressable
-        onPress={() => toggleExpandedTrophy('silver')}
-        style={[styles.trophiesCard, { backgroundColor: palette.silver }]}
-      >
-        <View style={styles.trophiesHeader}>
-          <View style={styles.trophiesContent}>
-            <Text style={styles.trophiesTitle}>Sølv pokaler</Text>
-            <Text style={styles.trophiesCount}>{silverTrophies}</Text>
-          </View>
-          <View style={styles.trophiesMeta}>
-            <Text style={styles.trophiesEmoji}>🥈</Text>
-            <Text style={styles.expandHint}>{expandedTrophy === 'silver' ? 'Skjul' : 'Vis uger'}</Text>
-          </View>
-        </View>
-        {expandedTrophy === 'silver' && (
-          <FlatList
-            data={trophyWeeksByType.silver}
-            scrollEnabled={false}
-            keyExtractor={(item, index) => `silver-${item.year}-${item.week}-${index}`}
-            contentContainerStyle={styles.expandedList}
-            ListEmptyComponent={<Text style={styles.emptyWeekText}>Ingen sølv-uger endnu</Text>}
-            renderItem={({ item }) => (
-              <View style={styles.weekRow}>
-                <Text style={styles.weekLabel}>Uge {item.week}, {item.year}</Text>
-                <Text style={styles.weekValue}>{item.completedTasks} / {item.totalTasks}</Text>
+              <View style={styles.trophiesMeta}>
+                <Text style={styles.trophiesEmoji}>🥇</Text>
+                <Text style={styles.expandHint}>{expandedTrophy === 'gold' ? 'Skjul' : 'Vis uger'}</Text>
               </View>
+            </View>
+            {expandedTrophy === 'gold' && (
+              <FlatList
+                data={trophyWeeksByType.gold}
+                scrollEnabled={false}
+                keyExtractor={(item, index) => `gold-${item.year}-${item.week}-${index}`}
+                contentContainerStyle={styles.expandedList}
+                ListEmptyComponent={<Text style={styles.emptyWeekText}>Ingen guld-uger endnu</Text>}
+                renderItem={({ item }) => (
+                  <View style={styles.weekRow}>
+                    <Text style={styles.weekLabel}>Uge {item.week}, {item.year}</Text>
+                    <Text style={styles.weekValue}>{item.completedTasks} / {item.totalTasks}</Text>
+                  </View>
+                )}
+              />
             )}
-          />
-        )}
-      </Pressable>
+          </Pressable>
 
-      <Pressable
-        onPress={() => toggleExpandedTrophy('bronze')}
-        style={[styles.trophiesCard, { backgroundColor: palette.bronze }]}
-      >
-        <View style={styles.trophiesHeader}>
-          <View style={styles.trophiesContent}>
-            <Text style={styles.trophiesTitle}>Bronze pokaler</Text>
-            <Text style={styles.trophiesCount}>{bronzeTrophies}</Text>
-          </View>
-          <View style={styles.trophiesMeta}>
-            <Text style={styles.trophiesEmoji}>🥉</Text>
-            <Text style={styles.expandHint}>{expandedTrophy === 'bronze' ? 'Skjul' : 'Vis uger'}</Text>
-          </View>
-        </View>
-        {expandedTrophy === 'bronze' && (
-          <FlatList
-            data={trophyWeeksByType.bronze}
-            scrollEnabled={false}
-            keyExtractor={(item, index) => `bronze-${item.year}-${item.week}-${index}`}
-            contentContainerStyle={styles.expandedList}
-            ListEmptyComponent={<Text style={styles.emptyWeekText}>Ingen bronze-uger endnu</Text>}
-            renderItem={({ item }) => (
-              <View style={styles.weekRow}>
-                <Text style={styles.weekLabel}>Uge {item.week}, {item.year}</Text>
-                <Text style={styles.weekValue}>{item.completedTasks} / {item.totalTasks}</Text>
+          <Pressable
+            onPress={() => toggleExpandedTrophy('silver')}
+            style={[styles.trophiesCard, { backgroundColor: palette.silver }]}
+          >
+            <View style={styles.trophiesHeader}>
+              <View style={styles.trophiesContent}>
+                <Text style={styles.trophiesTitle}>Sølv pokaler</Text>
+                <Text style={styles.trophiesCount}>{silverTrophies}</Text>
               </View>
+              <View style={styles.trophiesMeta}>
+                <Text style={styles.trophiesEmoji}>🥈</Text>
+                <Text style={styles.expandHint}>{expandedTrophy === 'silver' ? 'Skjul' : 'Vis uger'}</Text>
+              </View>
+            </View>
+            {expandedTrophy === 'silver' && (
+              <FlatList
+                data={trophyWeeksByType.silver}
+                scrollEnabled={false}
+                keyExtractor={(item, index) => `silver-${item.year}-${item.week}-${index}`}
+                contentContainerStyle={styles.expandedList}
+                ListEmptyComponent={<Text style={styles.emptyWeekText}>Ingen sølv-uger endnu</Text>}
+                renderItem={({ item }) => (
+                  <View style={styles.weekRow}>
+                    <Text style={styles.weekLabel}>Uge {item.week}, {item.year}</Text>
+                    <Text style={styles.weekValue}>{item.completedTasks} / {item.totalTasks}</Text>
+                  </View>
+                )}
+              />
             )}
-          />
-        )}
-      </Pressable>
+          </Pressable>
 
-      <ProgressionSection categories={categories} />
+          <Pressable
+            onPress={() => toggleExpandedTrophy('bronze')}
+            style={[styles.trophiesCard, { backgroundColor: palette.bronze }]}
+          >
+            <View style={styles.trophiesHeader}>
+              <View style={styles.trophiesContent}>
+                <Text style={styles.trophiesTitle}>Bronze pokaler</Text>
+                <Text style={styles.trophiesCount}>{bronzeTrophies}</Text>
+              </View>
+              <View style={styles.trophiesMeta}>
+                <Text style={styles.trophiesEmoji}>🥉</Text>
+                <Text style={styles.expandHint}>{expandedTrophy === 'bronze' ? 'Skjul' : 'Vis uger'}</Text>
+              </View>
+            </View>
+            {expandedTrophy === 'bronze' && (
+              <FlatList
+                data={trophyWeeksByType.bronze}
+                scrollEnabled={false}
+                keyExtractor={(item, index) => `bronze-${item.year}-${item.week}-${index}`}
+                contentContainerStyle={styles.expandedList}
+                ListEmptyComponent={<Text style={styles.emptyWeekText}>Ingen bronze-uger endnu</Text>}
+                renderItem={({ item }) => (
+                  <View style={styles.weekRow}>
+                    <Text style={styles.weekLabel}>Uge {item.week}, {item.year}</Text>
+                    <Text style={styles.weekValue}>{item.completedTasks} / {item.totalTasks}</Text>
+                  </View>
+                )}
+              />
+            )}
+          </Pressable>
+        </>
+      ) : null}
+
+      <View style={styles.historySection}>
+        <Pressable
+          style={({ pressed }) => [styles.historyHeaderPressable, pressed && styles.historyHeaderPressed]}
+          onPress={() => setIsProgressionSectionExpanded((prev) => !prev)}
+          testID="performance.progression.toggle"
+        >
+          <View style={styles.historyHeaderShadow}>
+            <LinearGradient
+              colors={
+                isDark
+                  ? ['rgba(43, 76, 92, 0.62)', 'rgba(29, 52, 69, 0.62)', 'rgba(25, 43, 56, 0.62)']
+                  : ['rgba(255, 255, 255, 0.62)', 'rgba(234, 243, 238, 0.62)', 'rgba(221, 239, 227, 0.62)']
+              }
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 1 }}
+              style={[styles.historyHeaderCard, { borderColor: isDark ? 'rgba(191, 220, 203, 0.20)' : 'rgba(76, 175, 80, 0.22)' }]}
+            >
+              <LinearGradient
+                colors={
+                  isDark
+                    ? ['rgba(255, 255, 255, 0.10)', 'rgba(255, 255, 255, 0.00)']
+                    : ['rgba(255, 255, 255, 0.55)', 'rgba(255, 255, 255, 0.00)']
+                }
+                start={{ x: 0, y: 0 }}
+                end={{ x: 0.8, y: 0.8 }}
+                style={styles.historyHeaderSheen}
+              />
+
+              <View style={styles.historyHeader}>
+                <View style={styles.historyTitleBlock}>
+                  <Text style={[styles.historyTitle, { color: isDark ? '#E6F5EC' : '#1D3A2A' }]}>Udvikling</Text>
+                  <Text style={[styles.historySubtitle, { color: isDark ? '#B5D8C2' : '#2C5A40' }]}>
+                    Se din udvikling for fokuspunkter og intensitet.
+                  </Text>
+                </View>
+                <View style={styles.historyChevronShadow}>
+                  <LinearGradient
+                    colors={isDark ? ['#3CC06A', '#1F8A43'] : ['#4CC46E', '#279B4A']}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 1 }}
+                    style={styles.historyChevronButton}
+                  >
+                    <IconSymbol
+                      ios_icon_name={isProgressionSectionExpanded ? 'chevron.up' : 'chevron.down'}
+                      android_material_icon_name={isProgressionSectionExpanded ? 'keyboard-arrow-up' : 'keyboard-arrow-down'}
+                      size={20}
+                      color="#FFFFFF"
+                    />
+                    <LinearGradient
+                      colors={['rgba(255,255,255,0.35)', 'rgba(255,255,255,0.00)']}
+                      start={{ x: 0, y: 0 }}
+                      end={{ x: 1, y: 1 }}
+                      style={styles.historyChevronSheen}
+                    />
+                  </LinearGradient>
+                </View>
+              </View>
+            </LinearGradient>
+          </View>
+        </Pressable>
+      </View>
+
+      {isProgressionSectionExpanded ? <ProgressionSection categories={categories} /> : null}
 
       <View style={styles.historySection}>
         <Pressable
@@ -518,88 +558,6 @@ const styles = StyleSheet.create({
   },
   headerSubtitle: {
     fontSize: 16,
-  },
-  currentWeekCard: {
-    borderRadius: 20,
-    padding: 24,
-    marginBottom: 16,
-  },
-  currentWeekHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  currentWeekTitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    color: '#fff',
-  },
-  trophyBadge: {
-    fontSize: 32,
-  },
-  currentWeekSubtitle: {
-    fontSize: 14,
-    color: '#fff',
-    opacity: 0.9,
-    marginBottom: 20,
-  },
-  statsRow: {
-    flexDirection: 'row',
-    gap: 12,
-    marginBottom: 20,
-  },
-  statBox: {
-    flex: 1,
-    backgroundColor: 'rgba(255, 255, 255, 0.2)',
-    borderRadius: 12,
-    padding: 16,
-  },
-  statLabel: {
-    fontSize: 12,
-    color: '#fff',
-    opacity: 0.9,
-    marginBottom: 8,
-    fontWeight: '600',
-  },
-  statPercentage: {
-    fontSize: 32,
-    fontWeight: 'bold',
-    color: '#fff',
-    marginBottom: 4,
-  },
-  statTasks: {
-    fontSize: 14,
-    color: '#fff',
-    opacity: 0.9,
-    marginBottom: 8,
-  },
-  progressBarContainer: {
-    height: 6,
-    backgroundColor: 'rgba(255, 255, 255, 0.3)',
-    borderRadius: 3,
-    overflow: 'hidden',
-  },
-  progressBar: {
-    height: '100%',
-    backgroundColor: '#fff',
-    borderRadius: 3,
-  },
-  coachingBox: {
-    backgroundColor: 'rgba(255, 255, 255, 0.2)',
-    borderRadius: 12,
-    padding: 16,
-  },
-  coachingTitle: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: '#fff',
-    marginBottom: 8,
-  },
-  coachingText: {
-    fontSize: 15,
-    color: '#fff',
-    lineHeight: 22,
   },
   trophiesCard: {
     borderRadius: 16,


### PR DESCRIPTION
## Summary
Denne PR opdaterer `Performance`-siden med nye kollapsbare sektioner og finjusterer UI på `Home`-sidens “Denne uge”-kort.

## Hvad er ændret

### Performance (`app/(tabs)/performance.tsx`)
- Fjernet kortet **“Denne uge”**.
- Tilføjet kollapsbar header **“Pokaler”** over pokalboksene:
  - Samme UI/interaction som “Historik” (chevron, press feedback, animation).
  - Undertekst: *“Se dine pokaler for tidligere uger”*.
- Tilføjet kollapsbar header **“Udvikling”** over progression-sektionen:
  - Samme UI/interaction som “Historik”.
  - Undertekst: *“Se din udvikling for fokuspunkter og intensitet.”*.
- Sat **Historik** til at starte kollapset som default.

### Tests (`__tests__/performance.screen.test.tsx`)
- Opdateret test til ny UI:
  - Verificerer kollaps/expand for **Pokaler** og **Udvikling**.
  - Justeret historik-test til at åbne historik først (nu default kollapset).

### Home-kort UI (`app/(tabs)/(home)/index.tsx`, `app/(tabs)/(home)/index.ios.tsx`)
- Justeret badge-layout på “Denne uge”-kortet:
  - Rækkefølge matcher kommende-uge kort.
  - “I dag”-badge forbliver halv bredde.
  - Badge-højde, spacing og typografi matcher kommende-uge kort.
- Finjusteret billedlag/crop samt positionering:
  - Baggrundsbillede skaleret let op (+2 px i bredde/højde, centreret).
- Genskabt farvet kant rundt om boksen og lagt den i **øverste overlay-lag**, så den ikke skjules af billedet.
- Flyttet progressionscirkel, progress bar og medalje-cirkel nedad (ca. 3 mm).

## QA
Kørt lokalt:
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test -- __tests__/performance.screen.test.tsx` ✅
- `npm test -- __tests__/home.performance-card-hours.test.tsx` ✅  
  (kendte `act(...)` warnings i eksisterende testflow, ingen failures)

## Risiko / bemærkninger
- Ændringerne er primært UI/styling og toggle-adfærd.
- Ingen nye refactors eller komponentudtræk; ændringer er holdt lokalt i eksisterende filer.