### PR TITLE
hotfix: stabilize iOS gating and external activity metadata fetch

### DIFF
--- a/__tests__/OnboardingGate.test.tsx
+++ b/__tests__/OnboardingGate.test.tsx
@@ -134,7 +134,8 @@ describe('OnboardingGate startup hydration', () => {
       </OnboardingGate>
     );
 
-    expect(screen.getByText('Klargører konto')).toBeTruthy();
+    expect(screen.getByText('App indhold')).toBeTruthy();
+    expect(screen.queryByText('Klargører konto')).toBeNull();
 
     await act(async () => {
       jest.advanceTimersByTime(12000);
@@ -183,7 +184,8 @@ describe('OnboardingGate startup hydration', () => {
       </OnboardingGate>
     );
 
-    expect(screen.getByText('Klargører konto')).toBeTruthy();
+    expect(screen.getByText('App indhold')).toBeTruthy();
+    expect(screen.queryByText('Klargører konto')).toBeNull();
 
     await act(async () => {
       await Promise.resolve();
@@ -251,7 +253,8 @@ describe('OnboardingGate startup hydration', () => {
       </OnboardingGate>
     );
 
-    expect(screen.getByText('Klargører konto')).toBeTruthy();
+    expect(screen.getByText('App indhold')).toBeTruthy();
+    expect(screen.queryByText('Klargører konto')).toBeNull();
 
     await act(async () => {
       await Promise.resolve();

--- a/__tests__/accessGate.test.ts
+++ b/__tests__/accessGate.test.ts
@@ -1,0 +1,61 @@
+import { resolveSubscriptionAccessState } from '@/utils/accessGate';
+
+describe('resolveSubscriptionAccessState', () => {
+  it('returns granted when user has backend lifetime access', () => {
+    const result = resolveSubscriptionAccessState({
+      user: { id: 'u1' },
+      subscriptionStatus: { isLifetime: true, hasSubscription: false, status: 'lifetime' },
+      subscriptionMeta: { backendAuthoritative: true },
+      entitlementSnapshot: { resolving: false, isAuthoritativelyUnsubscribed: true },
+    });
+
+    expect(result.accessState).toBe('granted');
+    expect(result.hasActiveSubscription).toBe(true);
+  });
+
+  it('returns granted when backend only exposes a meaningful plan name', () => {
+    const result = resolveSubscriptionAccessState({
+      user: { id: 'u1' },
+      subscriptionStatus: {
+        hasSubscription: false,
+        subscriptionTier: null,
+        isLifetime: false,
+        status: null,
+        planName: 'Livstid',
+      },
+      subscriptionMeta: { backendAuthoritative: true },
+      entitlementSnapshot: { resolving: false, isAuthoritativelyUnsubscribed: true },
+    });
+
+    expect(result.accessState).toBe('granted');
+    expect(result.hasActiveSubscription).toBe(true);
+  });
+
+  it('returns grace when iap says no subscription but backend is not authoritative yet', () => {
+    const result = resolveSubscriptionAccessState({
+      user: { id: 'u1' },
+      subscriptionStatus: null,
+      subscriptionMeta: { backendAuthoritative: false },
+      entitlementSnapshot: { resolving: false, isAuthoritativelyUnsubscribed: true },
+    });
+
+    expect(result.accessState).toBe('grace');
+  });
+
+  it('returns denied_authoritative only when both iap and backend are authoritative negative', () => {
+    const result = resolveSubscriptionAccessState({
+      user: { id: 'u1' },
+      subscriptionStatus: {
+        hasSubscription: false,
+        subscriptionTier: null,
+        isLifetime: false,
+        status: 'canceled',
+        planName: null,
+      },
+      subscriptionMeta: { backendAuthoritative: true },
+      entitlementSnapshot: { resolving: false, isAuthoritativelyUnsubscribed: true },
+    });
+
+    expect(result.accessState).toBe('denied_authoritative');
+  });
+});

--- a/__tests__/subscriptionGate.test.ts
+++ b/__tests__/subscriptionGate.test.ts
@@ -50,6 +50,23 @@ describe('subscription gate state', () => {
     expect(state.shouldShowChooseSubscription).toBe(false);
   });
 
+  it('treats meaningful backend planName as active', () => {
+    const state = getSubscriptionGateState({
+      user: { id: 'u1' },
+      subscriptionStatus: { planName: 'Livstid' },
+    });
+    expect(state.hasBackendSubscription).toBe(true);
+    expect(state.shouldShowChooseSubscription).toBe(false);
+  });
+
+  it('does not treat unknown planName as active', () => {
+    const state = getSubscriptionGateState({
+      user: { id: 'u1' },
+      subscriptionStatus: { planName: 'ukendt' },
+    });
+    expect(state.hasBackendSubscription).toBe(false);
+  });
+
   it('normalizes uppercase status when evaluating active state', () => {
     const state = getSubscriptionGateState({
       user: { id: 'u1' },
@@ -86,5 +103,48 @@ describe('subscription gate state', () => {
     expect(state.hasActiveSubscription).toBe(false);
     expect(state.shouldShowChooseSubscription).toBe(true);
   });
-});
 
+  it('keeps gate closed when authoritative signals exist but are inconclusive', () => {
+    const state = getSubscriptionGateState({
+      user: { id: 'u1' },
+      entitlementSnapshot: {
+        isEntitled: false,
+        hasActiveSubscription: false,
+        isAuthoritative: false,
+        isAuthoritativelyUnsubscribed: false,
+      },
+    });
+    expect(state.hasAuthoritativeNoSubscription).toBe(false);
+    expect(state.shouldShowChooseSubscription).toBe(false);
+  });
+
+  it('opens gate only when authoritative no-subscription signal is present', () => {
+    const state = getSubscriptionGateState({
+      user: { id: 'u1' },
+      entitlementSnapshot: {
+        isEntitled: false,
+        hasActiveSubscription: false,
+        isAuthoritative: true,
+        isAuthoritativelyUnsubscribed: true,
+      },
+    });
+    expect(state.hasAuthoritativeNoSubscription).toBe(true);
+    expect(state.shouldShowChooseSubscription).toBe(true);
+  });
+
+  it('keeps gate closed when backend says active even if iap says authoritative no-sub', () => {
+    const state = getSubscriptionGateState({
+      user: { id: 'u1' },
+      subscriptionStatus: {
+        hasSubscription: true,
+        planName: 'Livstid',
+      },
+      entitlementSnapshot: {
+        isAuthoritative: true,
+        isAuthoritativelyUnsubscribed: true,
+      },
+    });
+    expect(state.hasActiveSubscription).toBe(true);
+    expect(state.shouldShowChooseSubscription).toBe(false);
+  });
+});

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -8,6 +8,8 @@ import { useUserRole } from '@/hooks/useUserRole';
 import { useSubscription } from '@/contexts/SubscriptionContext';
 import { OnboardingGate } from '@/components/OnboardingGate';
 import { useSubscriptionFeatures } from '@/hooks/useSubscriptionFeatures';
+import { useAppleIAP } from '@/contexts/AppleIAPContext';
+import { resolveSubscriptionAccessState } from '@/utils/accessGate';
 
 /* ======================================================
    ROOT TAB LAYOUT
@@ -16,8 +18,13 @@ import { useSubscriptionFeatures } from '@/hooks/useSubscriptionFeatures';
 export default function TabLayout() {
   const router = useRouter();
   const segments = useSegments();
-  const { userRole, loading } = useUserRole();
-  const { entitlementVersion, subscriptionStatus: serverSubscriptionStatus } = useSubscription();
+  const { userRole, loading, isAuthenticated } = useUserRole();
+  const {
+    entitlementVersion,
+    subscriptionStatus: serverSubscriptionStatus,
+    subscriptionMeta,
+  } = useSubscription();
+  const { entitlementSnapshot } = useAppleIAP();
   const {
     hasActiveSubscription,
     subscriptionTier,
@@ -45,10 +52,20 @@ export default function TabLayout() {
     subscriptionFeaturesLoading && lastStableHasSubscriptionRef.current != null
       ? lastStableHasSubscriptionRef.current
       : hasSubscription;
+  const subscriptionAccess = resolveSubscriptionAccessState({
+    user: isAuthenticated ? { id: 'authenticated' } : null,
+    subscriptionStatus: serverSubscriptionStatus,
+    subscriptionMeta,
+    entitlementSnapshot,
+  });
 
-  const locked =
-    !effectiveRole ||
-    (!effectiveHasSubscription && !(Platform.OS === 'ios' && subscriptionFeaturesLoading));
+  const lockedByRole = !isAuthenticated && !loading;
+  const lockedBySubscription =
+    Platform.OS === 'ios'
+      ? false
+      : subscriptionAccess.accessState === 'denied_authoritative' ||
+        (!effectiveHasSubscription && !subscriptionFeaturesLoading);
+  const locked = lockedByRole || lockedBySubscription;
 
   const navigationKey = useMemo(() => {
     const rolePart = effectiveRole ?? 'anon';

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -36,6 +36,7 @@ import { useSubscriptionFeatures } from '@/hooks/useSubscriptionFeatures';
 import { forceUserRoleRefresh } from '@/hooks/useUserRole';
 import { useAppleIAP, PRODUCT_IDS } from '@/contexts/AppleIAPContext';
 import { getSubscriptionGateState } from '@/utils/subscriptionGate';
+import { resolveSubscriptionAccessState } from '@/utils/accessGate';
 import { checkNotificationPermissions, openNotificationSettings, requestNotificationPermissions } from '@/utils/notificationService';
 import { syncPushTokenForCurrentUser } from '@/utils/pushTokenService';
 import { DropdownSelect } from '@/components/ui/DropdownSelect';
@@ -755,6 +756,7 @@ export default function ProfileScreen() {
   // Get subscription status
   const {
     subscriptionStatus,
+    subscriptionMeta,
     refreshSubscription,
     createSubscription,
     loading: subscriptionLoading,
@@ -774,7 +776,13 @@ export default function ProfileScreen() {
     subscriptionStatus,
     entitlementSnapshot,
   });
-  const shouldShowChooseSubscription = subscriptionGate.shouldShowChooseSubscription;
+  const subscriptionAccess = resolveSubscriptionAccessState({
+    user,
+    subscriptionStatus,
+    subscriptionMeta,
+    entitlementSnapshot,
+  });
+  const shouldShowChooseSubscription = subscriptionAccess.accessState === 'denied_authoritative';
 
   const subscriptionPlansLoading =
     Platform.OS === 'ios'

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { useFonts } from 'expo-font';
 import { Stack, usePathname, useRouter, useRootNavigationState } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
+import { Platform } from 'react-native';
 import 'react-native-reanimated';
 import { FootballProvider } from '@/contexts/FootballContext';
 import { SubscriptionProvider, useSubscription } from '@/contexts/SubscriptionContext';
@@ -489,6 +490,10 @@ function SubscriptionRedirectObserver() {
   }, [authChecked, pathname, triggerRedirect, unverifiedEmail]);
 
   useEffect(() => {
+    if (Platform.OS === 'ios') {
+      return;
+    }
+
     if (!authChecked || resolving || !userId) {
       const now = Date.now();
       if (now - lastSuppressedLogAtRef.current > 2000) {

--- a/app/activity-details.tsx
+++ b/app/activity-details.tsx
@@ -3065,8 +3065,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
           throw new Error(localTemplateError?.message || 'Kunne ikke oprette lokal skabelon.');
         }
 
-        const payload = {
-          activity_id: activity.id,
+        const basePayload = {
           title: String(template.title ?? '').trim() || 'Opgave',
           description: String(template.description ?? ''),
           completed: false,
@@ -3083,8 +3082,32 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
               ? clampMinutes(template.taskDurationMinutes ?? template.task_duration_minutes ?? 0)
               : null,
         };
+        const fallbackBasePayload = { ...basePayload } as Record<string, any>;
+        delete fallbackBasePayload.after_training_enabled;
+        delete fallbackBasePayload.after_training_delay_minutes;
+        delete fallbackBasePayload.task_duration_enabled;
+        delete fallbackBasePayload.task_duration_minutes;
 
-        const { error } = await supabase.from('activity_tasks').insert(payload);
+        const table = activity.isExternal ? 'external_event_tasks' : 'activity_tasks';
+        const payload = activity.isExternal
+          ? { local_meta_id: activity.id, ...basePayload }
+          : { activity_id: activity.id, ...basePayload };
+
+        let { error } = await supabase.from(table).insert(payload as any);
+        if (
+          error &&
+          (isMissingColumn(error, 'after_training_enabled') ||
+            isMissingColumn(error, 'after_training_delay_minutes') ||
+            isMissingColumn(error, 'task_duration_enabled') ||
+            isMissingColumn(error, 'task_duration_minutes'))
+        ) {
+          const fallbackPayload = activity.isExternal
+            ? { local_meta_id: activity.id, ...fallbackBasePayload }
+            : { activity_id: activity.id, ...fallbackBasePayload };
+          const retry = await supabase.from(table).insert(fallbackPayload as any);
+          error = retry.error;
+        }
+
         if (error) {
           if (error.code === '23505') {
             Alert.alert('Findes allerede', 'Denne opgave er allerede tilføjet til aktiviteten.');
@@ -3102,7 +3125,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
         setIsTemplateTaskSaving(false);
       }
     },
-    [activity.id, currentUserId, isTemplateTaskSaving, refreshActivityTasks],
+    [activity.id, activity.isExternal, currentUserId, isTemplateTaskSaving, refreshActivityTasks],
   );
 
   const formatTemplateTaskMeta = useCallback((template: Task): string => {
@@ -3964,7 +3987,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
 
         <View style={styles.v2TasksHeaderRow}>
           <Text style={[styles.v2SectionTitle, styles.v2SectionTitleInRow]}>Opgaver</Text>
-            {!activity.isExternal && !isEditing && (
+            {!isEditing && (
               <TouchableOpacity
                 style={[styles.addTaskHeaderButton, { backgroundColor: primaryColor }]}
                 onPress={handleAddTask}
@@ -4582,6 +4605,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
           activityTitle={activity.title}
           activityDate={activity.date}
           activityTime={activity.time}
+          isExternalActivity={activity.isExternal}
         />
       )}
 

--- a/components/CreateActivityTaskModal.tsx
+++ b/components/CreateActivityTaskModal.tsx
@@ -60,6 +60,40 @@ const REMINDER_DELAY_OPTIONS = [
   { value: 120, label: '120' },
 ] as const;
 const LOCAL_ACTIVITY_TEMPLATE_SOURCE = 'activity_local_task';
+const TASK_LOCAL_OPTIONAL_COLUMNS = [
+  'after_training_enabled',
+  'after_training_delay_minutes',
+  'task_duration_enabled',
+  'task_duration_minutes',
+] as const;
+const TASK_FEEDBACK_OPTIONAL_COLUMNS = [
+  'feedback_template_id',
+  'is_feedback_task',
+] as const;
+
+const isMissingColumn = (error: any, columnName: string): boolean => {
+  const needle = String(columnName ?? '').trim().toLowerCase();
+  if (!needle.length) return false;
+  const haystack = [error?.message, error?.details, error?.hint, error?.code]
+    .filter(Boolean)
+    .map((value) => String(value).toLowerCase())
+    .join(' | ');
+  return haystack.includes(needle);
+};
+
+const hasMissingTaskLocalOptionError = (error: any): boolean =>
+  TASK_LOCAL_OPTIONAL_COLUMNS.some((columnName) => isMissingColumn(error, columnName));
+const hasMissingTaskFeedbackOptionError = (error: any): boolean =>
+  TASK_FEEDBACK_OPTIONAL_COLUMNS.some((columnName) => isMissingColumn(error, columnName));
+
+const omitTaskLocalOptions = (payload: Record<string, any>): Record<string, any> => {
+  const next = { ...payload };
+  delete next.after_training_enabled;
+  delete next.after_training_delay_minutes;
+  delete next.task_duration_enabled;
+  delete next.task_duration_minutes;
+  return next;
+};
 
 interface SubtaskDraft {
   id: string;
@@ -128,6 +162,7 @@ interface CreateActivityTaskModalProps {
   activityTitle: string;
   activityDate?: Date | string | null;
   activityTime: string;
+  isExternalActivity?: boolean;
 }
 
 export function CreateActivityTaskModal({
@@ -141,6 +176,7 @@ export function CreateActivityTaskModal({
   activityTitle,
   activityDate,
   activityTime,
+  isExternalActivity = false,
 }: CreateActivityTaskModalProps) {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -154,6 +190,7 @@ export function CreateActivityTaskModal({
   const [isLoading, setIsLoading] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
   const [activityExists, setActivityExists] = useState(false);
+  const [resolvedExternalMetaId, setResolvedExternalMetaId] = useState<string | null>(null);
   const scrollViewRef = useRef<ScrollView>(null);
   const isEditMode = !!editingTask?.id;
 
@@ -167,6 +204,12 @@ export function CreateActivityTaskModal({
     () => (safeActivityDate ? safeActivityDate.toLocaleDateString('da-DK') : 'Ukendt dato'),
     [safeActivityDate],
   );
+  const resolvedActivityLinkId = useMemo(() => {
+    if (!isExternalActivity) {
+      return String(activityId ?? '').trim();
+    }
+    return String(resolvedExternalMetaId ?? '').trim();
+  }, [activityId, isExternalActivity, resolvedExternalMetaId]);
 
   const normalizeDurationInput = useCallback((raw: string): number => {
     const parsed = Number(raw);
@@ -291,32 +334,50 @@ export function CreateActivityTaskModal({
   const syncLocalFeedbackTask = useCallback(
     async ({
       parentTaskId,
+      activityLinkId,
       templateId,
       taskTitle,
       enabled,
       delayMinutes,
     }: {
       parentTaskId: string;
+      activityLinkId?: string;
       templateId: string;
       taskTitle: string;
       enabled: boolean;
       delayMinutes: number | null;
     }) => {
       const parentId = String(parentTaskId ?? '').trim();
+      const normalizedActivityLinkId = String(activityLinkId ?? activityId ?? '').trim();
       const normalizedTemplateId = String(templateId ?? '').trim();
-      if (!parentId || !normalizedTemplateId) return;
+      if (!parentId || !normalizedTemplateId || !normalizedActivityLinkId) return;
 
       const legacyMarker = `[[feedback_parent_task_id:${parentId}]]`;
       const description = buildFeedbackTaskDescription(normalizedTemplateId);
       const title = buildFeedbackTaskTitle(taskTitle);
 
-      const { data: existingRows, error: existingError } = await supabase
+      let supportsFeedbackColumns = true;
+      let existingRows: any[] = [];
+      const existingRowsFull = await supabase
         .from('activity_tasks')
         .select('id, description, created_at, completed, feedback_template_id, task_template_id, is_feedback_task')
-        .eq('activity_id', activityId);
+        .eq('activity_id', normalizedActivityLinkId);
 
-      if (existingError) {
-        throw new Error(`Kunne ikke hente eksisterende feedback-opgave: ${existingError.message}`);
+      if (existingRowsFull.error) {
+        if (!hasMissingTaskFeedbackOptionError(existingRowsFull.error)) {
+          throw new Error(`Kunne ikke hente eksisterende feedback-opgave: ${existingRowsFull.error.message}`);
+        }
+        supportsFeedbackColumns = false;
+        const existingRowsFallback = await supabase
+          .from('activity_tasks')
+          .select('id, description, created_at, completed, task_template_id')
+          .eq('activity_id', normalizedActivityLinkId);
+        if (existingRowsFallback.error) {
+          throw new Error(`Kunne ikke hente eksisterende feedback-opgave: ${existingRowsFallback.error.message}`);
+        }
+        existingRows = Array.isArray(existingRowsFallback.data) ? existingRowsFallback.data : [];
+      } else {
+        existingRows = Array.isArray(existingRowsFull.data) ? existingRowsFull.data : [];
       }
 
       const matchedRows = (existingRows || []).filter((row: any) => {
@@ -366,17 +427,20 @@ export function CreateActivityTaskModal({
 
       if (matchedIds.length) {
         const keepId = matchedIds[0];
+        const updateFeedbackPayload: Record<string, any> = {
+          title,
+          description,
+          reminder_minutes: delayMinutes,
+          task_template_id: null,
+          updated_at: new Date().toISOString(),
+        };
+        if (supportsFeedbackColumns) {
+          updateFeedbackPayload.feedback_template_id = normalizedTemplateId;
+          updateFeedbackPayload.is_feedback_task = true;
+        }
         const { error: updateFeedbackError } = await supabase
           .from('activity_tasks')
-          .update({
-            title,
-            description,
-            reminder_minutes: delayMinutes,
-            feedback_template_id: normalizedTemplateId,
-            is_feedback_task: true,
-            task_template_id: null,
-            updated_at: new Date().toISOString(),
-          })
+          .update(updateFeedbackPayload)
           .eq('id', keepId);
         if (updateFeedbackError) {
           throw new Error(`Kunne ikke opdatere feedback-opgave: ${updateFeedbackError.message}`);
@@ -396,28 +460,179 @@ export function CreateActivityTaskModal({
         return;
       }
 
+      const insertFeedbackPayload: Record<string, any> = {
+        activity_id: normalizedActivityLinkId,
+        title,
+        description,
+        completed: false,
+        reminder_minutes: delayMinutes,
+        task_template_id: null,
+      };
+      if (supportsFeedbackColumns) {
+        insertFeedbackPayload.feedback_template_id = normalizedTemplateId;
+        insertFeedbackPayload.is_feedback_task = true;
+      }
       const { error: insertFeedbackError } = await supabase
         .from('activity_tasks')
-        .insert({
-          activity_id: activityId,
-          title,
-          description,
-          completed: false,
-          reminder_minutes: delayMinutes,
-          feedback_template_id: normalizedTemplateId,
-          is_feedback_task: true,
-          task_template_id: null,
-          after_training_enabled: false,
-          after_training_delay_minutes: null,
-          task_duration_enabled: false,
-          task_duration_minutes: null,
-        });
+        .insert(insertFeedbackPayload as any);
 
       if (insertFeedbackError) {
         throw new Error(`Kunne ikke oprette feedback-opgave: ${insertFeedbackError.message}`);
       }
     },
     [activityId, buildFeedbackTaskDescription, buildFeedbackTaskTitle],
+  );
+
+  const syncExternalFeedbackTask = useCallback(
+    async ({
+      parentTaskId,
+      localMetaId,
+      templateId,
+      taskTitle,
+      enabled,
+      delayMinutes,
+    }: {
+      parentTaskId: string;
+      localMetaId: string;
+      templateId: string;
+      taskTitle: string;
+      enabled: boolean;
+      delayMinutes: number | null;
+    }) => {
+      const parentId = String(parentTaskId ?? '').trim();
+      const normalizedLocalMetaId = String(localMetaId ?? '').trim();
+      const normalizedTemplateId = String(templateId ?? '').trim();
+      if (!parentId || !normalizedLocalMetaId || !normalizedTemplateId) return;
+
+      const legacyMarker = `[[feedback_parent_task_id:${parentId}]]`;
+      const description = buildFeedbackTaskDescription(normalizedTemplateId);
+      const title = buildFeedbackTaskTitle(taskTitle);
+
+      let supportsFeedbackColumns = true;
+      let existingRows: any[] = [];
+      const existingRowsFull = await supabase
+        .from('external_event_tasks')
+        .select('id, description, created_at, completed, feedback_template_id, task_template_id, is_feedback_task')
+        .eq('local_meta_id', normalizedLocalMetaId);
+
+      if (existingRowsFull.error) {
+        if (!hasMissingTaskFeedbackOptionError(existingRowsFull.error)) {
+          throw new Error(`Kunne ikke hente eksisterende feedback-opgave: ${existingRowsFull.error.message}`);
+        }
+        supportsFeedbackColumns = false;
+        const existingRowsFallback = await supabase
+          .from('external_event_tasks')
+          .select('id, description, created_at, completed, task_template_id')
+          .eq('local_meta_id', normalizedLocalMetaId);
+        if (existingRowsFallback.error) {
+          throw new Error(`Kunne ikke hente eksisterende feedback-opgave: ${existingRowsFallback.error.message}`);
+        }
+        existingRows = Array.isArray(existingRowsFallback.data) ? existingRowsFallback.data : [];
+      } else {
+        existingRows = Array.isArray(existingRowsFull.data) ? existingRowsFull.data : [];
+      }
+
+      const matchedRows = (existingRows || []).filter((row: any) => {
+        const directFeedbackTemplateId =
+          typeof row?.feedback_template_id === 'string' ? row.feedback_template_id.trim() : '';
+        if (directFeedbackTemplateId && directFeedbackTemplateId === normalizedTemplateId) {
+          return true;
+        }
+
+        const directTaskTemplateId =
+          typeof row?.task_template_id === 'string' ? row.task_template_id.trim() : '';
+        if (row?.is_feedback_task === true && directTaskTemplateId && directTaskTemplateId === normalizedTemplateId) {
+          return true;
+        }
+
+        const rowDescription = typeof row?.description === 'string' ? row.description : '';
+        const markerTemplateId = parseTemplateIdFromMarker(rowDescription);
+        if (markerTemplateId && String(markerTemplateId).trim() === normalizedTemplateId) {
+          return true;
+        }
+        return rowDescription.includes(legacyMarker);
+      });
+
+      const matchedRowsSorted = sortFeedbackTaskCandidates(
+        matchedRows as {
+          id?: string | null;
+          created_at?: string | null;
+          completed?: boolean | null;
+        }[],
+      );
+      const matchedIds = matchedRowsSorted
+        .map((row: any) => String(row?.id ?? '').trim())
+        .filter((id: string) => id.length > 0);
+
+      if (!enabled) {
+        if (matchedIds.length) {
+          const { error: deleteError } = await supabase
+            .from('external_event_tasks')
+            .delete()
+            .in('id', matchedIds);
+          if (deleteError) {
+            throw new Error(`Kunne ikke fjerne feedback-opgave: ${deleteError.message}`);
+          }
+        }
+        return;
+      }
+
+      if (matchedIds.length) {
+        const keepId = matchedIds[0];
+        const updateFeedbackPayload: Record<string, any> = {
+          title,
+          description,
+          reminder_minutes: delayMinutes,
+          task_template_id: null,
+          updated_at: new Date().toISOString(),
+        };
+        if (supportsFeedbackColumns) {
+          updateFeedbackPayload.feedback_template_id = normalizedTemplateId;
+          updateFeedbackPayload.is_feedback_task = true;
+        }
+        const { error: updateFeedbackError } = await supabase
+          .from('external_event_tasks')
+          .update(updateFeedbackPayload)
+          .eq('id', keepId);
+        if (updateFeedbackError) {
+          throw new Error(`Kunne ikke opdatere feedback-opgave: ${updateFeedbackError.message}`);
+        }
+
+        if (matchedIds.length > 1) {
+          const extras = matchedIds.slice(1);
+          const { error: deleteExtrasError } = await supabase
+            .from('external_event_tasks')
+            .delete()
+            .in('id', extras);
+          if (deleteExtrasError) {
+            throw new Error(`Kunne ikke rydde op i ekstra feedback-opgaver: ${deleteExtrasError.message}`);
+          }
+        }
+
+        return;
+      }
+
+      const insertFeedbackPayload: Record<string, any> = {
+        local_meta_id: normalizedLocalMetaId,
+        title,
+        description,
+        completed: false,
+        reminder_minutes: delayMinutes,
+        task_template_id: null,
+      };
+      if (supportsFeedbackColumns) {
+        insertFeedbackPayload.feedback_template_id = normalizedTemplateId;
+        insertFeedbackPayload.is_feedback_task = true;
+      }
+      const { error: insertFeedbackError } = await supabase
+        .from('external_event_tasks')
+        .insert(insertFeedbackPayload as any);
+
+      if (insertFeedbackError) {
+        throw new Error(`Kunne ikke oprette feedback-opgave: ${insertFeedbackError.message}`);
+      }
+    },
+    [buildFeedbackTaskDescription, buildFeedbackTaskTitle],
   );
 
   const syncActivitySubtasks = useCallback(async (activityTaskId: string, drafts: SubtaskDraft[]) => {
@@ -596,33 +811,57 @@ export function CreateActivityTaskModal({
     const verifyActivity = async () => {
       if (!activityId || !visible) {
         setActivityExists(false);
+        setResolvedExternalMetaId(null);
         return;
       }
 
-      console.log('🔍 Verifying activity exists:', activityId);
-      
       try {
+        if (isExternalActivity) {
+          const { data: directMeta, error: directMetaError } = await supabase
+            .from('events_local_meta')
+            .select('id')
+            .eq('id', activityId)
+            .maybeSingle();
+
+          if (directMetaError) {
+            setResolvedExternalMetaId(null);
+            setActivityExists(false);
+            return;
+          }
+
+          if (directMeta?.id) {
+            setResolvedExternalMetaId(String(directMeta.id));
+            setActivityExists(true);
+            return;
+          }
+
+          const { data: linkedMeta, error: linkedMetaError } = await supabase
+            .from('events_local_meta')
+            .select('id')
+            .eq('external_event_id', activityId)
+            .maybeSingle();
+
+          if (linkedMetaError || !linkedMeta?.id) {
+            setResolvedExternalMetaId(null);
+            setActivityExists(false);
+            return;
+          }
+
+          setResolvedExternalMetaId(String(linkedMeta.id));
+          setActivityExists(true);
+          return;
+        }
+
         const { data, error } = await supabase
           .from('activities')
           .select('id')
           .eq('id', activityId)
           .single();
 
-        if (error) {
-          console.error('❌ Error verifying activity:', error);
-          setActivityExists(false);
-          return;
-        }
-
-        if (data) {
-          console.log('✅ Activity verified:', data.id);
-          setActivityExists(true);
-        } else {
-          console.log('⚠️ Activity not found');
-          setActivityExists(false);
-        }
+        setResolvedExternalMetaId(null);
+        setActivityExists(!error && !!data);
       } catch (error) {
-        console.error('❌ Exception verifying activity:', error);
+        setResolvedExternalMetaId(null);
         setActivityExists(false);
       }
     };
@@ -636,7 +875,7 @@ export function CreateActivityTaskModal({
     } else {
       verifyActivity();
     }
-  }, [activityId, visible]);
+  }, [activityId, isExternalActivity, visible]);
 
   const handleSave = useCallback(async () => {
     if (!title.trim()) {
@@ -649,10 +888,12 @@ export function CreateActivityTaskModal({
       return;
     }
 
-    if (!activityExists) {
+    if (!activityExists || !resolvedActivityLinkId) {
       Alert.alert(
         'Vent venligst',
-        'Aktiviteten er ved at blive oprettet. Prøv igen om et øjeblik.',
+        isExternalActivity
+          ? 'Aktiviteten synkroniseres stadig. Prøv igen om et øjeblik.'
+          : 'Aktiviteten er ved at blive oprettet. Prøv igen om et øjeblik.',
         [{ text: 'OK' }]
       );
       return;
@@ -685,101 +926,186 @@ export function CreateActivityTaskModal({
         taskDurationEnabled: hasTaskDuration,
         taskDurationMinutes: taskDurationPayload,
       });
+      const baseTaskPayload: Record<string, any> = {
+        title: title.trim(),
+        description: description.trim(),
+        completed: false,
+        reminder_minutes: reminderPayload,
+        task_template_id: localTemplateId,
+        after_training_enabled: hasAfterTrainingFeedback,
+        after_training_delay_minutes: feedbackDelayPayload,
+        task_duration_enabled: hasTaskDuration,
+        task_duration_minutes: taskDurationPayload,
+      };
+      const baseTaskPayloadWithoutLocalOptions = omitTaskLocalOptions(baseTaskPayload);
+      const buildTaskUpdatePayload = () => ({
+        ...baseTaskPayload,
+        updated_at: new Date().toISOString(),
+      });
 
-      if (isEditMode && editingTask?.id) {
-        const updatePayload: Record<string, any> = {
-          title: title.trim(),
-          description: description.trim(),
-          reminder_minutes: reminderPayload,
-          task_template_id: localTemplateId,
-          feedback_template_id: null,
-          is_feedback_task: false,
-          after_training_enabled: hasAfterTrainingFeedback,
-          after_training_delay_minutes: feedbackDelayPayload,
-          task_duration_enabled: hasTaskDuration,
-          task_duration_minutes: taskDurationPayload,
-          updated_at: new Date().toISOString(),
-        };
-
-        const { error: updateError } = await supabase
-          .from('activity_tasks')
+      const runTaskUpdate = async (
+        table: 'activity_tasks' | 'external_event_tasks',
+        linkColumn: 'activity_id' | 'local_meta_id',
+        taskId: string,
+      ): Promise<boolean> => {
+        const updatePayload = buildTaskUpdatePayload();
+        let updateResponse = await (supabase as any)
+          .from(table)
           .update(updatePayload)
-          .eq('id', editingTask.id)
-          .eq('activity_id', activityId);
+          .eq('id', taskId)
+          .eq(linkColumn, resolvedActivityLinkId)
+          .select('id');
 
-        if (updateError) {
-          throw new Error(`Database fejl: ${updateError.message}`);
+        if (updateResponse.error && hasMissingTaskLocalOptionError(updateResponse.error)) {
+          const fallbackPayload = omitTaskLocalOptions(updatePayload);
+          updateResponse = await (supabase as any)
+            .from(table)
+            .update(fallbackPayload)
+            .eq('id', taskId)
+            .eq(linkColumn, resolvedActivityLinkId)
+            .select('id');
         }
 
-        await syncActivitySubtasks(editingTask.id, subtasks);
+        if (updateResponse.error) {
+          throw new Error(`Database fejl: ${updateResponse.error.message}`);
+        }
 
-        await syncLocalFeedbackTask({
-          parentTaskId: editingTask.id,
-          templateId: localTemplateId,
-          taskTitle: title.trim(),
-          enabled: hasAfterTrainingFeedback,
-          delayMinutes: feedbackDelayPayload,
-        });
+        return Array.isArray(updateResponse.data) && updateResponse.data.length > 0;
+      };
+
+      const runTaskInsert = async (
+        table: 'activity_tasks' | 'external_event_tasks',
+        linkColumn: 'activity_id' | 'local_meta_id',
+      ): Promise<any> => {
+        const insertPayload: Record<string, any> = {
+          [linkColumn]: resolvedActivityLinkId,
+          ...baseTaskPayload,
+        };
+
+        let insertResponse = await (supabase as any)
+          .from(table)
+          .insert(insertPayload)
+          .select()
+          .single();
+
+        if (insertResponse.error && hasMissingTaskLocalOptionError(insertResponse.error)) {
+          const fallbackPayload: Record<string, any> = {
+            [linkColumn]: resolvedActivityLinkId,
+            ...baseTaskPayloadWithoutLocalOptions,
+          };
+          insertResponse = await (supabase as any)
+            .from(table)
+            .insert(fallbackPayload)
+            .select()
+            .single();
+        }
+
+        if (insertResponse.error) {
+          throw new Error(`Database fejl: ${insertResponse.error.message}`);
+        }
+
+        if (!insertResponse.data) {
+          throw new Error('Ingen data returneret fra databasen');
+        }
+
+        return insertResponse.data;
+      };
+
+      if (isEditMode && editingTask?.id) {
+        let activeTable: 'activity_tasks' | 'external_event_tasks' = isExternalActivity
+          ? 'external_event_tasks'
+          : 'activity_tasks';
+        let updated = await runTaskUpdate(
+          activeTable,
+          activeTable === 'external_event_tasks' ? 'local_meta_id' : 'activity_id',
+          editingTask.id,
+        );
+
+        if (!updated && isExternalActivity) {
+          updated = await runTaskUpdate('activity_tasks', 'activity_id', editingTask.id);
+          if (updated) {
+            activeTable = 'activity_tasks';
+          }
+        }
+
+        if (!updated) {
+          throw new Error('Opgaven kunne ikke findes på aktiviteten.');
+        }
+
+        if (activeTable === 'activity_tasks') {
+          await syncActivitySubtasks(editingTask.id, subtasks);
+          await syncLocalFeedbackTask({
+            parentTaskId: editingTask.id,
+            activityLinkId: resolvedActivityLinkId,
+            templateId: localTemplateId,
+            taskTitle: title.trim(),
+            enabled: hasAfterTrainingFeedback,
+            delayMinutes: feedbackDelayPayload,
+          });
+        } else {
+          await syncExternalFeedbackTask({
+            parentTaskId: editingTask.id,
+            localMetaId: resolvedActivityLinkId,
+            templateId: localTemplateId,
+            taskTitle: title.trim(),
+            enabled: hasAfterTrainingFeedback,
+            delayMinutes: feedbackDelayPayload,
+          });
+        }
 
         Alert.alert('Opgave opdateret', `Opgaven "${title}" er opdateret.`, [{ text: 'OK' }]);
         if (onTaskUpdated) {
           await onTaskUpdated();
         }
       } else {
-        const { data: activityCheck, error: activityCheckError } = await supabase
-          .from('activities')
-          .select('id')
-          .eq('id', activityId)
-          .single();
+        if (!isExternalActivity) {
+          const { data: activityCheck, error: activityCheckError } = await supabase
+            .from('activities')
+            .select('id')
+            .eq('id', resolvedActivityLinkId)
+            .single();
 
-        if (activityCheckError || !activityCheck) {
-          throw new Error('Aktiviteten kunne ikke findes. Prøv at lukke og åbne aktiviteten igen.');
+          if (activityCheckError || !activityCheck) {
+            throw new Error('Aktiviteten kunne ikke findes. Prøv at lukke og åbne aktiviteten igen.');
+          }
         }
 
-        const taskPayload: Record<string, any> = {
-          activity_id: activityId,
-          title: title.trim(),
-          description: description.trim(),
-          completed: false,
-          reminder_minutes: reminderPayload,
-          task_template_id: localTemplateId,
-          after_training_enabled: hasAfterTrainingFeedback,
-          after_training_delay_minutes: feedbackDelayPayload,
-          task_duration_enabled: hasTaskDuration,
-          task_duration_minutes: taskDurationPayload,
-        };
+        const activeTable: 'activity_tasks' | 'external_event_tasks' = isExternalActivity
+          ? 'external_event_tasks'
+          : 'activity_tasks';
+        const taskData = await runTaskInsert(
+          activeTable,
+          activeTable === 'external_event_tasks' ? 'local_meta_id' : 'activity_id',
+        );
 
-        const { data: taskData, error: taskError } = await supabase
-          .from('activity_tasks')
-          .insert(taskPayload as any)
-          .select()
-          .single();
-
-        if (taskError) {
-          throw new Error(`Database fejl: ${taskError.message}`);
+        if (activeTable === 'activity_tasks') {
+          await syncActivitySubtasks(String(taskData.id), subtasks);
+          await syncLocalFeedbackTask({
+            parentTaskId: String(taskData.id),
+            activityLinkId: resolvedActivityLinkId,
+            templateId: localTemplateId,
+            taskTitle: title.trim(),
+            enabled: hasAfterTrainingFeedback,
+            delayMinutes: feedbackDelayPayload,
+          });
+        } else {
+          await syncExternalFeedbackTask({
+            parentTaskId: String(taskData.id),
+            localMetaId: resolvedActivityLinkId,
+            templateId: localTemplateId,
+            taskTitle: title.trim(),
+            enabled: hasAfterTrainingFeedback,
+            delayMinutes: feedbackDelayPayload,
+          });
         }
 
-        if (!taskData) {
-          throw new Error('Ingen data returneret fra databasen');
-        }
-
-        await syncActivitySubtasks(String(taskData.id), subtasks);
-
-        await syncLocalFeedbackTask({
-          parentTaskId: String(taskData.id),
-          templateId: localTemplateId,
-          taskTitle: title.trim(),
-          enabled: hasAfterTrainingFeedback,
-          delayMinutes: feedbackDelayPayload,
-        });
-
-        if (hasReminder && safeActivityDate) {
+        if (!isExternalActivity && hasReminder && safeActivityDate) {
           const activityDateStr = safeActivityDate.toISOString().split('T')[0];
           const success = await scheduleTaskReminderImmediate(
             taskData.id,
             title.trim(),
             description.trim(),
-            activityId,
+            resolvedActivityLinkId,
             activityTitle,
             activityDateStr,
             activityTime,
@@ -799,7 +1125,7 @@ export function CreateActivityTaskModal({
               [{ text: 'OK' }]
             );
           }
-        } else if (hasReminder && !safeActivityDate) {
+        } else if (!isExternalActivity && hasReminder && !safeActivityDate) {
           Alert.alert(
             'Opgave oprettet',
             `Opgaven "${title}" er oprettet, men der kunne ikke planlægges påmindelse uden gyldig dato.`,
@@ -865,7 +1191,7 @@ export function CreateActivityTaskModal({
     title,
     userId,
     activityExists,
-    activityId,
+    resolvedActivityLinkId,
     activityTitle,
     safeActivityDate,
     activityTime,
@@ -880,6 +1206,7 @@ export function CreateActivityTaskModal({
     upsertLocalTaskTemplate,
     syncActivitySubtasks,
     syncLocalFeedbackTask,
+    syncExternalFeedbackTask,
     description,
     onSave,
     onTaskCreated,
@@ -887,6 +1214,7 @@ export function CreateActivityTaskModal({
     onClose,
     isEditMode,
     editingTask,
+    isExternalActivity,
   ]);
 
   return (
@@ -924,7 +1252,9 @@ export function CreateActivityTaskModal({
           {!activityExists && (
             <View style={styles.warningBanner}>
               <Text style={styles.warningText}>
-                ⏳ Venter på at aktiviteten bliver oprettet...
+                ⏳ {isExternalActivity
+                  ? 'Venter på at ekstern aktivitet bliver synkroniseret...'
+                  : 'Venter på at aktiviteten bliver oprettet...'}
               </Text>
             </View>
           )}

--- a/components/OnboardingGate.tsx
+++ b/components/OnboardingGate.tsx
@@ -17,7 +17,7 @@ import AppleSubscriptionManager from '@/components/AppleSubscriptionManager';
 import SubscriptionManager from '@/components/SubscriptionManager';
 import { useSubscription } from '@/contexts/SubscriptionContext';
 import { useAppleIAP, PRODUCT_IDS, TRAINER_PRODUCT_IDS } from '@/contexts/AppleIAPContext';
-import { getSubscriptionGateState } from '@/utils/subscriptionGate';
+import { resolveSubscriptionAccessState } from '@/utils/accessGate';
 import { TimeoutError, withTimeout } from '@/utils/withTimeout';
 
 type Role = 'admin' | 'trainer' | 'player';
@@ -36,6 +36,10 @@ interface OnboardingGateProps {
 }
 
 const ONBOARDING_ACCESS_CACHE_KEY = 'onboarding_gate_last_known_access_v1';
+const ONBOARDING_AUTHORITATIVE_NO_SUB_KEY = 'onboarding_gate_authoritative_no_sub_v1';
+const AUTHORITATIVE_NO_SUB_WINDOW_MS = 60 * 60 * 1000;
+const AUTHORITATIVE_NO_SUB_REQUIRED_HITS = 3;
+const AUTHORITATIVE_NO_SUB_DEDUPE_MS = 5 * 60 * 1000;
 
 type CachedOnboardingAccess = {
   userId: string | null;
@@ -44,12 +48,11 @@ type CachedOnboardingAccess = {
   updatedAt: string;
 };
 
-const FullScreenLoader = ({ message }: { message: string }) => (
-  <View style={styles.loaderContainer}>
-    <ActivityIndicator size="large" color={colors.primary} />
-    <Text style={styles.loaderText}>{message}</Text>
-  </View>
-);
+type CachedAuthoritativeNoSub = {
+  userId: string;
+  timestamps: number[];
+  updatedAt: string;
+};
 
 export function OnboardingGate({ children, renderInlinePaywall = false }: OnboardingGateProps) {
   const STARTUP_TIMEOUT_MS = 12000;
@@ -64,7 +67,8 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
   });
   const [activatingSubscription, setActivatingSubscription] = useState(false);
   const [activationMessage, setActivationMessage] = useState('Aktiverer abonnement...');
-  const { subscriptionStatus, refreshSubscription, createSubscription } = useSubscription();
+  const { subscriptionStatus, subscriptionMeta, refreshSubscription, createSubscription } =
+    useSubscription();
   const { entitlementSnapshot, refreshSubscriptionStatus } = useAppleIAP();
   const { resolving } = entitlementSnapshot;
   const router = useRouter();
@@ -79,6 +83,8 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
   const backgroundRecoveryInFlightRef = useRef(false);
   const isMountedRef = useRef(true);
   const hydrationRunRef = useRef(0);
+  const startupMountedAtRef = useRef(Date.now());
+  const startupHomeRedirectDoneRef = useRef(false);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -96,27 +102,6 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
     },
     [router]
   );
-  useEffect(() => {
-    setState(prev => {
-      if (prev.hydrating) return prev;
-      const gateState = getSubscriptionGateState({
-        user: prev.user,
-        subscriptionStatus,
-        entitlementSnapshot,
-      });
-      const shouldNeed = gateState.shouldShowChooseSubscription;
-      if (shouldNeed === prev.needsSubscription) return prev;
-      console.log('[OnboardingGate] needsSubscription updated', {
-        shouldNeed,
-        user: prev.user?.id ?? null,
-        role: prev.role,
-        resolving: gateState.isResolving,
-        isEntitled: gateState.hasActiveEntitlement,
-        backendHasSubscription: gateState.hasBackendSubscription,
-      });
-      return { ...prev, needsSubscription: shouldNeed };
-    });
-  }, [entitlementSnapshot, subscriptionStatus]);
   useEffect(() => {
     subscriptionStatusRef.current = subscriptionStatus;
   }, [subscriptionStatus]);
@@ -155,6 +140,47 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
       // Non-blocking cache persistence
     }
   }, []);
+
+  const loadAuthoritativeNoSubCache = useCallback(async (): Promise<CachedAuthoritativeNoSub | null> => {
+    try {
+      const raw = await AsyncStorage.getItem(ONBOARDING_AUTHORITATIVE_NO_SUB_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as Partial<CachedAuthoritativeNoSub>;
+      const userId = typeof parsed.userId === 'string' ? parsed.userId.trim() : '';
+      const timestamps = Array.isArray(parsed.timestamps)
+        ? parsed.timestamps
+            .map(value => Number(value))
+            .filter(value => Number.isFinite(value) && value > 0)
+        : [];
+      if (!userId.length) return null;
+      return {
+        userId,
+        timestamps,
+        updatedAt:
+          typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date(0).toISOString(),
+      };
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const persistAuthoritativeNoSubCache = useCallback(
+    async (payload: CachedAuthoritativeNoSub | null) => {
+      try {
+        if (!payload) {
+          await AsyncStorage.removeItem(ONBOARDING_AUTHORITATIVE_NO_SUB_KEY);
+          return;
+        }
+        await AsyncStorage.setItem(
+          ONBOARDING_AUTHORITATIVE_NO_SUB_KEY,
+          JSON.stringify(payload),
+        );
+      } catch {
+        // Non-blocking cache persistence
+      }
+    },
+    []
+  );
 
   const applyCachedApprovedAccess = useCallback(
     async (user: any | null, runId: number, setStateIfCurrent?: (next: React.SetStateAction<GateState>) => void) => {
@@ -199,6 +225,103 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
       return subscriptionStatusRef.current ?? null;
     }
   }, [refreshSubscription]);
+
+  const resolveNeedsSubscription = useCallback(
+    async ({
+      user,
+      accessState,
+    }: {
+      user: any | null;
+      accessState: 'granted' | 'grace' | 'denied_authoritative';
+    }): Promise<boolean> => {
+      const userId = typeof user?.id === 'string' ? user.id.trim() : '';
+      if (!userId.length) {
+        await persistAuthoritativeNoSubCache(null);
+        return false;
+      }
+
+      if (accessState === 'granted') {
+        await persistAuthoritativeNoSubCache(null);
+        return false;
+      }
+
+      if (accessState !== 'denied_authoritative') {
+        return false;
+      }
+
+      const now = Date.now();
+      const cached = await loadAuthoritativeNoSubCache();
+      const cachedTimestamps = Array.isArray(cached?.timestamps) ? cached.timestamps : [];
+      const previousTimestamps = cached?.userId === userId ? cachedTimestamps : [];
+      const withinWindow = previousTimestamps.filter(
+        value => Number.isFinite(value) && now - value <= AUTHORITATIVE_NO_SUB_WINDOW_MS
+      );
+      const lastHit = withinWindow.length ? withinWindow[withinWindow.length - 1] : null;
+      const shouldAppend = !lastHit || now - lastHit >= AUTHORITATIVE_NO_SUB_DEDUPE_MS;
+      const nextTimestamps = shouldAppend ? [...withinWindow, now] : withinWindow;
+
+      await persistAuthoritativeNoSubCache({
+        userId,
+        timestamps: nextTimestamps.slice(-20),
+        updatedAt: new Date(now).toISOString(),
+      });
+
+      return nextTimestamps.length >= AUTHORITATIVE_NO_SUB_REQUIRED_HITS;
+    },
+    [loadAuthoritativeNoSubCache, persistAuthoritativeNoSubCache]
+  );
+
+  useEffect(() => {
+    if (state.hydrating) return;
+    let cancelled = false;
+
+    const accessSnapshot = resolveSubscriptionAccessState({
+      user: state.user,
+      subscriptionStatus,
+      subscriptionMeta,
+      entitlementSnapshot,
+    });
+
+    const evaluateGate = async () => {
+      const shouldNeed = await resolveNeedsSubscription({
+        user: state.user,
+        accessState: accessSnapshot.accessState,
+      });
+
+      if (cancelled || !isMountedRef.current) return;
+
+      setState(prev => {
+        if (prev.hydrating) return prev;
+        if (prev.needsSubscription === shouldNeed) return prev;
+        console.log('[OnboardingGate] needsSubscription updated', {
+          shouldNeed,
+          user: prev.user?.id ?? null,
+          role: prev.role,
+          accessState: accessSnapshot.accessState,
+          hasActiveSubscription: accessSnapshot.hasActiveSubscription,
+          authoritativeIapNoSubscription:
+            accessSnapshot.hasAuthoritativeIapNoSubscription,
+          authoritativeBackendNoSubscription:
+            accessSnapshot.hasAuthoritativeBackendNoSubscription,
+        });
+        return { ...prev, needsSubscription: shouldNeed };
+      });
+    };
+
+    void evaluateGate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    entitlementSnapshot,
+    resolveNeedsSubscription,
+    state.hydrating,
+    state.user,
+    subscriptionMeta,
+    subscriptionStatus,
+  ]);
+
   const deriveRoleFromSubscription = useCallback((status: any): Role | null => {
     if (!status) return null;
     const maxPlayers = status.maxPlayers ?? status.max_players ?? status.playerLimit ?? null;
@@ -246,11 +369,13 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
         lastGateUserIdRef.current = nextUserId;
         refreshCalledRef.current = false;
         subscriptionStatusRef.current = null;
+        await persistAuthoritativeNoSubCache(null);
       }
       setStateIfCurrent(prev => ({ ...prev, hydrating: true, user, initError: null }));
 
       if (!user) {
         await persistCachedAccess(null);
+        await persistAuthoritativeNoSubCache(null);
         setStateIfCurrent({
           hydrating: false,
           user: null,
@@ -279,12 +404,17 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
           STARTUP_TIMEOUT_MS,
           'Onboarding subscription query timed out'
         );
-        const gateState = getSubscriptionGateState({
+        const accessSnapshot = resolveSubscriptionAccessState({
           user,
           subscriptionStatus: visibleStatus,
+          subscriptionMeta,
           entitlementSnapshot,
         });
-        const derivedRole = gateState.hasActiveSubscription
+        const shouldNeedSubscription = await resolveNeedsSubscription({
+          user,
+          accessState: accessSnapshot.accessState,
+        });
+        const derivedRole = accessSnapshot.hasActiveSubscription
           ? deriveRoleFromSubscription(visibleStatus) ?? roleFromDb
           : roleFromDb;
 
@@ -300,13 +430,13 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
           hydrating: false,
           user,
           role: derivedRole ?? roleFromDb,
-          needsSubscription: gateState.shouldShowChooseSubscription,
+          needsSubscription: shouldNeedSubscription,
           initError: null,
         });
         await persistCachedAccess({
           userId: user.id ?? null,
           role: derivedRole ?? roleFromDb,
-          hasApprovedAccess: !gateState.shouldShowChooseSubscription,
+          hasApprovedAccess: !shouldNeedSubscription,
           updatedAt: new Date().toISOString(),
         });
       } catch (error) {
@@ -341,6 +471,9 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
       ensureSubscriptionStatus,
       entitlementSnapshot,
       persistCachedAccess,
+      persistAuthoritativeNoSubCache,
+      resolveNeedsSubscription,
+      subscriptionMeta,
       upsertRole,
     ]
   );
@@ -515,6 +648,31 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
     }
   }, [needsPaywall, normalizeFallbackTarget, pathname, renderInlinePaywall, safeReplace]);
 
+  useEffect(() => {
+    if (renderInlinePaywall) return;
+    if (startupHomeRedirectDoneRef.current) return;
+    if (state.hydrating || state.initError || !state.user || needsPaywall) return;
+
+    const startupElapsedMs = Date.now() - startupMountedAtRef.current;
+    if (startupElapsedMs > 15_000) {
+      startupHomeRedirectDoneRef.current = true;
+      return;
+    }
+
+    if (pathname === '/(tabs)/profile' || pathname === '/profile') {
+      startupHomeRedirectDoneRef.current = true;
+      safeReplace('/(tabs)/(home)');
+    }
+  }, [
+    needsPaywall,
+    pathname,
+    renderInlinePaywall,
+    safeReplace,
+    state.hydrating,
+    state.initError,
+    state.user,
+  ]);
+
   if (needsPaywall && renderInlinePaywall) {
     return (
       <View style={styles.paywallContainer}>
@@ -550,13 +708,8 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
     );
   }
 
-  const showBlockingOverlay =
-    state.hydrating ||
-    Boolean(state.initError) ||
-    (!renderInlinePaywall && needsPaywall && pathname !== '/choose-plan');
-  const overlayMessage = state.hydrating
-    ? 'Klargører konto'
-    : state.initError ?? 'Åbner Vælg abonnement...';
+  const showBlockingOverlay = Boolean(state.initError);
+  const overlayMessage = state.initError ?? 'Der opstod en fejl.';
 
   return (
     <View style={styles.container}>

--- a/contexts/AppleIAPContext.tsx
+++ b/contexts/AppleIAPContext.tsx
@@ -186,6 +186,12 @@ interface SubscriptionStatus {
   isInTrialPeriod: boolean;
 }
 
+type EntitlementCheckState =
+  | 'idle'
+  | 'inconclusive'
+  | 'authoritative_entitled'
+  | 'authoritative_none';
+
 // IAP diagnostics and logging
 interface IapDiagnostics {
   requestedSkus: string[];
@@ -271,6 +277,11 @@ interface AppleIAPContextType {
     activeProductId: string | null;
     subscriptionTier: SubscriptionTier | null;
     isEntitled: boolean;
+    isAuthoritative: boolean;
+    isAuthoritativelyUnsubscribed: boolean;
+    checkState: EntitlementCheckState;
+    lastCheckedAt: string | null;
+    lastCheckError: string | null;
   };
   verifiedActiveProductId: string | null;
   verifying: boolean;
@@ -538,6 +549,10 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
   const [isRestoring, setIsRestoring] = useState(false);
   const [verifiedActiveProductId, setVerifiedActiveProductId] = useState<string | null>(null);
   const [verifying, setVerifying] = useState(false);
+  const [entitlementCheckState, setEntitlementCheckState] =
+    useState<EntitlementCheckState>('idle');
+  const [entitlementLastCheckedAtMs, setEntitlementLastCheckedAtMs] = useState<number | null>(null);
+  const [entitlementLastCheckError, setEntitlementLastCheckError] = useState<string | null>(null);
   const lastRequestedSkuRef = useRef<string | null>(null);
   const lastRequestedAtRef = useRef<number | null>(null);
   const subscriptionStatusRef = useRef<SubscriptionStatus | null>(null);
@@ -568,6 +583,15 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
   }, [pendingPlan]);
 
   const buildFlowKey = (sku: string) => `${sku}_${Date.now()}`;
+
+  const markEntitlementCheck = useCallback(
+    (nextState: EntitlementCheckState, errorMessage: string | null = null) => {
+      setEntitlementCheckState(nextState);
+      setEntitlementLastCheckError(errorMessage);
+      setEntitlementLastCheckedAtMs(Date.now());
+    },
+    []
+  );
 
   const showAlertOnceByKey = (key: string, title: string, message: string) => {
     if (alertInFlightRef.current) return;
@@ -714,20 +738,24 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
           await fetchEntitlements();
           const ready = await syncIapReadyState();
           if (!ready) {
-            setIapUnavailableReason(getIapUnavailableMessage());
+            const unavailableMessage = getIapUnavailableMessage();
+            setIapUnavailableReason(unavailableMessage);
             const emptyStatus: SubscriptionStatus = { isActive: false, productId: null, expiryDate: null, isInTrialPeriod: false };
             setSubscriptionStatus(emptyStatus);
             subscriptionStatusRef.current = emptyStatus;
             setPendingPlan(null);
+            markEntitlementCheck('inconclusive', unavailableMessage);
             return;
           }
           if (!RNIap || typeof RNIap.getAvailablePurchases !== 'function') {
-            setIapUnavailableReason(getIapUnavailableMessage());
+            const unavailableMessage = getIapUnavailableMessage();
+            setIapUnavailableReason(unavailableMessage);
             console.error('[AppleIAP] getAvailablePurchases unavailable – native module missing.');
             const emptyStatus: SubscriptionStatus = { isActive: false, productId: null, expiryDate: null, isInTrialPeriod: false };
             setSubscriptionStatus(emptyStatus);
             subscriptionStatusRef.current = emptyStatus;
             setPendingPlan(null);
+            markEntitlementCheck('inconclusive', 'iap_unavailable');
             return;
           }
           setIapUnavailableReason(null);
@@ -852,6 +880,7 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
               setSubscriptionStatus(nextStatus);
               subscriptionStatusRef.current = nextStatus;
               setPendingPlan(nextPending);
+              markEntitlementCheck('authoritative_entitled', null);
 
               const receiptOrToken =
                 activePurchase.original?.transactionReceipt ||
@@ -879,6 +908,7 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
               setSubscriptionStatus(emptyStatus);
               subscriptionStatusRef.current = emptyStatus;
               setPendingPlan(null);
+              markEntitlementCheck('authoritative_none', null);
               console.log('[AppleIAP] No active subscriptions found');
               if (!autoRestoreAttemptedRef.current && Platform.OS === 'ios') {
                 autoRestoreAttemptedRef.current = true;
@@ -895,6 +925,9 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
             }
           } catch (error) {
             console.error('[AppleIAP] Error refreshing subscription status:', error);
+            const errorMessage =
+              error instanceof Error ? error.message : typeof error === 'string' ? error : 'unknown_refresh_error';
+            markEntitlementCheck('inconclusive', errorMessage);
           }
         } finally {
           refreshInFlightRef.current = false;
@@ -907,6 +940,7 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
     [
       fetchEntitlements,
       getAvailablePurchasesSafe,
+      markEntitlementCheck,
       performRestore,
       syncIapReadyState,
     ],
@@ -918,6 +952,8 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
       if (session?.user) {
         autoRestoreAttemptedRef.current = false;
         setVerifiedActiveProductId(null);
+        setEntitlementCheckState('idle');
+        setEntitlementLastCheckError(null);
         void refreshSubscriptionStatus({ force: true, reason: 'auth_login' });
         return;
       }
@@ -939,6 +975,9 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
       lastAlertKeyRef.current = null;
       lastAlertAtRef.current = 0;
       setIapUnavailableReason(null);
+      setEntitlementCheckState('idle');
+      setEntitlementLastCheckedAtMs(null);
+      setEntitlementLastCheckError(null);
     });
     return () => {
       data.subscription.unsubscribe();
@@ -1633,14 +1672,35 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
         ? loading || isRestoring || verifying || (!iapReady && !isExpoGo)
         : loading;
     const hasActiveSubscription = Boolean(effectiveSubscriptionTier);
+    const isAuthoritative =
+      entitlementCheckState === 'authoritative_entitled' ||
+      entitlementCheckState === 'authoritative_none';
+    const lastCheckedAt =
+      entitlementLastCheckedAtMs != null ? new Date(entitlementLastCheckedAtMs).toISOString() : null;
     return {
       resolving,
       hasActiveSubscription,
       activeProductId: verifiedActiveProductId ?? appleActiveSku ?? null,
       subscriptionTier: effectiveSubscriptionTier,
       isEntitled: hasActiveSubscription,
+      isAuthoritative,
+      isAuthoritativelyUnsubscribed: entitlementCheckState === 'authoritative_none',
+      checkState: entitlementCheckState,
+      lastCheckedAt,
+      lastCheckError: entitlementLastCheckError,
     };
-  }, [appleActiveSku, effectiveSubscriptionTier, iapReady, isRestoring, loading, verifying, verifiedActiveProductId]);
+  }, [
+    appleActiveSku,
+    effectiveSubscriptionTier,
+    entitlementCheckState,
+    entitlementLastCheckError,
+    entitlementLastCheckedAtMs,
+    iapReady,
+    isRestoring,
+    loading,
+    verifying,
+    verifiedActiveProductId,
+  ]);
 
   const lastEntitlementSignatureRef = useRef<string | null>(null);
   useEffect(() => {

--- a/contexts/AppleIAPContext.web.tsx
+++ b/contexts/AppleIAPContext.web.tsx
@@ -69,6 +69,11 @@ interface AppleIAPContextType {
     activeProductId: string | null;
     subscriptionTier: string | null;
     isEntitled: boolean;
+    isAuthoritative: boolean;
+    isAuthoritativelyUnsubscribed: boolean;
+    checkState: 'idle' | 'inconclusive' | 'authoritative_entitled' | 'authoritative_none';
+    lastCheckedAt: string | null;
+    lastCheckError: string | null;
   };
   verifiedActiveProductId: string | null;
   verifying: boolean;
@@ -141,6 +146,11 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
       activeProductId: null,
       subscriptionTier: null,
       isEntitled: false,
+      isAuthoritative: false,
+      isAuthoritativelyUnsubscribed: false,
+      checkState: 'idle',
+      lastCheckedAt: null,
+      lastCheckError: null,
     },
     verifiedActiveProductId: null,
     verifying: false,

--- a/contexts/SubscriptionContext.tsx
+++ b/contexts/SubscriptionContext.tsx
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { PRODUCT_IDS } from '@/contexts/appleProductIds';
 import { bumpEntitlementsVersion, subscribeToEntitlementVersion } from '@/services/entitlementsEvents';
 import type { SubscriptionTier } from '@/services/entitlementsSync';
+import { getProfileEntitlements } from '@/utils/profileEntitlements';
 
 export function forceEntitlementVersionBump(reason = 'external') {
   bumpEntitlementsVersion(reason);
@@ -39,6 +40,12 @@ type SubscriptionStatus = {
   isLifetime?: boolean;
 };
 
+type SubscriptionStatusMeta = {
+  lastUpdateReason: string | null;
+  lastUpdatedAt: string | null;
+  backendAuthoritative: boolean;
+};
+
 export type AppleEntitlementIngest = {
   resolving: boolean;
   isEntitled: boolean;
@@ -67,6 +74,7 @@ const buildEmptyStatus = (): SubscriptionStatus => ({
 
 interface SubscriptionContextType {
   subscriptionStatus: SubscriptionStatus | null;
+  subscriptionMeta: SubscriptionStatusMeta;
   subscriptionPlans: SubscriptionPlan[];
   loading: boolean;
   refreshSubscription: () => Promise<void>;
@@ -154,8 +162,27 @@ const subscriptionTierFromSku = (sku: string | null): SubscriptionTier | null =>
   }
 };
 
+const subscriptionTierFromProfile = (tier: string | null): SubscriptionTier | null => {
+  const normalized = String(tier ?? '').trim().toLowerCase();
+  switch (normalized) {
+    case 'player_basic':
+    case 'player_premium':
+    case 'trainer_basic':
+    case 'trainer_standard':
+    case 'trainer_premium':
+      return normalized;
+    default:
+      return null;
+  }
+};
+
 export function SubscriptionProvider({ children }: { children: ReactNode }) {
   const [subscriptionStatus, setSubscriptionStatus] = useState<SubscriptionStatus | null>(null);
+  const [subscriptionMeta, setSubscriptionMeta] = useState<SubscriptionStatusMeta>({
+    lastUpdateReason: null,
+    lastUpdatedAt: null,
+    backendAuthoritative: false,
+  });
   const [subscriptionPlans, setSubscriptionPlans] = useState<SubscriptionPlan[]>([]);
   const [loading, setLoading] = useState(true);
   const [entitlementVersion, setEntitlementVersion] = useState(0);
@@ -182,6 +209,14 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const applyStatus = useCallback((next: SubscriptionStatus, reason: string) => {
+    const checkedAtIso = new Date().toISOString();
+    const backendAuthoritative = reason === 'fetch-success';
+    setSubscriptionMeta({
+      lastUpdateReason: reason,
+      lastUpdatedAt: checkedAtIso,
+      backendAuthoritative,
+    });
+
     const isAuthoritative = reason === 'fetch-success';
     const shouldPersist =
       next.hasSubscription || next.isLifetime || Boolean(next.subscriptionTier) || Boolean(next.planName) || isAuthoritative;
@@ -308,6 +343,48 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
     [appleIsEntitled, appleActiveProductId, appleEntitlementTier, appleResolving]
   );
 
+  const applyProfileEntitlementFallback = useCallback(
+    async (userId: string, status: SubscriptionStatus): Promise<SubscriptionStatus> => {
+      if (status.hasSubscription || status.subscriptionTier || status.isLifetime) {
+        return status;
+      }
+
+      const profileEntitlements = await getProfileEntitlements(userId);
+      if (!profileEntitlements.hasEntitlement) {
+        return status;
+      }
+
+      const tierFromProfile = subscriptionTierFromProfile(profileEntitlements.tier);
+      const planMeta =
+        derivePlanMetaFromTier(tierFromProfile) ??
+        derivePlanMetaFromSku(
+          profileEntitlements.productId ? String(profileEntitlements.productId) : null
+        );
+      const resolvedMaxPlayers = planMeta?.maxPlayers ?? status.maxPlayers ?? 1;
+
+      const fallbackStatus: SubscriptionStatus = {
+        ...status,
+        hasSubscription: true,
+        status: status.status ?? 'lifetime',
+        planName: planMeta?.name ?? status.planName ?? 'Livstid',
+        maxPlayers: resolvedMaxPlayers,
+        currentPlayers: Math.max(status.currentPlayers ?? 0, 1),
+        subscriptionTier: tierFromProfile ?? status.subscriptionTier,
+        isLifetime: true,
+      };
+
+      console.warn('[SubscriptionContext] Using profile entitlement fallback', {
+        userId,
+        profileTier: profileEntitlements.tier,
+        profileProductId: profileEntitlements.productId,
+        fallbackStatus,
+      });
+
+      return fallbackStatus;
+    },
+    []
+  );
+
   const fetchSubscriptionStatus = useCallback(async () => {
     try {
       console.log('[SubscriptionContext] Fetching subscription status');
@@ -382,8 +459,9 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         subscriptionTier: (data?.subscriptionTier as SubscriptionTier | null) ?? null,
       };
 
+      const statusWithProfileFallback = await applyProfileEntitlementFallback(user.id, statusData);
       const reason = payloadHasError ? 'fetch-fallback' : 'fetch-success';
-      applyStatus(coerceWithEntitlements(statusData, reason), reason);
+      applyStatus(coerceWithEntitlements(statusWithProfileFallback, reason), reason);
     } catch {
       console.warn('[SubscriptionContext] Network request failed');
 
@@ -397,7 +475,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         console.log('[SubscriptionContext] Loading set to false');
       }
     }
-  }, [applyStatus, coerceWithEntitlements]);
+  }, [applyProfileEntitlementFallback, applyStatus, coerceWithEntitlements]);
 
   useEffect(() => {
     const { data } = supabase.auth.onAuthStateChange((_event, session) => {
@@ -643,6 +721,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
     <SubscriptionContext.Provider
       value={{
         subscriptionStatus,
+        subscriptionMeta,
         subscriptionPlans,
         loading,
         refreshSubscription,

--- a/hooks/useHomeActivities.ts
+++ b/hooks/useHomeActivities.ts
@@ -258,6 +258,78 @@ const devLog = (...args: unknown[]) => {
   }
 };
 
+const EXTERNAL_META_QUERY_CHUNK_SIZE = 75;
+
+const chunkArray = <T,>(values: T[], size: number): T[][] => {
+  if (!values.length || size <= 0) return [];
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+  return chunks;
+};
+
+const summarizeSupabaseError = (error: any) => {
+  const message =
+    typeof error?.message === 'string'
+      ? error.message.slice(0, 240)
+      : String(error?.message ?? 'unknown').slice(0, 240);
+  return {
+    code: error?.code ?? null,
+    message,
+    details:
+      typeof error?.details === 'string'
+        ? error.details.slice(0, 240)
+        : error?.details ?? null,
+    hint: typeof error?.hint === 'string' ? error.hint.slice(0, 240) : error?.hint ?? null,
+  };
+};
+
+const fetchExternalMetaRows = async ({
+  userId,
+  column,
+  values,
+  metaSelect,
+}: {
+  userId: string;
+  column: 'external_event_id' | 'external_event_uid';
+  values: string[];
+  metaSelect: string;
+}): Promise<{ data: any[]; error: any | null }> => {
+  const normalized = Array.from(
+    new Set(
+      values
+        .map((value) => String(value ?? '').trim())
+        .filter((value) => value.length > 0)
+    )
+  );
+  if (!normalized.length) {
+    return { data: [], error: null };
+  }
+
+  const chunks = chunkArray(normalized, EXTERNAL_META_QUERY_CHUNK_SIZE);
+  const merged: any[] = [];
+  let firstError: any = null;
+
+  for (const chunk of chunks) {
+    const { data, error } = await supabase
+      .from('events_local_meta')
+      .select(metaSelect)
+      .eq('user_id', userId)
+      .in(column, chunk);
+
+    if (error) {
+      if (!firstError) firstError = error;
+      continue;
+    }
+    if (Array.isArray(data) && data.length) {
+      merged.push(...data);
+    }
+  }
+
+  return { data: merged, error: firstError };
+};
+
 interface UseHomeActivitiesResult {
   activities: ActivityWithCategory[];
   loading: boolean;
@@ -710,27 +782,31 @@ export function useHomeActivities(): UseHomeActivitiesResult {
             `;
 
           const [metaByEventIdRes, metaByUidRes] = await Promise.all([
-            eventRowIds.length
-              ? supabase
-                  .from('events_local_meta')
-                  .select(metaSelect)
-                  .eq('user_id', userId)
-                  .in('external_event_id', eventRowIds)
-              : Promise.resolve({ data: [], error: null }),
-            providerUids.length
-              ? supabase
-                  .from('events_local_meta')
-                  .select(metaSelect)
-                  .eq('user_id', userId)
-                  .in('external_event_uid', providerUids)
-              : Promise.resolve({ data: [], error: null }),
+            fetchExternalMetaRows({
+              userId,
+              column: 'external_event_id',
+              values: eventRowIds,
+              metaSelect,
+            }),
+            fetchExternalMetaRows({
+              userId,
+              column: 'external_event_uid',
+              values: providerUids,
+              metaSelect,
+            }),
           ]);
 
           if (metaByEventIdRes.error) {
-            console.error('[useHomeActivities] Error fetching external event metadata by id:', metaByEventIdRes.error);
+            console.warn(
+              '[useHomeActivities] External metadata by id fetch had partial failure',
+              summarizeSupabaseError(metaByEventIdRes.error),
+            );
           }
           if (metaByUidRes.error) {
-            console.error('[useHomeActivities] Error fetching external event metadata by uid:', metaByUidRes.error);
+            console.warn(
+              '[useHomeActivities] External metadata by uid fetch had partial failure',
+              summarizeSupabaseError(metaByUidRes.error),
+            );
           }
 
           const mergedMetaMap = new Map<string, any>();

--- a/hooks/useUserRole.ts
+++ b/hooks/useUserRole.ts
@@ -27,6 +27,7 @@ interface FetchRoleOptions {
 export function useUserRole() {
   const [userRole, setUserRole] = useState<UserRole | null>(null);
   const [loading, setLoading] = useState(true);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   const userIdRef = useRef<string | null>(null);
   const lastKnownRoleRef = useRef<UserRole | null>(null);
@@ -53,6 +54,7 @@ export function useUserRole() {
             lastKnownRoleRef.current = null;
             setUserRole(null);
             setCurrentUserId(null);
+            setIsAuthenticated(false);
           }
           return;
         }
@@ -65,6 +67,7 @@ export function useUserRole() {
       }
 
       userIdRef.current = targetUserId;
+      setIsAuthenticated(true);
       setCurrentUserId(prev => (prev === targetUserId ? prev : targetUserId));
 
       const { data, error } = await supabase
@@ -127,12 +130,14 @@ export function useUserRole() {
       }
 
       if (session?.user) {
+        setIsAuthenticated(true);
         fetchUserRole({ reason: 'auth-change', userId: session.user.id });
       } else {
         userIdRef.current = null;
         lastKnownRoleRef.current = null;
         setCurrentUserId(null);
         setUserRole(null);
+        setIsAuthenticated(false);
         setLoading(false);
       }
     });
@@ -203,5 +208,5 @@ export function useUserRole() {
   // Export isAdmin as a computed property - includes both admin and trainer roles
   const isAdmin = userRole === 'admin' || userRole === 'trainer';
 
-  return { userRole, loading, isAdmin, refreshUserRole };
+  return { userRole, loading, isAdmin, refreshUserRole, isAuthenticated };
 }

--- a/supabase/migrations/20260305103000_external_event_template_sync_cleanup.sql
+++ b/supabase/migrations/20260305103000_external_event_template_sync_cleanup.sql
@@ -1,0 +1,263 @@
+create or replace function public.create_tasks_for_external_event(p_local_meta_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_category_id uuid;
+  v_user_id uuid;
+  v_template record;
+  v_base_task_id uuid;
+  v_feedback_task_id uuid;
+  v_template_ids uuid[] := array[]::uuid[];
+
+  v_has_local_meta_id boolean := false;
+  v_has_task_template_id boolean := false;
+  v_has_title boolean := false;
+  v_has_description boolean := false;
+  v_has_reminder_minutes boolean := false;
+  v_has_completed boolean := false;
+  v_has_feedback_template_id boolean := false;
+  v_has_is_feedback_task boolean := false;
+  v_has_video_url boolean := false;
+
+  v_has_after_training_enabled boolean := false;
+  v_has_after_training_delay_minutes boolean := false;
+
+  v_should_create_feedback boolean := false;
+  v_feedback_reminder_minutes integer := null;
+begin
+  if p_local_meta_id is null then
+    return;
+  end if;
+
+  if to_regclass('public.external_event_tasks') is null
+     or to_regclass('public.events_local_meta') is null
+     or to_regclass('public.task_templates') is null
+     or to_regclass('public.task_template_categories') is null then
+    return;
+  end if;
+
+  select
+    coalesce(bool_or(column_name = 'local_meta_id'), false),
+    coalesce(bool_or(column_name = 'task_template_id'), false),
+    coalesce(bool_or(column_name = 'title'), false),
+    coalesce(bool_or(column_name = 'description'), false),
+    coalesce(bool_or(column_name = 'reminder_minutes'), false),
+    coalesce(bool_or(column_name = 'completed'), false),
+    coalesce(bool_or(column_name = 'feedback_template_id'), false),
+    coalesce(bool_or(column_name = 'is_feedback_task'), false),
+    coalesce(bool_or(column_name = 'video_url'), false)
+  into
+    v_has_local_meta_id,
+    v_has_task_template_id,
+    v_has_title,
+    v_has_description,
+    v_has_reminder_minutes,
+    v_has_completed,
+    v_has_feedback_template_id,
+    v_has_is_feedback_task,
+    v_has_video_url
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'external_event_tasks';
+
+  if not (
+    v_has_local_meta_id
+    and v_has_task_template_id
+    and v_has_title
+    and v_has_description
+    and v_has_reminder_minutes
+    and v_has_completed
+  ) then
+    return;
+  end if;
+
+  if not v_has_feedback_template_id then
+    return;
+  end if;
+
+  select
+    coalesce(bool_or(column_name = 'after_training_enabled'), false),
+    coalesce(bool_or(column_name = 'after_training_delay_minutes'), false)
+  into
+    v_has_after_training_enabled,
+    v_has_after_training_delay_minutes
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'task_templates';
+
+  select category_id, user_id
+    into v_category_id, v_user_id
+  from public.events_local_meta
+  where id = p_local_meta_id;
+
+  if v_category_id is null or v_user_id is null then
+    return;
+  end if;
+
+  select coalesce(array_remove(array_agg(distinct tt.id), null), array[]::uuid[])
+    into v_template_ids
+    from public.task_templates tt
+    join public.task_template_categories ttc on ttc.task_template_id = tt.id
+   where ttc.category_id = v_category_id
+     and tt.user_id = v_user_id;
+
+  -- Remove stale category-driven template tasks but keep local manual tasks.
+  delete from public.external_event_tasks eet
+   where eet.local_meta_id = p_local_meta_id
+     and eet.task_template_id is not null
+     and (
+       coalesce(array_length(v_template_ids, 1), 0) = 0
+       or not (eet.task_template_id = any(v_template_ids))
+     )
+     and not exists (
+       select 1
+         from public.task_templates tt
+        where tt.id = eet.task_template_id
+          and coalesce(tt.source_folder, '') = 'activity_local_task'
+     );
+
+  -- Remove stale feedback tasks tied to templates no longer in the category.
+  delete from public.external_event_tasks eet
+   where eet.local_meta_id = p_local_meta_id
+     and eet.feedback_template_id is not null
+     and (
+       coalesce(array_length(v_template_ids, 1), 0) = 0
+       or not (eet.feedback_template_id = any(v_template_ids))
+     )
+     and not exists (
+       select 1
+         from public.task_templates tt
+        where tt.id = eet.feedback_template_id
+          and coalesce(tt.source_folder, '') = 'activity_local_task'
+     );
+
+  for v_template in
+    select distinct tt.*
+      from public.task_templates tt
+      join public.task_template_categories ttc on ttc.task_template_id = tt.id
+     where ttc.category_id = v_category_id
+       and tt.user_id = v_user_id
+  loop
+    select id
+      into v_base_task_id
+    from public.external_event_tasks
+    where local_meta_id = p_local_meta_id
+      and task_template_id = v_template.id
+    limit 1;
+
+    if v_base_task_id is null then
+      insert into public.external_event_tasks (
+        local_meta_id,
+        task_template_id,
+        title,
+        description,
+        reminder_minutes,
+        completed
+      )
+      values (
+        p_local_meta_id,
+        v_template.id,
+        v_template.title,
+        v_template.description,
+        v_template.reminder_minutes,
+        false
+      )
+      returning id into v_base_task_id;
+    else
+      update public.external_event_tasks
+         set title = v_template.title,
+             description = v_template.description,
+             reminder_minutes = v_template.reminder_minutes
+       where id = v_base_task_id;
+    end if;
+
+    v_should_create_feedback := false;
+    if v_has_after_training_enabled then
+      v_should_create_feedback := coalesce(v_template.after_training_enabled, false);
+    end if;
+
+    v_feedback_reminder_minutes := null;
+    if v_has_after_training_delay_minutes then
+      v_feedback_reminder_minutes := v_template.after_training_delay_minutes;
+    end if;
+
+    if not v_should_create_feedback then
+      delete from public.external_event_tasks
+      where local_meta_id = p_local_meta_id
+        and feedback_template_id = v_template.id;
+
+      if v_has_is_feedback_task then
+        delete from public.external_event_tasks
+        where local_meta_id = p_local_meta_id
+          and coalesce(is_feedback_task, false) = true
+          and task_template_id is null
+          and (feedback_template_id is null or feedback_template_id = v_template.id);
+      end if;
+
+      continue;
+    end if;
+
+    select id
+      into v_feedback_task_id
+    from public.external_event_tasks
+    where local_meta_id = p_local_meta_id
+      and feedback_template_id = v_template.id
+    limit 1;
+
+    if v_feedback_task_id is null then
+      if v_has_is_feedback_task then
+        insert into public.external_event_tasks (
+          local_meta_id,
+          task_template_id,
+          feedback_template_id,
+          title,
+          description,
+          reminder_minutes,
+          completed,
+          is_feedback_task
+        )
+        values (
+          p_local_meta_id,
+          null,
+          v_template.id,
+          'Feedback på ' || coalesce(v_template.title, 'opgave'),
+          '',
+          v_feedback_reminder_minutes,
+          false,
+          true
+        )
+        returning id into v_feedback_task_id;
+      else
+        insert into public.external_event_tasks (
+          local_meta_id,
+          task_template_id,
+          feedback_template_id,
+          title,
+          description,
+          reminder_minutes,
+          completed
+        )
+        values (
+          p_local_meta_id,
+          null,
+          v_template.id,
+          'Feedback på ' || coalesce(v_template.title, 'opgave'),
+          '',
+          v_feedback_reminder_minutes,
+          false
+        )
+        returning id into v_feedback_task_id;
+      end if;
+    else
+      update public.external_event_tasks
+         set title = 'Feedback på ' || coalesce(v_template.title, 'opgave'),
+             description = '',
+             reminder_minutes = v_feedback_reminder_minutes
+       where id = v_feedback_task_id;
+    end if;
+  end loop;
+end;
+$$;

--- a/utils/accessGate.ts
+++ b/utils/accessGate.ts
@@ -1,0 +1,137 @@
+import { getSubscriptionGateState } from '@/utils/subscriptionGate';
+
+type SubscriptionStatusLike = {
+  hasSubscription?: boolean;
+  subscriptionTier?: string | null;
+  isLifetime?: boolean;
+  status?: string | null;
+  planName?: string | null;
+};
+
+type SubscriptionMetaLike = {
+  backendAuthoritative?: boolean | null;
+};
+
+type EntitlementSnapshotLike = {
+  resolving?: boolean;
+  isAuthoritativelyUnsubscribed?: boolean;
+};
+
+type ResolveAccessInput = {
+  user: any | null;
+  subscriptionStatus?: SubscriptionStatusLike | null;
+  subscriptionMeta?: SubscriptionMetaLike | null;
+  entitlementSnapshot?: EntitlementSnapshotLike | null;
+};
+
+export type AccessState = 'granted' | 'grace' | 'denied_authoritative';
+
+const NO_PLAN_NAME_VALUES = new Set([
+  'none',
+  '(none)',
+  'no_plan',
+  'no_subscription',
+  'unknown',
+  'ukendt',
+  'unsubscribed',
+  'null',
+  'undefined',
+]);
+
+const hasMeaningfulPlanName = (planName?: string | null): boolean => {
+  const normalized = String(planName ?? '').trim().toLowerCase();
+  if (!normalized.length) return false;
+  return !NO_PLAN_NAME_VALUES.has(normalized);
+};
+
+const backendHasActiveSubscription = (
+  subscriptionStatus?: SubscriptionStatusLike | null,
+): boolean => {
+  const normalizedStatus = (subscriptionStatus?.status ?? '').toLowerCase();
+  const statusImpliesActive =
+    normalizedStatus === 'active' ||
+    normalizedStatus === 'trial' ||
+    normalizedStatus === 'trialing' ||
+    normalizedStatus === 'lifetime';
+
+  return Boolean(
+    subscriptionStatus?.hasSubscription ||
+      subscriptionStatus?.subscriptionTier ||
+      subscriptionStatus?.isLifetime ||
+      statusImpliesActive ||
+      hasMeaningfulPlanName(subscriptionStatus?.planName),
+  );
+};
+
+export const resolveSubscriptionAccessState = ({
+  user,
+  subscriptionStatus,
+  subscriptionMeta,
+  entitlementSnapshot,
+}: ResolveAccessInput): {
+  accessState: AccessState;
+  hasActiveSubscription: boolean;
+  hasAuthoritativeIapNoSubscription: boolean;
+  hasAuthoritativeBackendNoSubscription: boolean;
+} => {
+  const gateState = getSubscriptionGateState({
+    user,
+    subscriptionStatus,
+    entitlementSnapshot,
+  });
+
+  const hasAuthoritativeIapNoSubscription = Boolean(
+    entitlementSnapshot?.isAuthoritativelyUnsubscribed,
+  );
+  const hasAuthoritativeBackendNoSubscription = Boolean(
+    subscriptionMeta?.backendAuthoritative &&
+      subscriptionStatus &&
+      !backendHasActiveSubscription(subscriptionStatus),
+  );
+
+  if (!user) {
+    return {
+      accessState: 'granted',
+      hasActiveSubscription: gateState.hasActiveSubscription,
+      hasAuthoritativeIapNoSubscription,
+      hasAuthoritativeBackendNoSubscription,
+    };
+  }
+
+  if (gateState.isResolving) {
+    return {
+      accessState: 'grace',
+      hasActiveSubscription: gateState.hasActiveSubscription,
+      hasAuthoritativeIapNoSubscription,
+      hasAuthoritativeBackendNoSubscription,
+    };
+  }
+
+  if (gateState.hasActiveSubscription) {
+    return {
+      accessState: 'granted',
+      hasActiveSubscription: gateState.hasActiveSubscription,
+      hasAuthoritativeIapNoSubscription,
+      hasAuthoritativeBackendNoSubscription,
+    };
+  }
+
+  if (
+    hasAuthoritativeIapNoSubscription &&
+    hasAuthoritativeBackendNoSubscription
+  ) {
+    return {
+      accessState: 'denied_authoritative',
+      hasActiveSubscription: gateState.hasActiveSubscription,
+      hasAuthoritativeIapNoSubscription,
+      hasAuthoritativeBackendNoSubscription,
+    };
+  }
+
+  return {
+    accessState: 'grace',
+    hasActiveSubscription: gateState.hasActiveSubscription,
+    hasAuthoritativeIapNoSubscription,
+    hasAuthoritativeBackendNoSubscription,
+  };
+};

--- a/utils/profileEntitlements.ts
+++ b/utils/profileEntitlements.ts
@@ -6,6 +6,24 @@ export interface ProfileEntitlements {
   hasEntitlement: boolean;
 }
 
+const NO_PLAN_VALUES = new Set([
+  'none',
+  '(none)',
+  'no_plan',
+  'no_subscription',
+  'unknown',
+  'ukendt',
+  'unsubscribed',
+  'null',
+  'undefined',
+]);
+
+const hasMeaningfulValue = (value: unknown): boolean => {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  if (!normalized.length) return false;
+  return !NO_PLAN_VALUES.has(normalized);
+};
+
 /**
  * Fetches profile entitlements (subscription_tier, subscription_product_id) from Supabase.
  * Tries 'profiles' table (id = userId).
@@ -19,22 +37,33 @@ export async function getProfileEntitlements(userId: string | null | undefined):
   }
 
   try {
-    // Try 'profiles' table (primary key: id = userId)
-    const { data: profileData, error: profileError } = await supabase
+    const { data: profileById, error: profileByIdError } = await supabase
       .from('profiles')
       .select('subscription_tier, subscription_product_id')
       .eq('id', userId)
       .maybeSingle();
 
-    if (!profileError && profileData) {
-      const tier = profileData.subscription_tier;
-      const productId = profileData.subscription_product_id;
-      const hasEntitlement = Boolean(tier || productId);
-      
+    if (!profileByIdError && profileById) {
+      const tier = profileById.subscription_tier;
+      const productId = profileById.subscription_product_id;
+      const hasEntitlement = hasMeaningfulValue(tier) || hasMeaningfulValue(productId);
       return { tier, productId, hasEntitlement };
     }
 
-    // No data found
+    const { data: profileByUserId, error: profileByUserIdError } = await supabase
+      .from('profiles')
+      .select('subscription_tier, subscription_product_id')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (!profileByUserIdError && profileByUserId) {
+      const tier = profileByUserId.subscription_tier;
+      const productId = profileByUserId.subscription_product_id;
+      const hasEntitlement = hasMeaningfulValue(tier) || hasMeaningfulValue(productId);
+      return { tier, productId, hasEntitlement };
+    }
+
+    // No data found or read failed
     return { tier: null, productId: null, hasEntitlement: false };
   } catch (error) {
     console.warn('[ProfileEntitlements] Error fetching profile entitlements:', error);

--- a/utils/subscriptionGate.ts
+++ b/utils/subscriptionGate.ts
@@ -10,12 +10,32 @@ type EntitlementSnapshotLike = {
   resolving?: boolean;
   isEntitled?: boolean;
   hasActiveSubscription?: boolean;
+  isAuthoritative?: boolean;
+  isAuthoritativelyUnsubscribed?: boolean;
 };
 
 type SubscriptionGateInput = {
   user: any | null;
   subscriptionStatus?: SubscriptionStatusLike | null;
   entitlementSnapshot?: EntitlementSnapshotLike | null;
+};
+
+const NO_PLAN_NAME_VALUES = new Set([
+  'none',
+  '(none)',
+  'no_plan',
+  'no_subscription',
+  'unknown',
+  'ukendt',
+  'unsubscribed',
+  'null',
+  'undefined',
+]);
+
+const hasMeaningfulPlanName = (planName?: string | null): boolean => {
+  const normalized = String(planName ?? '').trim().toLowerCase();
+  if (!normalized.length) return false;
+  return !NO_PLAN_NAME_VALUES.has(normalized);
 };
 
 export const getSubscriptionGateState = ({
@@ -33,20 +53,35 @@ export const getSubscriptionGateState = ({
     subscriptionStatus?.hasSubscription ||
       subscriptionStatus?.subscriptionTier ||
       subscriptionStatus?.isLifetime ||
-      statusImpliesActive
+      statusImpliesActive ||
+      hasMeaningfulPlanName(subscriptionStatus?.planName)
   );
   const hasActiveEntitlement = Boolean(
     entitlementSnapshot?.isEntitled || entitlementSnapshot?.hasActiveSubscription
   );
   const hasActiveSubscription = hasBackendSubscription || hasActiveEntitlement;
   const isResolving = Boolean(entitlementSnapshot?.resolving);
-  const shouldShowChooseSubscription = Boolean(user && !isResolving && !hasActiveSubscription);
+  const hasAuthoritativeNoSubscription = Boolean(
+    entitlementSnapshot?.isAuthoritativelyUnsubscribed
+  );
+  const hasAuthoritativeSignals = Boolean(
+    entitlementSnapshot &&
+      ('isAuthoritative' in entitlementSnapshot ||
+        'isAuthoritativelyUnsubscribed' in entitlementSnapshot)
+  );
+  const shouldShowChooseSubscription = Boolean(
+    user &&
+      !isResolving &&
+      !hasActiveSubscription &&
+      (hasAuthoritativeSignals ? hasAuthoritativeNoSubscription : true)
+  );
 
   return {
     hasBackendSubscription,
     hasActiveEntitlement,
     hasActiveSubscription,
     isResolving,
+    hasAuthoritativeNoSubscription,
     shouldShowChooseSubscription,
   };
 };


### PR DESCRIPTION
## Formål
Denne hotfix stabiliserer subscription-gating på iOS og løser fejl i hentning af metadata for eksterne aktiviteter, som kunne give fejlskærm og forkert paywall-adfærd for livstidsbrugere.

## Problemer der løses
- Livstids-/entitlement-brugere kunne ende på paywall (især fra profil-flowet).
- `useHomeActivities` kunne fejle ved store metadata-queries for eksterne events.
- Bundling-fejl pga. `??`/`||` operator-mix i `SubscriptionContext`.
- Eksterne aktivitet/task flows havde edge cases omkring fallback og schema-drift.

## Løsning
- Indført samlet access-state vurdering (`granted | grace | denied_authoritative`) via `utils/accessGate.ts`.
- Strammet `subscriptionGate` så paywall kun vises ved reelt negativ adgangstilstand, uden at overrule aktiv backend-adgang.
- Opdateret profile-flow til at bruge access-state i stedet for kun raw gate.
- Tilføjet fallback til profile-entitlements i `SubscriptionContext` for manuel/livstids-adgang.
- Chunked metadata-fetch i `useHomeActivities` for `events_local_meta` opslag (`external_event_id` / `external_event_uid`) for at undgå store/ustabile requests.
- Rettet TS/insert-typing i task-oprettelse (internal + external feedback task paths).
- Tilføjet migration til cleanup/sync af eksterne template-opgaver.

## Vigtigste filer
- `utils/accessGate.ts` (ny)
- `utils/subscriptionGate.ts`
- `contexts/SubscriptionContext.tsx`
- `app/(tabs)/profile.tsx`
- `components/OnboardingGate.tsx`
- `hooks/useHomeActivities.ts`
- `components/CreateActivityTaskModal.tsx`
- `app/activity-details.tsx`
- `supabase/migrations/20260305103000_external_event_template_sync_cleanup.sql` (ny)

## Test/validering
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test --runInBand` ✅ (39/39 suites)

## Deploy note
- Indeholder også Supabase migration. Hvis der deployes via Expo OTA, skal migration køres separat i DB.
