### PR TITLE
fix: keep startup loader until home is ready

### DIFF
--- a/app/(tabs)/(home)/index.ios.tsx
+++ b/app/(tabs)/(home)/index.ios.tsx
@@ -82,6 +82,7 @@ import { fetchSelfFeedbackForActivities } from '@/services/feedbackService';
 import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
 import { formatHoursDa, getActivityEffectiveDurationMinutes } from '@/utils/activityDuration';
 import { markHomeScreenReady } from '@/utils/startupLoader';
+import { withTimeout } from '@/utils/withTimeout';
 import type { TaskTemplateSelfFeedback } from '@/types';
 
 const FALLBACK_COLORS = {
@@ -222,6 +223,7 @@ const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
 const THIS_WEEK_PREMIUM_BG = require('../../../assets/images/home_this_week_premium_bg.png');
 const THIS_WEEK_CARD_RADIUS = 28;
 const THIS_WEEK_BG_CROP_RADIUS = THIS_WEEK_CARD_RADIUS;
+const HOME_REFRESH_TIMEOUT_MS = 10000;
 
 const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
   weekLabel,
@@ -1050,13 +1052,13 @@ export default function HomeScreen() {
   const {
     activities,
     loading,
-    initialLoadSucceeded,
     refresh: refreshActivities,
   } = useHomeActivities();
   const {
     categories,
     createActivity,
     refreshData,
+    isLoading: footballLoading,
     currentWeekStats,
     updateIntensityByCategory,
   } = useFootball();
@@ -1079,10 +1081,10 @@ export default function HomeScreen() {
   const emittedHomeReadyRef = useRef(false);
 
   useEffect(() => {
-    if (loading || !initialLoadSucceeded || emittedHomeReadyRef.current) return;
+    if (loading || footballLoading || emittedHomeReadyRef.current) return;
     emittedHomeReadyRef.current = true;
     markHomeScreenReady();
-  }, [initialLoadSucceeded, loading]);
+  }, [footballLoading, loading]);
 
   useEffect(() => {
     const handleSaved = (payload: any) => {
@@ -1390,6 +1392,36 @@ export default function HomeScreen() {
     setFeedbackRefreshKey((prev) => prev + 1);
   }, []);
 
+  const refreshHomeScreen = useCallback(async (timeoutMs: number = HOME_REFRESH_TIMEOUT_MS) => {
+    const refreshPromises: Promise<unknown>[] = [];
+
+    if (typeof refreshActivities === 'function') {
+      refreshPromises.push(refreshActivities());
+    } else {
+      console.error('[Home] refreshActivities is not a function');
+    }
+
+    if (typeof refreshData === 'function') {
+      refreshPromises.push(refreshData());
+    } else {
+      console.error('[Home] refreshData is not a function');
+    }
+
+    try {
+      if (!refreshPromises.length) {
+        return;
+      }
+
+      await withTimeout(
+        Promise.allSettled(refreshPromises),
+        timeoutMs,
+        '[Home] Refresh timed out'
+      );
+    } finally {
+      triggerFeedbackRefresh();
+    }
+  }, [refreshActivities, refreshData, triggerFeedbackRefresh]);
+
   useFocusEffect(
     useCallback(() => {
       if (!currentUserId || !feedbackActivityIds.length) return;
@@ -1399,17 +1431,10 @@ export default function HomeScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      const refreshPromises: Promise<unknown>[] = [];
-      if (typeof refreshActivities === 'function') {
-        refreshPromises.push(refreshActivities());
-      }
-      if (typeof refreshData === 'function') {
-        refreshPromises.push(refreshData());
-      }
-      if (refreshPromises.length) {
-        void Promise.allSettled(refreshPromises);
-      }
-    }, [refreshActivities, refreshData])
+      void refreshHomeScreen().catch((error) => {
+        console.error('[Home] Focus refresh failed:', error);
+      });
+    }, [refreshHomeScreen])
   );
 
   useEffect(() => {
@@ -1851,24 +1876,7 @@ export default function HomeScreen() {
     setIsRefreshing(true);
 
     try {
-      const refreshPromises: Promise<unknown>[] = [];
-
-      // STEP H: Guard against null/undefined refreshActivities
-      if (typeof refreshActivities === 'function') {
-        refreshPromises.push(refreshActivities());
-      } else {
-        console.error('[Home] refreshActivities is not a function');
-      }
-
-      if (typeof refreshData === 'function') {
-        refreshPromises.push(refreshData());
-      } else {
-        console.error('[Home] refreshData is not a function');
-      }
-
-      if (refreshPromises.length) {
-        await Promise.allSettled(refreshPromises);
-      }
+      await refreshHomeScreen();
       console.log('[Home] Pull-to-refresh completed successfully');
     } catch (error) {
       console.error('[Home] Pull-to-refresh error:', error);
@@ -1878,7 +1886,7 @@ export default function HomeScreen() {
       setIsRefreshing(false);
       console.log('[Home] Pull-to-refresh spinner stopped');
     }
-  }, [isRefreshing, refreshActivities, refreshData]);
+  }, [isRefreshing, refreshHomeScreen]);
 
   const buildActivityKey = useCallback((activity: any, section: string) => {
     if (!activity) return `fallback:activity:${section}`;

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -85,6 +85,7 @@ import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
 import { formatHoursDa, getActivityEffectiveDurationMinutes } from '@/utils/activityDuration';
 import { resolveActivityDateTime } from '@/utils/performanceHistory';
 import { markHomeScreenReady } from '@/utils/startupLoader';
+import { withTimeout } from '@/utils/withTimeout';
 import type { TaskTemplateSelfFeedback } from '@/types';
 
 function getWeekLabel(date: Date): string {
@@ -184,6 +185,7 @@ const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
 const THIS_WEEK_PREMIUM_BG = require('../../../assets/images/home_this_week_premium_bg.png');
 const THIS_WEEK_CARD_RADIUS = 28;
 const THIS_WEEK_BG_CROP_RADIUS = THIS_WEEK_CARD_RADIUS;
+const HOME_REFRESH_TIMEOUT_MS = 10000;
 
 const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
   weekLabel,
@@ -1061,13 +1063,13 @@ export default function HomeScreen() {
   const {
     activities,
     loading,
-    initialLoadSucceeded,
     refresh: refreshActivities,
   } = useHomeActivities();
   const {
     categories,
     createActivity,
     refreshData,
+    isLoading: footballLoading,
     currentWeekStats,
     toggleTaskCompletion,
     updateActivitySingle,
@@ -1100,10 +1102,10 @@ export default function HomeScreen() {
   const emittedHomeReadyRef = useRef(false);
 
   useEffect(() => {
-    if (loading || !initialLoadSucceeded || emittedHomeReadyRef.current) return;
+    if (loading || footballLoading || emittedHomeReadyRef.current) return;
     emittedHomeReadyRef.current = true;
     markHomeScreenReady();
-  }, [initialLoadSucceeded, loading]);
+  }, [footballLoading, loading]);
 
   useEffect(() => {
     const handleSaved = (payload: any) => {
@@ -1387,6 +1389,36 @@ export default function HomeScreen() {
     setFeedbackRefreshKey((prev) => prev + 1);
   }, []);
 
+  const refreshHomeScreen = useCallback(async (timeoutMs: number = HOME_REFRESH_TIMEOUT_MS) => {
+    const refreshPromises: Promise<unknown>[] = [];
+
+    if (typeof refreshActivities === 'function') {
+      refreshPromises.push(refreshActivities());
+    } else {
+      console.error('[Home] refreshActivities is not a function');
+    }
+
+    if (typeof refreshData === 'function') {
+      refreshPromises.push(refreshData());
+    } else {
+      console.error('[Home] refreshData is not a function');
+    }
+
+    try {
+      if (!refreshPromises.length) {
+        return;
+      }
+
+      await withTimeout(
+        Promise.allSettled(refreshPromises),
+        timeoutMs,
+        '[Home] Refresh timed out'
+      );
+    } finally {
+      triggerFeedbackRefresh();
+    }
+  }, [refreshActivities, refreshData, triggerFeedbackRefresh]);
+
   useFocusEffect(
     useCallback(() => {
       if (!currentUserId || !feedbackActivityIds.length) return;
@@ -1396,17 +1428,10 @@ export default function HomeScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      const refreshPromises: Promise<unknown>[] = [];
-      if (typeof refreshActivities === 'function') {
-        refreshPromises.push(refreshActivities());
-      }
-      if (typeof refreshData === 'function') {
-        refreshPromises.push(refreshData());
-      }
-      if (refreshPromises.length) {
-        void Promise.allSettled(refreshPromises);
-      }
-    }, [refreshActivities, refreshData])
+      void refreshHomeScreen().catch((error) => {
+        console.error('[Home] Focus refresh failed:', error);
+      });
+    }, [refreshHomeScreen])
   );
 
   useEffect(() => {
@@ -1849,24 +1874,7 @@ export default function HomeScreen() {
     setIsRefreshing(true);
     
     try {
-      const refreshPromises: Promise<unknown>[] = [];
-
-      // STEP H: Guard against null/undefined refreshActivities
-      if (typeof refreshActivities === 'function') {
-        refreshPromises.push(refreshActivities());
-      } else {
-        console.error('[Home] refreshActivities is not a function');
-      }
-
-      if (typeof refreshData === 'function') {
-        refreshPromises.push(refreshData());
-      } else {
-        console.error('[Home] refreshData is not a function');
-      }
-
-      if (refreshPromises.length) {
-        await Promise.allSettled(refreshPromises);
-      }
+      await refreshHomeScreen();
       console.log('[Home] Pull-to-refresh completed successfully');
     } catch (error) {
       console.error('[Home] Pull-to-refresh error:', error);
@@ -1876,7 +1884,7 @@ export default function HomeScreen() {
       setIsRefreshing(false);
       console.log('[Home] Pull-to-refresh spinner stopped');
     }
-  }, [isRefreshing, refreshActivities, refreshData]);
+  }, [isRefreshing, refreshHomeScreen]);
 
   const getActivityIntensityValueById = useCallback((activityId: string) => {
     if (!activityId) {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -31,7 +31,7 @@ SplashScreen.preventAutoHideAsync().catch(() => {});
 
 const PENDING_NOTIFICATION_ROUTE_KEY = '@pending_notification_route_v1';
 const AUTH_BOOTSTRAP_TIMEOUT_MS = 4000;
-const STARTUP_LOADER_HOME_TIMEOUT_MS = 5000;
+const STARTUP_LOADER_STALL_LOG_MS = 5000;
 
 const NO_PLAN_TIER_VALUES = new Set([
   'none',
@@ -268,19 +268,17 @@ export default function RootLayout() {
     }
 
     const timer = setTimeout(() => {
-      console.warn('[RootLayout] Startup loader fallback hide fired before home ready');
-      startupLoaderHideReasonRef.current = 'home_ready_timeout';
+      console.warn('[RootLayout] Startup loader still waiting for home ready');
       void trackStartupTelemetry(supabase, {
-        eventName: 'startup_loader_fallback',
-        status: 'timeout',
+        eventName: 'startup_loader_waiting',
+        status: 'waiting',
         route: pathname,
         metadata: {
-          timeoutMs: STARTUP_LOADER_HOME_TIMEOUT_MS,
+          timeoutMs: STARTUP_LOADER_STALL_LOG_MS,
           shouldWaitForHomeReady,
         },
       });
-      setShowStartupLoader(false);
-    }, STARTUP_LOADER_HOME_TIMEOUT_MS);
+    }, STARTUP_LOADER_STALL_LOG_MS);
 
     return () => clearTimeout(timer);
   }, [homeScreenReady, pathname, shouldWaitForHomeReady, showStartupLoader, startupPrerequisitesReady]);

--- a/hooks/useFootballData.ts
+++ b/hooks/useFootballData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   Activity,
   ActivityCategory,
@@ -239,6 +239,7 @@ export const useFootballData = () => {
     weekActivities: [] as Activity[],
   });
   const [loading, setLoading] = useState(true);
+  const refreshDataPromiseRef = useRef<Promise<void> | null>(null);
 
   const findTaskCompletionState = useCallback(
     (activityId: string, taskId: string): boolean | null => {
@@ -1407,16 +1408,33 @@ export const useFootballData = () => {
   );
 
   const refreshData = useCallback(async () => {
-    console.log('[refreshData] Refreshing core datasets...');
-    await Promise.all([
-      fetchCategories(),
-      fetchActivities(),
-      fetchTasks(),
-      fetchTrophies(),
-      fetchExternalCalendars(),
-      fetchActivitySeries(),
-      fetchCurrentWeekStats(),
-    ]);
+    if (refreshDataPromiseRef.current) {
+      await refreshDataPromiseRef.current;
+      return;
+    }
+
+    const pendingRefresh = (async () => {
+      console.log('[refreshData] Refreshing core datasets...');
+      await Promise.all([
+        fetchCategories(),
+        fetchActivities(),
+        fetchTasks(),
+        fetchTrophies(),
+        fetchExternalCalendars(),
+        fetchActivitySeries(),
+        fetchCurrentWeekStats(),
+      ]);
+    })();
+
+    refreshDataPromiseRef.current = pendingRefresh;
+
+    try {
+      await pendingRefresh;
+    } finally {
+      if (refreshDataPromiseRef.current === pendingRefresh) {
+        refreshDataPromiseRef.current = null;
+      }
+    }
   }, [
     fetchCategories,
     fetchActivities,


### PR DESCRIPTION
## Summary
- Keep the startup loader visible until the home screen is actually ready instead of hiding it on the previous timeout fallback.
- Fix home pull-to-refresh getting stuck by routing refresh through a single timeout-bound refresh flow on both iOS and shared home implementations.
- Deduplicate concurrent `refreshData()` calls so focus refresh and pull-to-refresh do not trigger overlapping fetches.

## Changes
- Updated root startup handling to log when home readiness is still pending, without forcing the loader to close early.
- Updated both home screen implementations to wait for both home activity data and shared football data before marking the screen ready.
- Added a shared home refresh helper with timeout protection and reused it for focus refresh and pull-to-refresh.
- Added promise deduping in `useFootballData.refreshData()` to prevent parallel refresh races.

## Testing
- `npm run typecheck`
- `npm run lint`
- `npx jest __tests__/home.performance-card-hours.test.tsx --runInBand`

## Notes
- Verified with static checks and targeted test coverage.
- Simulator/device validation was not run as part of this change.
