### PR TITLE
Improve startup loader flow and add partner trainer entitlement

### DIFF
--- a/app/(tabs)/(home)/index.ios.tsx
+++ b/app/(tabs)/(home)/index.ios.tsx
@@ -81,6 +81,7 @@ import { canTrainerManageActivity } from '@/utils/permissions';
 import { fetchSelfFeedbackForActivities } from '@/services/feedbackService';
 import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
 import { formatHoursDa, getActivityEffectiveDurationMinutes } from '@/utils/activityDuration';
+import { markHomeScreenReady } from '@/utils/startupLoader';
 import type { TaskTemplateSelfFeedback } from '@/types';
 
 const FALLBACK_COLORS = {
@@ -1031,7 +1032,12 @@ function getActivityTasks(activity: any): any[] {
 export default function HomeScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { activities, loading, refresh: refreshActivities } = useHomeActivities();
+  const {
+    activities,
+    loading,
+    initialLoadSucceeded,
+    refresh: refreshActivities,
+  } = useHomeActivities();
   const {
     categories,
     createActivity,
@@ -1055,6 +1061,13 @@ export default function HomeScreen() {
   const [feedbackRefreshKey, setFeedbackRefreshKey] = useState(0);
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
+  const emittedHomeReadyRef = useRef(false);
+
+  useEffect(() => {
+    if (loading || !initialLoadSucceeded || emittedHomeReadyRef.current) return;
+    emittedHomeReadyRef.current = true;
+    markHomeScreenReady();
+  }, [initialLoadSucceeded, loading]);
 
   useEffect(() => {
     const handleSaved = (payload: any) => {

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -84,6 +84,7 @@ import { fetchSelfFeedbackForActivities } from '@/services/feedbackService';
 import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
 import { formatHoursDa, getActivityEffectiveDurationMinutes } from '@/utils/activityDuration';
 import { resolveActivityDateTime } from '@/utils/performanceHistory';
+import { markHomeScreenReady } from '@/utils/startupLoader';
 import type { TaskTemplateSelfFeedback } from '@/types';
 
 function getWeekLabel(date: Date): string {
@@ -1042,7 +1043,12 @@ function getActivityTasks(activity: any): any[] {
 export default function HomeScreen() {
   const router = useRouter();
   const { userRole } = useUserRole();
-  const { activities, loading, refresh: refreshActivities } = useHomeActivities();
+  const {
+    activities,
+    loading,
+    initialLoadSucceeded,
+    refresh: refreshActivities,
+  } = useHomeActivities();
   const {
     categories,
     createActivity,
@@ -1076,6 +1082,13 @@ export default function HomeScreen() {
   const colorScheme = useColorScheme();
   const themeColors = getColors(colorScheme);
   const isDark = colorScheme === 'dark';
+  const emittedHomeReadyRef = useRef(false);
+
+  useEffect(() => {
+    if (loading || !initialLoadSucceeded || emittedHomeReadyRef.current) return;
+    emittedHomeReadyRef.current = true;
+    markHomeScreenReady();
+  }, [initialLoadSucceeded, loading]);
 
   useEffect(() => {
     const handleSaved = (payload: any) => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,7 +3,7 @@ import { useFonts } from 'expo-font';
 import { Stack, usePathname, useRouter, useRootNavigationState } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
-import { Platform } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import 'react-native-reanimated';
 import { FootballProvider } from '@/contexts/FootballContext';
 import { SubscriptionProvider, useSubscription } from '@/contexts/SubscriptionContext';
@@ -17,6 +17,14 @@ import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { clearPushTokenCache, syncPushTokenForCurrentUser } from '@/utils/pushTokenService';
 import { buildNotificationRouteFromResponse } from '@/utils/notificationDeepLink';
+import AppStartupLoader from '@/components/AppStartupLoader';
+import {
+  getHomeLoadProgress,
+  isHomeStartupPath,
+  resetHomeScreenReady,
+  subscribeToHomeLoadProgress,
+  subscribeToHomeScreenReady,
+} from '@/utils/startupLoader';
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
@@ -46,6 +54,7 @@ const isUserEmailConfirmed = (user: any) =>
 
 export default function RootLayout() {
   const router = useRouter();
+  const pathname = usePathname();
   const rootNavigationState = useRootNavigationState();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
@@ -57,8 +66,33 @@ export default function RootLayout() {
   const [authReady, setAuthReady] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [pendingRouteStorageLoaded, setPendingRouteStorageLoaded] = useState(false);
+  const [showStartupLoader, setShowStartupLoader] = useState(true);
+  const [homeScreenReady, setHomeScreenReady] = useState(false);
+  const [homeLoadProgress, setHomeLoadProgress] = useState(getHomeLoadProgress());
   const isNavigationReady = Boolean(rootNavigationState?.key);
   const canHandleNotificationNavigation = isNavigationReady && authReady && isAuthenticated;
+  const startupPrerequisitesReady =
+    loaded && authReady && pendingRouteStorageLoaded && isNavigationReady;
+  const isTabsPath = pathname.startsWith('/(tabs)');
+  const isHomePath = isHomeStartupPath(pathname);
+  const isBootstrapPath = pathname === '/index' || pathname.length === 0;
+  const shouldWaitForHomeReady = isHomePath || isBootstrapPath || isTabsPath;
+  const startupPrerequisitesDoneCount = [
+    loaded,
+    authReady,
+    pendingRouteStorageLoaded,
+    isNavigationReady,
+  ].filter(Boolean).length;
+  const startupPrerequisitesProgress = startupPrerequisitesDoneCount / 4;
+  const startupProgress = shouldWaitForHomeReady
+    ? homeScreenReady
+      ? 1
+      : Math.min(
+          startupPrerequisitesProgress * 0.6 +
+            (startupPrerequisitesReady ? homeLoadProgress * 0.4 : 0),
+          0.99,
+        )
+    : Math.min(startupPrerequisitesProgress, 0.99);
 
   const persistPendingRoute = useCallback(
     (route: { pathname: string; params?: Record<string, string> } | null) => {
@@ -173,6 +207,45 @@ export default function RootLayout() {
   }, []);
 
   useEffect(() => {
+    resetHomeScreenReady();
+    setHomeScreenReady(false);
+    setHomeLoadProgress(getHomeLoadProgress());
+
+    const unsubscribeReady = subscribeToHomeScreenReady(() => {
+      setHomeScreenReady(true);
+    });
+    const unsubscribeProgress = subscribeToHomeLoadProgress((progress) => {
+      setHomeLoadProgress(progress);
+    });
+
+    return () => {
+      unsubscribeReady();
+      unsubscribeProgress();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!showStartupLoader || !startupPrerequisitesReady) return;
+
+    if (shouldWaitForHomeReady && homeScreenReady) {
+      setShowStartupLoader(false);
+      return;
+    }
+
+    if (!shouldWaitForHomeReady) {
+      setShowStartupLoader(false);
+    }
+  }, [
+    homeScreenReady,
+    isBootstrapPath,
+    isHomePath,
+    isTabsPath,
+    showStartupLoader,
+    shouldWaitForHomeReady,
+    startupPrerequisitesReady,
+  ]);
+
+  useEffect(() => {
     const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
       handleNotificationResponse(response);
     });
@@ -272,72 +345,75 @@ export default function RootLayout() {
           <AdminProvider>
             <CelebrationProvider>
               <FootballProvider>
-                <NotificationPermissionPrompt />
-                <Stack initialRouteName="index">
-                  {/* Root redirect route (/) */}
-                  <Stack.Screen name="index" options={{ headerShown: false }} />
+                <View style={styles.container}>
+                  <NotificationPermissionPrompt />
+                  <Stack initialRouteName="index">
+                    {/* Root redirect route (/) */}
+                    <Stack.Screen name="index" options={{ headerShown: false }} />
 
-                  {/* Subscription paywall */}
-                  <Stack.Screen name="choose-plan" options={{ headerShown: false }} />
+                    {/* Subscription paywall */}
+                    <Stack.Screen name="choose-plan" options={{ headerShown: false }} />
 
-                  {/* Main tabs */}
-                  <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-                  <Stack.Screen name="profile" options={{ headerShown: false }} />
+                    {/* Main tabs */}
+                    <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                    <Stack.Screen name="profile" options={{ headerShown: false }} />
 
-                  {/* Modals overlay */}
-                  <Stack.Screen
-                    name="(modals)"
-                    options={{
-                      presentation: 'transparentModal',
-                      headerShown: false,
-                      contentStyle: { backgroundColor: 'transparent' },
-                      animation: 'fade',
-                    }}
-                  />
-
-                  {/* Activity details */}
-                  <Stack.Screen
-                    name="activity-details"
-                    options={{
-                      presentation: 'modal',
-                      headerShown: false,
-                    }}
-                  />
-
-                  {/* Not found */}
-                  <Stack.Screen name="+not-found" options={{ headerShown: false }} />
-
-                  {/* Debug routes - only available in development */}
-                  {__DEV__ ? (
+                    {/* Modals overlay */}
                     <Stack.Screen
-                      name="console-logs"
+                      name="(modals)"
+                      options={{
+                        presentation: 'transparentModal',
+                        headerShown: false,
+                        contentStyle: { backgroundColor: 'transparent' },
+                        animation: 'fade',
+                      }}
+                    />
+
+                    {/* Activity details */}
+                    <Stack.Screen
+                      name="activity-details"
                       options={{
                         presentation: 'modal',
                         headerShown: false,
-                        title: 'Console Logs (DEV)',
                       }}
                     />
-                  ) : null}
-                  {__DEV__ ? (
-                    <Stack.Screen
-                      name="notification-debug"
-                      options={{
-                        presentation: 'modal',
-                        headerShown: false,
-                        title: 'Notification Debug (DEV)',
-                      }}
-                    />
-                  ) : null}
-                  <Stack.Screen name="auth/check-email" options={{ headerShown: false }} />
-                  <Stack.Screen name="auth/forgot-password" options={{ headerShown: false }} />
-                  <Stack.Screen name="auth/callback" options={{ headerShown: false }} />
-                  <Stack.Screen name="auth/recovery-callback" options={{ headerShown: false }} />
-                  <Stack.Screen name="auth/recovery-redirect" options={{ headerShown: false }} />
-                  <Stack.Screen name="email-confirmed" options={{ headerShown: false }} />
-                  <Stack.Screen name="update-password" options={{ headerShown: false }} />
-                </Stack>
 
-                <StatusBar style="auto" />
+                    {/* Not found */}
+                    <Stack.Screen name="+not-found" options={{ headerShown: false }} />
+
+                    {/* Debug routes - only available in development */}
+                    {__DEV__ ? (
+                      <Stack.Screen
+                        name="console-logs"
+                        options={{
+                          presentation: 'modal',
+                          headerShown: false,
+                          title: 'Console Logs (DEV)',
+                        }}
+                      />
+                    ) : null}
+                    {__DEV__ ? (
+                      <Stack.Screen
+                        name="notification-debug"
+                        options={{
+                          presentation: 'modal',
+                          headerShown: false,
+                          title: 'Notification Debug (DEV)',
+                        }}
+                      />
+                    ) : null}
+                    <Stack.Screen name="auth/check-email" options={{ headerShown: false }} />
+                    <Stack.Screen name="auth/forgot-password" options={{ headerShown: false }} />
+                    <Stack.Screen name="auth/callback" options={{ headerShown: false }} />
+                    <Stack.Screen name="auth/recovery-callback" options={{ headerShown: false }} />
+                    <Stack.Screen name="auth/recovery-redirect" options={{ headerShown: false }} />
+                    <Stack.Screen name="email-confirmed" options={{ headerShown: false }} />
+                    <Stack.Screen name="update-password" options={{ headerShown: false }} />
+                  </Stack>
+
+                  <StatusBar style="auto" />
+                  <AppStartupLoader visible={showStartupLoader} progress={startupProgress} />
+                </View>
               </FootballProvider>
             </CelebrationProvider>
           </AdminProvider>
@@ -346,6 +422,12 @@ export default function RootLayout() {
     </SubscriptionProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
 
 function SubscriptionRedirectObserver() {
   const router = useRouter();

--- a/app/_layout.web.tsx
+++ b/app/_layout.web.tsx
@@ -3,6 +3,7 @@ import { Stack, usePathname, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
 import { useFonts } from 'expo-font';
+import { StyleSheet, View } from 'react-native';
 import 'react-native-reanimated';
 
 import { FootballProvider } from '@/contexts/FootballContext';
@@ -12,6 +13,14 @@ import { AdminProvider } from '@/contexts/AdminContext';
 import { AppleIAPProvider, useAppleIAP } from '@/contexts/AppleIAPContext';
 import { CelebrationProvider } from '@/contexts/CelebrationContext';
 import { supabase } from '@/integrations/supabase/client';
+import AppStartupLoader from '@/components/AppStartupLoader';
+import {
+  getHomeLoadProgress,
+  isHomeStartupPath,
+  resetHomeScreenReady,
+  subscribeToHomeLoadProgress,
+  subscribeToHomeScreenReady,
+} from '@/utils/startupLoader';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
@@ -76,15 +85,73 @@ const isUserEmailConfirmed = (user: any) =>
   Boolean(user?.email_confirmed_at || user?.confirmed_at);
 
 export default function RootLayout() {
+  const pathname = usePathname();
   const [fontsLoaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
+  const [showStartupLoader, setShowStartupLoader] = useState(true);
+  const [homeScreenReady, setHomeScreenReady] = useState(false);
+  const [homeLoadProgress, setHomeLoadProgress] = useState(getHomeLoadProgress());
+  const isTabsPath = pathname.startsWith('/(tabs)');
+  const isHomePath = isHomeStartupPath(pathname);
+  const isBootstrapPath = pathname === '/index' || pathname.length === 0;
+  const shouldWaitForHomeReady = isHomePath || isBootstrapPath || isTabsPath;
+  const startupPrerequisitesDoneCount = [fontsLoaded].filter(Boolean).length;
+  const startupPrerequisitesProgress = startupPrerequisitesDoneCount / 1;
+  const startupProgress = shouldWaitForHomeReady
+    ? homeScreenReady
+      ? 1
+      : Math.min(
+          startupPrerequisitesProgress * 0.6 +
+            (fontsLoaded ? homeLoadProgress * 0.4 : 0),
+          0.99,
+        )
+    : Math.min(startupPrerequisitesProgress, 0.99);
 
   useEffect(() => {
     if (fontsLoaded) {
       SplashScreen.hideAsync().catch(() => {});
     }
   }, [fontsLoaded]);
+
+  useEffect(() => {
+    resetHomeScreenReady();
+    setHomeScreenReady(false);
+    setHomeLoadProgress(getHomeLoadProgress());
+
+    const unsubscribeReady = subscribeToHomeScreenReady(() => {
+      setHomeScreenReady(true);
+    });
+    const unsubscribeProgress = subscribeToHomeLoadProgress((progress) => {
+      setHomeLoadProgress(progress);
+    });
+
+    return () => {
+      unsubscribeReady();
+      unsubscribeProgress();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!showStartupLoader || !fontsLoaded) return;
+
+    if (shouldWaitForHomeReady && homeScreenReady) {
+      setShowStartupLoader(false);
+      return;
+    }
+
+    if (!shouldWaitForHomeReady) {
+      setShowStartupLoader(false);
+    }
+  }, [
+    fontsLoaded,
+    homeScreenReady,
+    isBootstrapPath,
+    isHomePath,
+    isTabsPath,
+    shouldWaitForHomeReady,
+    showStartupLoader,
+  ]);
 
   useEffect(() => {
     if (__DEV__) {
@@ -101,26 +168,29 @@ export default function RootLayout() {
           <AdminProvider>
             <CelebrationProvider>
               <FootballProvider>
-                <Stack screenOptions={{ headerShown: false }}>
-                  <Stack.Screen name="index" />
-                  <Stack.Screen name="choose-plan" />
-                  <Stack.Screen name="(tabs)" />
-                  <Stack.Screen name="profile" />
-                  <Stack.Screen name="+not-found" />
-                  <Stack.Screen name="activity-details" options={{ presentation: 'modal' }} />
-                  <Stack.Screen name="auth/check-email" />
-                  <Stack.Screen name="auth/forgot-password" />
-                  <Stack.Screen name="auth/callback" />
-                  <Stack.Screen name="auth/recovery-callback" />
-                  <Stack.Screen name="auth/recovery-redirect" />
-                  <Stack.Screen name="email-confirmed" />
-                  <Stack.Screen name="update-password" />
-                  {__DEV__ ? <Stack.Screen name="console-logs" options={{ headerShown: true }} /> : null}
-                  {__DEV__ ? (
-                    <Stack.Screen name="notification-debug" options={{ headerShown: true }} />
-                  ) : null}
-                </Stack>
-                <StatusBar style="auto" />
+                <View style={styles.container}>
+                  <Stack screenOptions={{ headerShown: false }}>
+                    <Stack.Screen name="index" />
+                    <Stack.Screen name="choose-plan" />
+                    <Stack.Screen name="(tabs)" />
+                    <Stack.Screen name="profile" />
+                    <Stack.Screen name="+not-found" />
+                    <Stack.Screen name="activity-details" options={{ presentation: 'modal' }} />
+                    <Stack.Screen name="auth/check-email" />
+                    <Stack.Screen name="auth/forgot-password" />
+                    <Stack.Screen name="auth/callback" />
+                    <Stack.Screen name="auth/recovery-callback" />
+                    <Stack.Screen name="auth/recovery-redirect" />
+                    <Stack.Screen name="email-confirmed" />
+                    <Stack.Screen name="update-password" />
+                    {__DEV__ ? <Stack.Screen name="console-logs" options={{ headerShown: true }} /> : null}
+                    {__DEV__ ? (
+                      <Stack.Screen name="notification-debug" options={{ headerShown: true }} />
+                    ) : null}
+                  </Stack>
+                  <StatusBar style="auto" />
+                  <AppStartupLoader visible={showStartupLoader} progress={startupProgress} />
+                </View>
               </FootballProvider>
             </CelebrationProvider>
           </AdminProvider>
@@ -129,6 +199,12 @@ export default function RootLayout() {
     </SubscriptionProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
 
 function SubscriptionRedirectObserver() {
   const router = useRouter();

--- a/components/AppStartupLoader.tsx
+++ b/components/AppStartupLoader.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+
+type AppStartupLoaderProps = {
+  visible: boolean;
+  progress?: number;
+};
+
+const clampProgress = (value: number) => {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+};
+
+export default function AppStartupLoader({ visible, progress = 0 }: AppStartupLoaderProps) {
+  if (!visible) return null;
+  const clampedProgress = clampProgress(progress);
+  const progressPercent = Math.round(clampedProgress * 100);
+
+  return (
+    <View style={styles.overlay} pointerEvents="auto" accessibilityLabel="App loader">
+      <ActivityIndicator size="large" color="#2A7A3B" />
+      <Text style={styles.label}>App loader</Text>
+      <View style={styles.progressTrack}>
+        <View style={[styles.progressFill, { width: `${progressPercent}%` }]} />
+      </View>
+      <Text style={styles.progressText}>{progressPercent}%</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#F6FAF7',
+    zIndex: 9999,
+  },
+  label: {
+    marginTop: 12,
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1E293B',
+  },
+  progressTrack: {
+    width: 220,
+    height: 8,
+    borderRadius: 999,
+    backgroundColor: '#D5E4D8',
+    marginTop: 12,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 999,
+    backgroundColor: '#2A7A3B',
+  },
+  progressText: {
+    marginTop: 8,
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#334155',
+  },
+});

--- a/hooks/useHomeActivities.ts
+++ b/hooks/useHomeActivities.ts
@@ -13,6 +13,7 @@ import {
   getActivitiesRefreshRequestedVersion,
   getLastActivitiesRefreshRequestedEvent,
 } from '@/utils/activityEvents';
+import { setHomeLoadProgress } from '@/utils/startupLoader';
 
 interface ActivityTask {
   id: string;
@@ -333,13 +334,16 @@ const fetchExternalMetaRows = async ({
 interface UseHomeActivitiesResult {
   activities: ActivityWithCategory[];
   loading: boolean;
+  initialLoadSucceeded: boolean;
   refresh: () => Promise<void>;
 }
 
 export function useHomeActivities(): UseHomeActivitiesResult {
   const [userId, setUserId] = useState<string | null>(null);
+  const [sessionChecked, setSessionChecked] = useState(false);
   const [activities, setActivities] = useState<ActivityWithCategory[]>([]);
   const [loading, setLoading] = useState(true);
+  const [initialLoadSucceeded, setInitialLoadSucceeded] = useState(false);
   const categoryMapRef = useRef<Map<string, DatabaseActivityCategory>>(new Map());
   const refetchInFlightRef = useRef(false);
   const pendingRefreshReasonRef = useRef<string | null>(null);
@@ -487,6 +491,7 @@ export function useHomeActivities(): UseHomeActivitiesResult {
   // Get user ID
   useEffect(() => {
     const fetchUser = async () => {
+      setHomeLoadProgress(0.05);
       try {
         const {
           data: { session },
@@ -496,34 +501,51 @@ export function useHomeActivities(): UseHomeActivitiesResult {
         if (error) {
           console.error('Failed to fetch session:', error);
           setActivities([]);
+          setInitialLoadSucceeded(false);
           setLoading(false);
+          setSessionChecked(true);
           return;
         }
 
         const userIdFromSession = session?.user?.id;
         if (!userIdFromSession) {
           setActivities([]);
+          setInitialLoadSucceeded(true);
           setLoading(false);
+          setSessionChecked(true);
+          setHomeLoadProgress(1);
           return;
         }
 
         setUserId(userIdFromSession);
+        setSessionChecked(true);
+        setHomeLoadProgress(0.12);
       } catch (err) {
         console.error('Failed to fetch session:', err);
         setActivities([]);
+        setInitialLoadSucceeded(false);
         setLoading(false);
+        setSessionChecked(true);
+        setHomeLoadProgress(0);
       }
     };
     fetchUser();
   }, []);
 
-  const refetchActivities = useCallback(async () => {
+  const refetchActivities = useCallback(async (): Promise<boolean> => {
+    const setStartupProgressIfInitial = (progress: number) => {
+      if (hasLoadedOnceRef.current) return;
+      setHomeLoadProgress(progress);
+    };
+
     if (!userId) {
       setActivities([]);
-      return;
+      setStartupProgressIfInitial(1);
+      return true;
     }
 
     try {
+      setStartupProgressIfInitial(0.2);
       devLog('[useHomeActivities] Fetching activities for user:', userId);
 
       // ✅ PARALLEL FETCH GROUP 1: Categories + Internal Activities + External Calendars + Category Mappings
@@ -647,6 +669,7 @@ export function useHomeActivities(): UseHomeActivitiesResult {
       devLog('[useHomeActivities] Categories fetched:', categoriesData?.length ?? 0);
       devLog('[useHomeActivities] Internal activities:', internalData?.length ?? 0);
       devLog('[useHomeActivities] Category mappings:', categoryMappingsData?.length ?? 0);
+      setStartupProgressIfInitial(0.45);
 
       // Create a map for quick category lookup
       const categoryMap = new Map<string, DatabaseActivityCategory>();
@@ -906,6 +929,8 @@ export function useHomeActivities(): UseHomeActivitiesResult {
         }
       }
 
+      setStartupProgressIfInitial(0.65);
+
       devLog('[useHomeActivities] External activities:', externalActivities.length);
 
       // 4. Merge internal and external activities
@@ -1008,6 +1033,7 @@ export function useHomeActivities(): UseHomeActivitiesResult {
           : Promise.resolve({ data: [], error: null }),
         fetchActivityTasksWithFallback(externalEventRowIds),
       ]);
+      setStartupProgressIfInitial(0.85);
 
       // Preload after_training_delay_minutes for any task templates referenced directly or via markers
       const templateIdCandidates = new Set<string>();
@@ -1314,6 +1340,7 @@ export function useHomeActivities(): UseHomeActivitiesResult {
         }
       }
 
+      setStartupProgressIfInitial(0.95);
       setActivities(finalActivities);
 
       if (orphanCleanupResults.length && __DEV__) {
@@ -1339,29 +1366,36 @@ export function useHomeActivities(): UseHomeActivitiesResult {
           });
         }
       }
+      setStartupProgressIfInitial(0.98);
+      return true;
     } catch (err) {
       console.error('Failed to fetch activities:', err);
       setActivities([]);
+      if (!hasLoadedOnceRef.current) {
+        setHomeLoadProgress(0.2);
+      }
+      return false;
     }
   }, [userId]);
 
   const triggerRefetch = useCallback(
-    async (reason: string = 'unspecified') => {
+    async (reason: string = 'unspecified'): Promise<boolean> => {
       if (!userId) {
-        return;
+        return false;
       }
 
       if (refetchInFlightRef.current) {
         pendingRefreshReasonRef.current = reason;
-        return;
+        return false;
       }
 
       refetchInFlightRef.current = true;
       try {
         devLog(`[useHomeActivities] Refetch triggered (${reason})`);
-        await refetchActivities();
+        return await refetchActivities();
       } catch (error) {
         console.error(`[useHomeActivities] Refetch failed (${reason}):`, error);
+        return false;
       } finally {
         refetchInFlightRef.current = false;
         if (pendingRefreshReasonRef.current) {
@@ -1383,19 +1417,35 @@ export function useHomeActivities(): UseHomeActivitiesResult {
     let mounted = true;
 
     async function load() {
-      if (!userId) {
-        setActivities([]);
-        setLoading(false);
+      if (!sessionChecked) {
         return;
       }
 
+      if (!userId) {
+        setActivities([]);
+        setInitialLoadSucceeded(true);
+        setLoading(false);
+        setHomeLoadProgress(1);
+        return;
+      }
+
+      if (mounted) {
+        setLoading(true);
+        setInitialLoadSucceeded(false);
+        setHomeLoadProgress(0.15);
+      }
+
+      let firstLoadSucceeded = false;
       try {
-        await triggerRefetch('initial_load');
+        firstLoadSucceeded = await triggerRefetch('initial_load');
       } catch (err) {
         console.error('Failed to load home activities:', err);
       } finally {
         hasLoadedOnceRef.current = true;
-        if (mounted) setLoading(false);
+        if (mounted) {
+          setInitialLoadSucceeded(firstLoadSucceeded);
+          setLoading(false);
+        }
       }
     }
 
@@ -1404,7 +1454,7 @@ export function useHomeActivities(): UseHomeActivitiesResult {
     return () => {
       mounted = false;
     };
-  }, [userId, triggerRefetch]);
+  }, [sessionChecked, userId, triggerRefetch]);
 
   useFocusEffect(
     useCallback(() => {
@@ -1466,6 +1516,7 @@ export function useHomeActivities(): UseHomeActivitiesResult {
   return {
     activities,
     loading,
+    initialLoadSucceeded,
     refresh,
   };
 }

--- a/supabase/migrations/20260306120000_add_partner_trainer_premium_jka.sql
+++ b/supabase/migrations/20260306120000_add_partner_trainer_premium_jka.sql
@@ -1,0 +1,44 @@
+insert into public.partner_email_entitlements (email, entitlement, source, notes, is_active)
+values
+  ('jka@danishgoalkeeping.dk', U&'tr\00E6ner_premium', 'partner', 'Lifetime partner entitlement', true)
+on conflict (email, entitlement)
+do update set
+  source = excluded.source,
+  notes = excluded.notes,
+  is_active = excluded.is_active,
+  updated_at = now();
+
+update public.user_entitlements ue
+set
+  source = pee.source,
+  is_active = true,
+  expires_at = null,
+  notes = coalesce(pee.notes, 'Auto-assigned from partner email list')
+from auth.users au
+join public.partner_email_entitlements pee
+  on pee.email = lower(trim(coalesce(au.email, '')))
+where pee.is_active
+  and pee.email = 'jka@danishgoalkeeping.dk'
+  and ue.user_id = au.id
+  and ue.entitlement = pee.entitlement
+  and ue.is_active = false;
+
+insert into public.user_entitlements (user_id, entitlement, source, is_active, expires_at, notes)
+select
+  au.id,
+  pee.entitlement,
+  pee.source,
+  true,
+  null,
+  coalesce(pee.notes, 'Auto-assigned from partner email list')
+from auth.users au
+join public.partner_email_entitlements pee
+  on pee.email = lower(trim(coalesce(au.email, '')))
+where pee.is_active
+  and pee.email = 'jka@danishgoalkeeping.dk'
+  and not exists (
+    select 1
+    from public.user_entitlements ue
+    where ue.user_id = au.id
+      and ue.entitlement = pee.entitlement
+  );

--- a/utils/startupLoader.ts
+++ b/utils/startupLoader.ts
@@ -1,0 +1,75 @@
+type StartupReadyListener = () => void;
+type StartupProgressListener = (progress: number) => void;
+
+let homeScreenReady = false;
+const listeners = new Set<StartupReadyListener>();
+let homeLoadProgress = 0;
+const progressListeners = new Set<StartupProgressListener>();
+
+const clampProgress = (value: number) => {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+};
+
+export const markHomeScreenReady = () => {
+  if (homeScreenReady) return;
+  homeScreenReady = true;
+  setHomeLoadProgress(1);
+
+  listeners.forEach((listener) => {
+    try {
+      listener();
+    } catch {
+      // Listener failures should never block startup.
+    }
+  });
+};
+
+export const isHomeScreenReady = () => homeScreenReady;
+
+export const resetHomeScreenReady = () => {
+  homeScreenReady = false;
+  setHomeLoadProgress(0);
+};
+
+export const subscribeToHomeScreenReady = (listener: StartupReadyListener) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const getHomeLoadProgress = () => homeLoadProgress;
+
+export const setHomeLoadProgress = (progress: number) => {
+  const next = clampProgress(progress);
+  if (Math.abs(next - homeLoadProgress) < 0.0001) return;
+  homeLoadProgress = next;
+
+  progressListeners.forEach((listener) => {
+    try {
+      listener(homeLoadProgress);
+    } catch {
+      // Listener failures should never block startup.
+    }
+  });
+};
+
+export const subscribeToHomeLoadProgress = (listener: StartupProgressListener) => {
+  progressListeners.add(listener);
+  return () => {
+    progressListeners.delete(listener);
+  };
+};
+
+export const isHomeStartupPath = (pathname?: string | null) => {
+  const value = typeof pathname === 'string' ? pathname : '';
+  return (
+    value === '/' ||
+    value === '/home' ||
+    value === '/(tabs)' ||
+    value.startsWith('/(tabs)/(home)')
+  );
+};


### PR DESCRIPTION
## Formål
Forbedre opstartsoplevelsen, så loading-skærmen bliver vist korrekt indtil forsiden reelt er klar, samt tilføje progress-visning under load.

## Hvad er ændret
- Tilføjet dedikeret startup-loader komponent med spinner, progress bar og procent.
- Tilføjet global startup-loader state/event-håndtering (ready + progress).
- Opdateret root layout (native + web) til at:
  - vise loader ved opstart
  - opdatere progress undervejs
  - skjule loader først når home er klar
- Opdateret home startup-flow til kun at markere “ready” når første load er gennemført succesfuldt.
- Rettet race condition i `useHomeActivities`, så første load ikke kan markeres for tidligt.
- Tilføjet migration for partner livstids `træner_premium` for:
  - `jka@danishgoalkeeping.dk`

## Validering
- `npm run typecheck` kørt uden fejl.
- `eslint` kørt på berørte filer uden fejl.

## Database / migration
- Ny migration: `supabase/migrations/20260306120000_add_partner_trainer_premium_jka.sql`
- Migrationen er idempotent og håndterer både ny/opdateret partner-email entitlement samt backfill til eksisterende bruger.

## Risiko / påvirkning
- Ingen breaking API-ændringer.
- Ændringer er scoped til startup-loading og entitlement-migration.