### PR TITLE
feat: feedback fra træner (#255)

### DIFF
--- a/__tests__/activity-details.trainer-feedback.screen.test.tsx
+++ b/__tests__/activity-details.trainer-feedback.screen.test.tsx
@@ -1,0 +1,314 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import { ActivityDetailsContent } from '../app/activity-details';
+import type { TrainerActivityFeedback } from '@/types';
+
+const mockRouterPush = jest.fn();
+const mockRefreshData = jest.fn().mockResolvedValue(undefined);
+const mockFetchAssignments = jest.fn();
+const mockFetchSelfFeedbackForActivities = jest.fn().mockResolvedValue([]);
+const mockFetchSelfFeedbackForTemplates = jest.fn().mockResolvedValue([]);
+const mockFetchLatestCategoryFeedback = jest.fn().mockResolvedValue([]);
+const mockSendTrainerFeedback = jest.fn();
+const mockFetchTrainerFeedbackForPlayerActivity = jest.fn();
+const mockFetchTrainerFeedbackForTrainerActivity = jest.fn();
+const mockSessionGet = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    back: jest.fn(),
+    replace: jest.fn(),
+    canGoBack: jest.fn(() => true),
+  }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, left: 0, right: 0, bottom: 0 }),
+}));
+
+jest.mock('expo-linear-gradient', () => {
+  const React = jest.requireActual('react');
+  const { View: MockView } = jest.requireActual('react-native');
+  return {
+    LinearGradient: ({ children }: any) => <MockView>{children}</MockView>,
+  };
+});
+
+jest.mock('@/components/IconSymbol', () => {
+  const React = jest.requireActual('react');
+  const { Text: MockText } = jest.requireActual('react-native');
+  return {
+    IconSymbol: () => <MockText>icon</MockText>,
+  };
+});
+
+jest.mock('@/components/TaskDetailsModal', () => () => null);
+
+jest.mock('@/components/CreateActivityTaskModal', () => ({
+  CreateActivityTaskModal: () => null,
+}));
+
+jest.mock('@/components/AssignActivityModal', () => ({
+  AssignActivityModal: () => null,
+}));
+
+jest.mock('@/contexts/FootballContext', () => ({
+  useFootball: () => ({
+    updateActivitySingle: jest.fn(),
+    updateIntensityByCategory: jest.fn(),
+    updateActivitySeries: jest.fn(),
+    toggleTaskCompletion: jest.fn(),
+    deleteActivityTask: jest.fn(),
+    deleteActivitySingle: jest.fn(),
+    deleteActivitySeries: jest.fn(),
+    refreshData: mockRefreshData,
+    createActivity: jest.fn(),
+    duplicateActivity: jest.fn(),
+    tasks: [],
+  }),
+}));
+
+jest.mock('@/contexts/TeamPlayerContext', () => ({
+  useTeamPlayer: () => ({
+    players: [
+      { id: 'player-1', full_name: 'Spiller Test', email: '', phone_number: '' },
+      { id: 'player-2', full_name: 'Reserve Spiller', email: '', phone_number: '' },
+    ],
+  }),
+}));
+
+jest.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: (...args: any[]) => mockSessionGet(...args),
+    },
+    from: () => ({
+      select: () => ({
+        maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+      }),
+    }),
+  },
+}));
+
+jest.mock('@/services/feedbackService', () => ({
+  fetchSelfFeedbackForActivities: (...args: any[]) => mockFetchSelfFeedbackForActivities(...args),
+  fetchSelfFeedbackForTemplates: (...args: any[]) => mockFetchSelfFeedbackForTemplates(...args),
+  fetchLatestCategoryFeedback: (...args: any[]) => mockFetchLatestCategoryFeedback(...args),
+  upsertSelfFeedback: jest.fn(),
+}));
+
+jest.mock('@/services/activityAssignments', () => ({
+  activityAssignmentsService: {
+    fetchAssignments: (...args: any[]) => mockFetchAssignments(...args),
+    fetchAssignmentState: jest.fn(),
+    assignActivity: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/trainerFeedbackService', () => ({
+  fetchTrainerFeedbackForPlayerActivity: (...args: any[]) => mockFetchTrainerFeedbackForPlayerActivity(...args),
+  fetchTrainerFeedbackForTrainerActivity: (...args: any[]) =>
+    mockFetchTrainerFeedbackForTrainerActivity(...args),
+  sendTrainerFeedback: (...args: any[]) => mockSendTrainerFeedback(...args),
+}));
+
+const baseActivity = {
+  id: 'activity-1',
+  title: 'Mandagstræning',
+  date: new Date('2026-03-13T10:00:00.000Z'),
+  time: '10:00',
+  endTime: null,
+  location: 'Bane 1',
+  category: {
+    id: 'cat-1',
+    name: 'Træning',
+    color: '#123456',
+    emoji: '⚽️',
+  },
+  tasks: [],
+  intensity: null,
+  intensityEnabled: false,
+  intensityNote: null,
+  isExternal: false,
+};
+
+describe('ActivityDetails trainer feedback UI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    mockFetchAssignments.mockResolvedValue({ playerIds: ['player-1'], teamIds: [] });
+    mockFetchTrainerFeedbackForPlayerActivity.mockResolvedValue([]);
+    mockFetchTrainerFeedbackForTrainerActivity.mockResolvedValue([]);
+    mockSendTrainerFeedback.mockResolvedValue({
+      feedback: {
+        id: 'feedback-1',
+        activityContextType: 'internal',
+        activityContextId: 'activity-source-1',
+        playerId: 'player-1',
+        trainerId: 'trainer-1',
+        feedbackText: 'God førsteberøring',
+        createdAt: '2026-03-13T10:00:00.000Z',
+        updatedAt: '2026-03-13T10:00:00.000Z',
+      },
+      delivery: {
+        mail: { status: 'sent', provider: 'aws_ses', warning: null },
+        push: { status: 'sent', tokenCount: 1, warning: null },
+      },
+    });
+  });
+
+  it('shows the trainer section and add-flow for trainers', async () => {
+    mockSessionGet.mockResolvedValue({
+      data: { session: { user: { id: 'trainer-1' } } },
+      error: null,
+    });
+
+    const { findByTestId, getByText, getByTestId, queryByText } = render(
+      <ActivityDetailsContent
+        activity={{ ...baseActivity, user_id: 'trainer-1' } as any}
+        categories={[baseActivity.category]}
+        isAdmin
+        isTrainerProfile
+        isDark={false}
+        onBack={jest.fn()}
+        onActivityUpdated={jest.fn()}
+      />,
+    );
+
+    expect(await findByTestId('trainer-feedback-section')).toBeTruthy();
+
+    fireEvent.press(getByTestId('trainer-feedback-add-button'));
+
+    expect(await findByTestId('trainer-feedback-player-picker')).toBeTruthy();
+    fireEvent.press(getByText('Spiller Test'));
+    expect(queryByText('Reserve Spiller')).toBeNull();
+    fireEvent.changeText(getByTestId('trainer-feedback-input'), 'Fortsæt med orienteringen.');
+    fireEvent.press(getByTestId('trainer-feedback-send-button'));
+
+    await waitFor(() =>
+      expect(mockSendTrainerFeedback).toHaveBeenCalledWith({
+        activityId: 'activity-1',
+        playerId: 'player-1',
+        feedbackText: 'Fortsæt med orienteringen.',
+      }),
+    );
+  });
+
+  it('shows sent trainer feedback and opens a read modal for the trainer', async () => {
+    const feedback: TrainerActivityFeedback = {
+      id: 'feedback-1',
+      activityContextType: 'internal',
+      activityContextId: 'activity-1',
+      playerId: 'player-1',
+      trainerId: 'trainer-1',
+      feedbackText: 'Bliv ved med at orientere dig før førsteberøringen.',
+      createdAt: '2026-03-13T10:00:00.000Z',
+      updatedAt: '2026-03-13T10:05:00.000Z',
+    };
+
+    mockSessionGet.mockResolvedValue({
+      data: { session: { user: { id: 'trainer-1' } } },
+      error: null,
+    });
+    mockFetchTrainerFeedbackForTrainerActivity.mockResolvedValue([feedback]);
+
+    const { findByTestId, getByTestId, findByText, queryByText } = render(
+      <ActivityDetailsContent
+        activity={{ ...baseActivity, user_id: 'trainer-1' } as any}
+        categories={[baseActivity.category]}
+        isAdmin
+        isTrainerProfile
+        isDark={false}
+        onBack={jest.fn()}
+        onActivityUpdated={jest.fn()}
+      />,
+    );
+
+    expect(await findByTestId('trainer-feedback-section')).toBeTruthy();
+    expect(await findByText('Spiller Test')).toBeTruthy();
+    expect(queryByText('Bliv ved med at orientere dig før førsteberøringen.')).toBeNull();
+
+    fireEvent.press(getByTestId('trainer-feedback-open-modal-feedback-1'));
+
+    expect(await findByText('Feedback til Spiller Test')).toBeTruthy();
+    expect(await findByText('Bliv ved med at orientere dig før førsteberøringen.')).toBeTruthy();
+  });
+
+  it('shows the player section only when trainer feedback exists and opens the modal', async () => {
+    const feedback: TrainerActivityFeedback[] = [
+      {
+        id: 'feedback-2',
+        activityContextType: 'internal',
+        activityContextId: 'activity-source-1',
+        playerId: 'player-1',
+        trainerId: 'trainer-1',
+        feedbackText: 'God førsteberøring i små rum.',
+        createdAt: '2026-03-13T10:00:00.000Z',
+        updatedAt: '2026-03-13T10:00:00.000Z',
+      },
+      {
+        id: 'feedback-3',
+        activityContextType: 'internal',
+        activityContextId: 'activity-source-1',
+        playerId: 'player-1',
+        trainerId: 'trainer-2',
+        feedbackText: 'Spil hurtigere i anden bølge.',
+        createdAt: '2026-03-13T10:06:00.000Z',
+        updatedAt: '2026-03-13T10:08:00.000Z',
+      },
+    ];
+
+    mockSessionGet.mockResolvedValue({
+      data: { session: { user: { id: 'player-1' } } },
+      error: null,
+    });
+    mockFetchTrainerFeedbackForPlayerActivity.mockResolvedValue(feedback);
+
+    const { findByTestId, getByTestId, findByText, queryByText } = render(
+      <ActivityDetailsContent
+        activity={{ ...baseActivity, user_id: 'player-1', source_activity_id: 'activity-source-1' } as any}
+        categories={[baseActivity.category]}
+        isAdmin={false}
+        isPlayerProfile
+        isDark={false}
+        onBack={jest.fn()}
+        onActivityUpdated={jest.fn()}
+      />,
+    );
+
+    expect(await findByTestId('player-trainer-feedback-section')).toBeTruthy();
+    expect(await findByText('Feedback 1')).toBeTruthy();
+    expect(await findByText('Feedback 2')).toBeTruthy();
+    expect(queryByText('Spil hurtigere i anden bølge.')).toBeNull();
+
+    fireEvent.press(getByTestId('player-trainer-feedback-open-modal-feedback-2'));
+
+    expect(await findByText('God førsteberøring i små rum.')).toBeTruthy();
+  });
+
+  it('does not show the player section when no trainer feedback exists', async () => {
+    mockSessionGet.mockResolvedValue({
+      data: { session: { user: { id: 'player-1' } } },
+      error: null,
+    });
+    mockFetchTrainerFeedbackForPlayerActivity.mockResolvedValue([]);
+
+    const { queryByTestId } = render(
+      <ActivityDetailsContent
+        activity={{ ...baseActivity, user_id: 'player-1', source_activity_id: 'activity-source-1' } as any}
+        categories={[baseActivity.category]}
+        isAdmin={false}
+        isPlayerProfile
+        isDark={false}
+        onBack={jest.fn()}
+        onActivityUpdated={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(mockFetchTrainerFeedbackForPlayerActivity).toHaveBeenCalled());
+    expect(queryByTestId('player-trainer-feedback-section')).toBeNull();
+  });
+});

--- a/__tests__/notificationDeepLink.test.ts
+++ b/__tests__/notificationDeepLink.test.ts
@@ -1,3 +1,4 @@
+import { buildTrainerFeedbackPushPayload } from '../supabase/functions/_shared/trainerFeedbackDelivery';
 import { buildNotificationRouteFromData } from '@/utils/notificationDeepLink';
 
 describe('notification deeplink mapping', () => {
@@ -124,6 +125,25 @@ describe('notification deeplink mapping', () => {
       params: {
         id: 'activity-only',
         activityId: 'activity-only',
+      },
+    });
+  });
+
+  it('maps trainer feedback push payloads to the activity deeplink', () => {
+    const payload = buildTrainerFeedbackPushPayload({
+      activityId: 'player-activity-1',
+      activityTitle: 'Mandagstræning',
+      trainerName: 'Coach Kim',
+      feedbackText: 'Bliv ved med at orientere dig før førsteberøringen.',
+    });
+
+    const route = buildNotificationRouteFromData(payload.data);
+
+    expect(route).toEqual({
+      pathname: '/activity-details',
+      params: {
+        id: 'player-activity-1',
+        activityId: 'player-activity-1',
       },
     });
   });

--- a/__tests__/profile.settings.notifications.test.tsx
+++ b/__tests__/profile.settings.notifications.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { ScrollView } from 'react-native';
 
 import ProfileScreen from '@/app/(tabs)/profile';
 
 const mockCheckNotificationPermissions = jest.fn();
 const mockRequestNotificationPermissions = jest.fn();
 const mockOpenNotificationSettings = jest.fn();
+const mockGetUser = jest.fn();
 
 const mockLoadOverdueReminderSettings = jest.fn();
 const mockPersistOverdueReminderSettings = jest.fn();
@@ -195,7 +197,7 @@ jest.mock('@/integrations/supabase/client', () => {
   return {
     supabase: {
       auth: {
-        getUser: () => Promise.resolve({ data: { user: { id: 'user-1', email: 'test@example.com' } } }),
+        getUser: (...args: any[]) => mockGetUser(...args),
         onAuthStateChange: () => ({ data: { subscription: { unsubscribe: jest.fn() } } }),
         signUp: jest.fn(),
         signInWithPassword: jest.fn(),
@@ -225,6 +227,9 @@ describe('profile overdue reminder settings', () => {
     mockPersistOverdueReminderSettings.mockResolvedValue(undefined);
     mockCancelOverdueReminderNotifications.mockResolvedValue(undefined);
     mockRescheduleOverdueReminderNotifications.mockResolvedValue(['first-id', 'repeat-id']);
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1', email: 'test@example.com' } },
+    });
 
     mockCheckNotificationPermissions.mockResolvedValue(true);
     mockRequestNotificationPermissions.mockResolvedValue(true);
@@ -262,5 +267,27 @@ describe('profile overdue reminder settings', () => {
       expect(screen.getByTestId('profile.overdueReminders.deniedBanner')).toBeTruthy();
       expect(screen.getByTestId('profile.overdueReminders.openSettingsCta')).toBeTruthy();
     });
+  });
+
+  it('keeps paste/context menu enabled on login inputs', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+    });
+
+    const screen = render(<ProfileScreen />);
+
+    const emailInput = await screen.findByTestId('auth.login.emailInput');
+    const passwordInput = await screen.findByTestId('auth.login.passwordInput');
+
+    expect(emailInput.props.contextMenuHidden).toBe(false);
+    expect(emailInput.props.autoComplete).toBe('email');
+    expect(emailInput.props.textContentType).toBe('username');
+    expect(passwordInput.props.contextMenuHidden).toBe(false);
+    expect(passwordInput.props.autoComplete).toBe('password');
+    expect(passwordInput.props.textContentType).toBe('password');
+    const rootScrollView = screen.UNSAFE_getByType(ScrollView);
+    expect(rootScrollView.props.keyboardShouldPersistTaps).toBe('handled');
+    expect(rootScrollView.props.canCancelContentTouches).toBeUndefined();
+    expect(rootScrollView.props.scrollEnabled).toBeUndefined();
   });
 });

--- a/__tests__/trainerFeedbackDelivery.test.ts
+++ b/__tests__/trainerFeedbackDelivery.test.ts
@@ -1,0 +1,187 @@
+import {
+  buildTrainerFeedbackAppUrl,
+  buildTrainerFeedbackEmailContent,
+  buildTrainerFeedbackPath,
+  buildTrainerFeedbackPushPayload,
+  deliverTrainerFeedbackEmail,
+  deliverTrainerFeedbackPush,
+  type TrainerFeedbackEmailConfig,
+} from '../supabase/functions/_shared/trainerFeedbackDelivery';
+
+const config: TrainerFeedbackEmailConfig = {
+  appName: 'Footy Trainer',
+  appScheme: 'footballcoach',
+  fromEmail: 'feedback@example.com',
+  fromName: 'Footy Trainer',
+  awsRegion: 'eu-west-1',
+  awsAccessKeyId: 'AKIATESTKEY',
+  awsSecretAccessKey: 'secret-test-key',
+  awsSessionToken: null,
+};
+
+function createPushClient(tokens: (string | null)[]) {
+  return {
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn().mockResolvedValue({
+          data: tokens.map((expo_push_token) => ({ expo_push_token })),
+          error: null,
+        }),
+      })),
+    })),
+  };
+}
+
+describe('trainer feedback delivery helpers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('builds activity deeplinks for trainer feedback', () => {
+    expect(buildTrainerFeedbackPath('activity-1')).toBe('/activity-details?id=activity-1&activityId=activity-1');
+    expect(buildTrainerFeedbackAppUrl('activity-1')).toBe(
+      'footballcoach:///activity-details?id=activity-1&activityId=activity-1',
+    );
+  });
+
+  it('builds push payloads that deep-link to the activity', () => {
+    expect(
+      buildTrainerFeedbackPushPayload({
+        activityId: 'activity-1',
+        activityTitle: 'Mandagstræning',
+        trainerName: 'Coach Kim',
+        feedbackText: 'Hold fokus på orienteringen.',
+      }),
+    ).toEqual({
+      title: 'Ny feedback fra træner',
+      body: 'Coach Kim har sendt feedback på Mandagstræning.',
+      data: {
+        type: 'trainer-feedback',
+        activityId: 'activity-1',
+        url: '/activity-details?id=activity-1&activityId=activity-1',
+        feedbackPreview: 'Hold fokus på orienteringen.',
+      },
+    });
+  });
+
+  it('renders trainer feedback email copy with the feedback text and activity link', () => {
+    const content = buildTrainerFeedbackEmailContent(
+      {
+        activityId: 'activity-1',
+        activityTitle: 'Mandagstræning',
+        trainerName: 'Coach Kim',
+        feedbackText: 'Vær tidligere i din orientering.',
+      },
+      config,
+    );
+
+    expect(content.subject).toBe('Ny feedback fra din træner');
+    expect(content.html).toContain('Coach Kim');
+    expect(content.html).toContain('Vær tidligere i din orientering.');
+    expect(content.html).toContain('footballcoach:///activity-details?id=activity-1&amp;activityId=activity-1');
+    expect(content.text).toContain('Aktivitet: Mandagstræning');
+  });
+
+  it('skips trainer feedback emails when config is missing', async () => {
+    await expect(
+      deliverTrainerFeedbackEmail('player@example.com', {
+        activityId: 'activity-1',
+        activityTitle: 'Mandagstræning',
+        trainerName: 'Coach Kim',
+        feedbackText: 'Vær tidligere i din orientering.',
+      }),
+    ).resolves.toEqual({
+      status: 'skipped',
+      provider: 'none',
+      warning:
+        'Trainer feedback email skipped: missing TRAINER_FEEDBACK_FROM_EMAIL/CLUB_INVITE_FROM_EMAIL, AWS_SES_REGION, AWS_SES_ACCESS_KEY_ID, AWS_SES_SECRET_ACCESS_KEY.',
+    });
+  });
+
+  it('sends trainer feedback emails through AWS SES when config is provided', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+    } as Response);
+
+    await expect(
+      deliverTrainerFeedbackEmail(
+        'player@example.com',
+        {
+          activityId: 'activity-1',
+          activityTitle: 'Mandagstræning',
+          trainerName: 'Coach Kim',
+          feedbackText: 'Vær tidligere i din orientering.',
+        },
+        { config },
+      ),
+    ).resolves.toEqual({
+      status: 'sent',
+      provider: 'aws_ses',
+      warning: null,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://email.eu-west-1.amazonaws.com/v2/email/outbound-emails',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: expect.stringContaining('AWS4-HMAC-SHA256 Credential=AKIATESTKEY/'),
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+  });
+
+  it('skips push delivery when the player has no tokens', async () => {
+    await expect(
+      deliverTrainerFeedbackPush(
+        createPushClient([]) as any,
+        'player-1',
+        buildTrainerFeedbackPushPayload({
+          activityId: 'activity-1',
+          activityTitle: 'Mandagstræning',
+          trainerName: 'Coach Kim',
+          feedbackText: 'Hold fokus på orienteringen.',
+        }),
+      ),
+    ).resolves.toEqual({
+      status: 'skipped',
+      tokenCount: 0,
+      warning: 'No push tokens for player.',
+    });
+  });
+
+  it('sends push delivery through Expo when the player has tokens', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+    } as Response);
+
+    await expect(
+      deliverTrainerFeedbackPush(
+        createPushClient(['ExponentPushToken[test-token]']) as any,
+        'player-1',
+        buildTrainerFeedbackPushPayload({
+          activityId: 'activity-1',
+          activityTitle: 'Mandagstræning',
+          trainerName: 'Coach Kim',
+          feedbackText: 'Hold fokus på orienteringen.',
+        }),
+      ),
+    ).resolves.toEqual({
+      status: 'sent',
+      tokenCount: 1,
+      warning: null,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://exp.host/--/api/v2/push/send',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      }),
+    );
+  });
+});

--- a/__tests__/trainerFeedbackService.test.ts
+++ b/__tests__/trainerFeedbackService.test.ts
@@ -1,0 +1,284 @@
+import {
+  fetchTrainerFeedbackForTrainerActivity,
+  fetchTrainerFeedbackForPlayerActivity,
+  mapTrainerFeedbackRow,
+  resolveTrainerFeedbackActivityContext,
+  sendTrainerFeedback,
+} from '@/services/trainerFeedbackService';
+
+const mockOrder = jest.fn();
+const mockEq = jest.fn();
+const mockSelect = jest.fn(() => ({ eq: mockEq }));
+const mockFrom = jest.fn(() => ({ select: mockSelect }));
+const mockInvoke = jest.fn();
+
+jest.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (...args: any[]) => (mockFrom as (...innerArgs: any[]) => unknown)(...args),
+    functions: {
+      invoke: (...args: any[]) => (mockInvoke as (...innerArgs: any[]) => unknown)(...args),
+    },
+  },
+}));
+
+describe('trainerFeedbackService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEq.mockImplementation(() => ({
+      eq: mockEq,
+      order: mockOrder,
+    }));
+  });
+
+  it('maps trainer feedback rows', () => {
+    expect(
+      mapTrainerFeedbackRow({
+        id: 'feedback-1',
+        activity_context_type: 'external',
+        activity_context_id: 'activity-1',
+        player_id: 'player-1',
+        trainer_id: 'trainer-1',
+        feedback_text: 'God indsats',
+        created_at: '2026-03-13T10:00:00.000Z',
+        updated_at: '2026-03-13T11:00:00.000Z',
+      }),
+    ).toEqual({
+      id: 'feedback-1',
+      activityContextType: 'external',
+      activityContextId: 'activity-1',
+      playerId: 'player-1',
+      trainerId: 'trainer-1',
+      feedbackText: 'God indsats',
+      createdAt: '2026-03-13T10:00:00.000Z',
+      updatedAt: '2026-03-13T11:00:00.000Z',
+    });
+  });
+
+  it('maps trainer feedback rows returned in camelCase from the edge function', () => {
+    expect(
+      mapTrainerFeedbackRow({
+        id: 'feedback-camel-1',
+        activityContextType: 'internal',
+        activityContextId: 'activity-1',
+        playerId: 'player-1',
+        trainerId: 'trainer-1',
+        feedbackText: 'Bliv ved med at vende op i fart.',
+        createdAt: '2026-03-13T10:00:00.000Z',
+        updatedAt: '2026-03-13T11:00:00.000Z',
+      }),
+    ).toEqual({
+      id: 'feedback-camel-1',
+      activityContextType: 'internal',
+      activityContextId: 'activity-1',
+      playerId: 'player-1',
+      trainerId: 'trainer-1',
+      feedbackText: 'Bliv ved med at vende op i fart.',
+      createdAt: '2026-03-13T10:00:00.000Z',
+      updatedAt: '2026-03-13T11:00:00.000Z',
+    });
+  });
+
+  it('resolves internal trainer feedback context from assigned activities', () => {
+    expect(
+      resolveTrainerFeedbackActivityContext({
+        id: 'assigned-activity-1',
+        isExternal: false,
+        source_activity_id: 'source-activity-1',
+      }),
+    ).toEqual({
+      activityContextType: 'internal',
+      activityContextId: 'source-activity-1',
+    });
+  });
+
+  it('resolves internal trainer feedback context from trainer-owned source activities', () => {
+    expect(
+      resolveTrainerFeedbackActivityContext({
+        id: 'source-activity-1',
+        isExternal: false,
+      }),
+    ).toEqual({
+      activityContextType: 'internal',
+      activityContextId: 'source-activity-1',
+    });
+  });
+
+  it('resolves external trainer feedback context from external event ids', () => {
+    expect(
+      resolveTrainerFeedbackActivityContext({
+        id: 'meta-1',
+        isExternal: true,
+        external_event_id: 'external-event-1',
+      }),
+    ).toEqual({
+      activityContextType: 'external',
+      activityContextId: 'external-event-1',
+    });
+  });
+
+  it('reads trainer feedback for a player activity', async () => {
+    mockOrder.mockResolvedValue({
+      data: [
+        {
+          id: 'feedback-1',
+          activity_context_type: 'internal',
+          activity_context_id: 'source-activity-1',
+          player_id: 'player-1',
+          trainer_id: 'trainer-1',
+          feedback_text: 'Fortsæt med førsteberøringen',
+          created_at: '2026-03-13T10:00:00.000Z',
+          updated_at: '2026-03-13T10:05:00.000Z',
+        },
+        {
+          id: 'feedback-2',
+          activity_context_type: 'internal',
+          activity_context_id: 'source-activity-1',
+          player_id: 'player-1',
+          trainer_id: 'trainer-2',
+          feedback_text: 'Spil hurtigere i anden bølge.',
+          created_at: '2026-03-13T10:06:00.000Z',
+          updated_at: '2026-03-13T10:08:00.000Z',
+        },
+      ],
+      error: null,
+    });
+
+    await expect(
+      fetchTrainerFeedbackForPlayerActivity({
+        activity: {
+          id: 'assigned-activity-1',
+          isExternal: false,
+          source_activity_id: 'source-activity-1',
+        },
+        playerId: 'player-1',
+      }),
+    ).resolves.toEqual([
+      {
+        id: 'feedback-1',
+        activityContextType: 'internal',
+        activityContextId: 'source-activity-1',
+        playerId: 'player-1',
+        trainerId: 'trainer-1',
+        feedbackText: 'Fortsæt med førsteberøringen',
+        createdAt: '2026-03-13T10:00:00.000Z',
+        updatedAt: '2026-03-13T10:05:00.000Z',
+      },
+      {
+        id: 'feedback-2',
+        activityContextType: 'internal',
+        activityContextId: 'source-activity-1',
+        playerId: 'player-1',
+        trainerId: 'trainer-2',
+        feedbackText: 'Spil hurtigere i anden bølge.',
+        createdAt: '2026-03-13T10:06:00.000Z',
+        updatedAt: '2026-03-13T10:08:00.000Z',
+      },
+    ]);
+
+    expect(mockFrom).toHaveBeenCalledWith('trainer_activity_feedback');
+    expect(mockEq).toHaveBeenNthCalledWith(1, 'player_id', 'player-1');
+    expect(mockEq).toHaveBeenNthCalledWith(2, 'activity_context_type', 'internal');
+    expect(mockEq).toHaveBeenNthCalledWith(3, 'activity_context_id', 'source-activity-1');
+    expect(mockOrder).toHaveBeenCalledWith('updated_at', { ascending: false });
+  });
+
+  it('reads trainer feedback for a trainer activity', async () => {
+    mockOrder.mockResolvedValue({
+      data: [
+        {
+          id: 'feedback-2',
+          activity_context_type: 'internal',
+          activity_context_id: 'source-activity-1',
+          player_id: 'player-2',
+          trainer_id: 'trainer-1',
+          feedback_text: 'Hold tempo i første aktion.',
+          created_at: '2026-03-13T10:00:00.000Z',
+          updated_at: '2026-03-13T10:05:00.000Z',
+        },
+      ],
+      error: null,
+    });
+
+    await expect(
+      fetchTrainerFeedbackForTrainerActivity({
+        activity: {
+          id: 'source-activity-1',
+          isExternal: false,
+        },
+        trainerId: 'trainer-1',
+      }),
+    ).resolves.toEqual([
+      {
+        id: 'feedback-2',
+        activityContextType: 'internal',
+        activityContextId: 'source-activity-1',
+        playerId: 'player-2',
+        trainerId: 'trainer-1',
+        feedbackText: 'Hold tempo i første aktion.',
+        createdAt: '2026-03-13T10:00:00.000Z',
+        updatedAt: '2026-03-13T10:05:00.000Z',
+      },
+    ]);
+
+    expect(mockFrom).toHaveBeenCalledWith('trainer_activity_feedback');
+    expect(mockEq).toHaveBeenNthCalledWith(1, 'trainer_id', 'trainer-1');
+    expect(mockEq).toHaveBeenNthCalledWith(2, 'activity_context_type', 'internal');
+    expect(mockEq).toHaveBeenNthCalledWith(3, 'activity_context_id', 'source-activity-1');
+    expect(mockOrder).toHaveBeenCalledWith('updated_at', { ascending: false });
+  });
+
+  it('saves trainer feedback via the edge function', async () => {
+    mockInvoke.mockResolvedValue({
+      data: {
+        data: {
+          feedback: {
+            id: 'feedback-2',
+            activityContextType: 'internal',
+            activityContextId: 'source-activity-2',
+            playerId: 'player-2',
+            trainerId: 'trainer-2',
+            feedbackText: 'Bliv ved med at scanne før modtagelse.',
+            createdAt: '2026-03-13T12:00:00.000Z',
+            updatedAt: '2026-03-13T12:00:00.000Z',
+          },
+          delivery: {
+            mail: { status: 'sent', provider: 'aws_ses', warning: null },
+            push: { status: 'sent', tokenCount: 1, warning: null },
+          },
+        },
+      },
+      error: null,
+    });
+
+    await expect(
+      sendTrainerFeedback({
+        activityId: 'activity-2',
+        playerId: 'player-2',
+        feedbackText: 'Bliv ved med at scanne før modtagelse.',
+      }),
+    ).resolves.toEqual({
+      feedback: {
+        id: 'feedback-2',
+        activityContextType: 'internal',
+        activityContextId: 'source-activity-2',
+        playerId: 'player-2',
+        trainerId: 'trainer-2',
+        feedbackText: 'Bliv ved med at scanne før modtagelse.',
+        createdAt: '2026-03-13T12:00:00.000Z',
+        updatedAt: '2026-03-13T12:00:00.000Z',
+      },
+      delivery: {
+        mail: { status: 'sent', provider: 'aws_ses', warning: null },
+        push: { status: 'sent', tokenCount: 1, warning: null },
+      },
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith('sendTrainerFeedback', {
+      body: {
+        activityId: 'activity-2',
+        playerId: 'player-2',
+        feedbackText: 'Bliv ved med at scanne før modtagelse.',
+      },
+    });
+  });
+});

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2535,8 +2535,11 @@ export default function ProfileScreen() {
                   placeholderTextColor={textSecondaryColor}
                   autoCapitalize="none"
                   keyboardType="email-address"
+                  autoComplete="email"
+                  textContentType="username"
                   editable={!loading}
                   autoCorrect={false}
+                  contextMenuHidden={false}
                   testID="auth.login.emailInput"
                   accessibilityLabel="Email"
                 />
@@ -2558,6 +2561,9 @@ export default function ProfileScreen() {
                   editable={!loading}
                   autoCorrect={false}
                   autoCapitalize="none"
+                  autoComplete="password"
+                  textContentType="password"
+                  contextMenuHidden={false}
                   testID="auth.login.passwordInput"
                   accessibilityLabel="Adgangskode"
                 />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -97,6 +97,7 @@ export default function RootLayout() {
           0.99,
         )
     : Math.min(startupPrerequisitesProgress, 0.99);
+  const shouldRenderStartupLoader = showStartupLoader && shouldWaitForHomeReady;
 
   const persistPendingRoute = useCallback(
     (route: { pathname: string; params?: Record<string, string> } | null) => {
@@ -503,7 +504,7 @@ export default function RootLayout() {
                   </Stack>
 
                   <StatusBar style="auto" />
-                  <AppStartupLoader visible={showStartupLoader} progress={startupProgress} />
+                  <AppStartupLoader visible={shouldRenderStartupLoader} progress={startupProgress} />
                 </View>
               </FootballProvider>
             </CelebrationProvider>

--- a/app/activity-details.tsx
+++ b/app/activity-details.tsx
@@ -20,12 +20,19 @@ import Svg, { Path } from 'react-native-svg';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useFootball } from '@/contexts/FootballContext';
+import { useTeamPlayer } from '@/contexts/TeamPlayerContext';
 
 // Robust import: avoid runtime crash if named export "colors" changes
 import * as CommonStyles from '@/styles/commonStyles';
 
 import { IconSymbol } from '@/components/IconSymbol';
-import { Activity, ActivityCategory, Task, TaskTemplateSelfFeedback } from '@/types';
+import {
+  Activity,
+  ActivityCategory,
+  Task,
+  TaskTemplateSelfFeedback,
+  TrainerActivityFeedback,
+} from '@/types';
 import { useUserRole } from '@/hooks/useUserRole';
 import { CreateActivityTaskModal } from '@/components/CreateActivityTaskModal';
 import { AssignActivityModal } from '@/components/AssignActivityModal';
@@ -37,6 +44,11 @@ import {
   fetchSelfFeedbackForTemplates,
   upsertSelfFeedback,
 } from '@/services/feedbackService';
+import {
+  fetchTrainerFeedbackForPlayerActivity,
+  fetchTrainerFeedbackForTrainerActivity,
+  sendTrainerFeedback,
+} from '@/services/trainerFeedbackService';
 import { activityAssignmentsService } from '@/services/activityAssignments';
 import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
 import { filterVisibleTasksForActivity } from '@/utils/taskTemplateVisibility';
@@ -271,6 +283,17 @@ function formatShortDate(value: string): string {
   });
 }
 
+function sortTrainerFeedbackByUpdatedAtDesc(entries: TrainerActivityFeedback[]): TrainerActivityFeedback[] {
+  return [...entries].sort((left, right) => {
+    const leftTime = Date.parse(left.updatedAt || left.createdAt || '');
+    const rightTime = Date.parse(right.updatedAt || right.createdAt || '');
+    if (Number.isFinite(leftTime) && Number.isFinite(rightTime) && leftTime !== rightTime) {
+      return rightTime - leftTime;
+    }
+    return right.createdAt.localeCompare(left.createdAt);
+  });
+}
+
 function formatDateTime(date: Date, time: string): string {
   const timeDisplay = time.substring(0, 5);
   return `${formatDate(date)} kl. ${timeDisplay}`;
@@ -321,6 +344,7 @@ const INTERNAL_SELECT_WITH_VIDEO = `
   user_id,
   player_id,
   team_id,
+  source_activity_id,
   title,
   activity_date,
   activity_time,
@@ -363,6 +387,7 @@ const INTERNAL_SELECT_NO_VIDEO = `
   user_id,
   player_id,
   team_id,
+  source_activity_id,
   title,
   activity_date,
   activity_time,
@@ -904,6 +929,8 @@ export async function fetchActivityFromDatabase(activityId: string): Promise<Act
         user_id: internalActivityAny.user_id ?? null,
         player_id: internalActivityAny.player_id ?? null,
         team_id: internalActivityAny.team_id ?? null,
+        sourceActivityId: internalActivityAny.source_activity_id ?? null,
+        source_activity_id: internalActivityAny.source_activity_id ?? null,
       } as Activity;
     }
 
@@ -1409,6 +1436,11 @@ type LatestCategoryFeedbackEntry = {
   note?: string | null;
 };
 
+type TrainerFeedbackPlayerOption = {
+  id: string;
+  name: string;
+};
+
 function normalizeId(value: unknown): string | null {
   if (value === null || value === undefined) return null;
   const trimmed = String(value).trim();
@@ -1782,6 +1814,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
     duplicateActivity,
     tasks: taskTemplates,
   } = useFootball();
+  const { players } = useTeamPlayer();
 
   const listRef = useRef<FlatList<TaskListItem>>(null);
 
@@ -1802,6 +1835,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
     playerCount: number;
     teamCount: number;
   } | null>(null);
+  const [activityAssignmentPlayerIds, setActivityAssignmentPlayerIds] = useState<string[]>([]);
 
   const [feedbackConfigByTemplate, setFeedbackConfigByTemplate] = useState<
     Record<string, AfterTrainingFeedbackConfig>
@@ -1820,6 +1854,21 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
   const [isLatestCategoryFeedbackLoading, setIsLatestCategoryFeedbackLoading] = useState(true);
   const [latestFeedbackRefreshKey, setLatestFeedbackRefreshKey] = useState(0);
   const [isLatestFeedbackExpanded, setIsLatestFeedbackExpanded] = useState(true);
+  const [trainerFeedbackModalVisible, setTrainerFeedbackModalVisible] = useState(false);
+  const [selectedTrainerFeedbackPlayerId, setSelectedTrainerFeedbackPlayerId] = useState<string | null>(null);
+  const [trainerFeedbackInput, setTrainerFeedbackInput] = useState('');
+  const [isTrainerFeedbackSending, setIsTrainerFeedbackSending] = useState(false);
+  const [trainerActivityFeedback, setTrainerActivityFeedback] = useState<TrainerActivityFeedback[]>([]);
+  const [isTrainerActivityFeedbackLoading, setIsTrainerActivityFeedbackLoading] = useState(false);
+  const [selectedTrainerActivityFeedback, setSelectedTrainerActivityFeedback] =
+    useState<TrainerActivityFeedback | null>(null);
+  const [trainerActivityFeedbackModalVisible, setTrainerActivityFeedbackModalVisible] =
+    useState(false);
+  const [playerTrainerFeedback, setPlayerTrainerFeedback] = useState<TrainerActivityFeedback[]>([]);
+  const [isPlayerTrainerFeedbackLoading, setIsPlayerTrainerFeedbackLoading] = useState(false);
+  const [selectedPlayerTrainerFeedback, setSelectedPlayerTrainerFeedback] =
+    useState<TrainerActivityFeedback | null>(null);
+  const [playerTrainerFeedbackModalVisible, setPlayerTrainerFeedbackModalVisible] = useState(false);
 
   const [selectedNormalTask, setSelectedNormalTask] = useState<FeedbackTask | null>(null);
   const [isNormalTaskModalVisible, setIsNormalTaskModalVisible] = useState(false);
@@ -1890,6 +1939,10 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
   const activityExternalEventId =
     activity.externalEventId ?? (activity as any)?.external_event_id;
   const activityTasks = activity.tasks;
+  const activityOwnerId = normalizeId((activity as any)?.user_id ?? (activity as any)?.userId);
+  const activitySourceActivityId = normalizeId(
+    (activity as any)?.sourceActivityId ?? (activity as any)?.source_activity_id,
+  );
   const activityPlayerScopeId = normalizeId((activity as any)?.playerId ?? (activity as any)?.player_id);
   const activityTeamScopeId = normalizeId((activity as any)?.teamId ?? (activity as any)?.team_id);
   const isTrainerAssignedActivityForPlayer = useMemo(
@@ -1923,6 +1976,13 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
       intensityNote,
     };
   }, [activity]);
+  const isTrainerOwnedActivity = useMemo(() => {
+    if (!currentUserId) return false;
+    if (activity.isExternal) {
+      return !activityOwnerId || activityOwnerId === currentUserId;
+    }
+    return activityOwnerId === currentUserId && !activitySourceActivityId;
+  }, [activity.isExternal, activityOwnerId, activitySourceActivityId, currentUserId]);
 
   const feedbackActivityCandidates = useMemo(() => {
     const ids: string[] = [];
@@ -2251,6 +2311,78 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
   }, [activity?.category?.id, currentUserId, isCurrentUserResolved, latestFeedbackRefreshKey]);
 
   useEffect(() => {
+    let cancelled = false;
+
+    if (!isPlayerProfile || !currentUserId) {
+      setPlayerTrainerFeedback([]);
+      setIsPlayerTrainerFeedbackLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setIsPlayerTrainerFeedbackLoading(true);
+    void fetchTrainerFeedbackForPlayerActivity({
+      activity,
+      playerId: currentUserId,
+    })
+      .then((feedbackRows) => {
+        if (cancelled) return;
+        setPlayerTrainerFeedback(sortTrainerFeedbackByUpdatedAtDesc(feedbackRows));
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error('[ActivityDetails] player trainer feedback load failed', error);
+        setPlayerTrainerFeedback([]);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsPlayerTrainerFeedbackLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activity, currentUserId, isPlayerProfile]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!isTrainerProfile || !currentUserId || !isTrainerOwnedActivity) {
+      setTrainerActivityFeedback([]);
+      setIsTrainerActivityFeedbackLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setIsTrainerActivityFeedbackLoading(true);
+    void fetchTrainerFeedbackForTrainerActivity({
+      activity,
+      trainerId: currentUserId,
+    })
+      .then((feedbackRows) => {
+        if (cancelled) return;
+        setTrainerActivityFeedback(sortTrainerFeedbackByUpdatedAtDesc(feedbackRows));
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error('[ActivityDetails] trainer feedback list load failed', error);
+        setTrainerActivityFeedback([]);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsTrainerActivityFeedbackLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activity, currentUserId, isTrainerOwnedActivity, isTrainerProfile]);
+
+  useEffect(() => {
     if (!pendingFeedbackTaskId) return;
 
     const task = tasksState.find((t) => String(t.id) === String(pendingFeedbackTaskId));
@@ -2427,7 +2559,18 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
 
   useEffect(() => {
     setActivityAssignmentSummary(null);
+    setActivityAssignmentPlayerIds([]);
     setAssignActivityModalVisible(false);
+    setTrainerFeedbackModalVisible(false);
+    setSelectedTrainerFeedbackPlayerId(null);
+    setTrainerFeedbackInput('');
+    setTrainerActivityFeedback([]);
+    setIsTrainerActivityFeedbackLoading(false);
+    setSelectedTrainerActivityFeedback(null);
+    setTrainerActivityFeedbackModalVisible(false);
+    setPlayerTrainerFeedback([]);
+    setSelectedPlayerTrainerFeedback(null);
+    setPlayerTrainerFeedbackModalVisible(false);
   }, [activity.id]);
 
   useEffect(() => {
@@ -2435,6 +2578,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
 
     if (!isTrainerProfile || !currentUserId) {
       setActivityAssignmentSummary(null);
+      setActivityAssignmentPlayerIds([]);
       return () => {
         cancelled = true;
       };
@@ -2453,11 +2597,13 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
           playerCount: assignment.playerIds.length,
           teamCount: assignment.teamIds.length,
         });
+        setActivityAssignmentPlayerIds(assignment.playerIds);
       })
       .catch((error) => {
         if (cancelled) return;
         console.error('[ActivityDetails] assignment summary load failed', error);
         setActivityAssignmentSummary(null);
+        setActivityAssignmentPlayerIds([]);
       });
 
     return () => {
@@ -3324,6 +3470,155 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
     return `Tilknyttet: ${activityAssignmentSummary.playerCount} ${playerLabel} · ${activityAssignmentSummary.teamCount} ${teamLabel}`;
   }, [activityAssignmentSummary]);
 
+  const trainerFeedbackPlayerOptions = useMemo<TrainerFeedbackPlayerOption[]>(() => {
+    if (!activityAssignmentPlayerIds.length) return [];
+
+    return activityAssignmentPlayerIds
+      .map((playerId) => {
+        const profile = players.find((player) => String(player.id) === playerId);
+        return {
+          id: playerId,
+          name:
+            typeof profile?.full_name === 'string' && profile.full_name.trim()
+              ? profile.full_name.trim()
+              : 'Spiller',
+        };
+      })
+      .sort((left, right) => left.name.localeCompare(right.name, 'da-DK', { sensitivity: 'base' }));
+  }, [activityAssignmentPlayerIds, players]);
+
+  const trainerFeedbackPlayerNamesById = useMemo(() => {
+    const nameMap: Record<string, string> = {};
+
+    for (const player of players) {
+      const playerId = normalizeId((player as any)?.id);
+      if (!playerId) continue;
+      const fullName =
+        typeof (player as any)?.full_name === 'string' && (player as any).full_name.trim()
+          ? (player as any).full_name.trim()
+          : 'Spiller';
+      nameMap[playerId] = fullName;
+    }
+
+    for (const player of trainerFeedbackPlayerOptions) {
+      nameMap[player.id] = player.name;
+    }
+
+    return nameMap;
+  }, [players, trainerFeedbackPlayerOptions]);
+
+  const selectedTrainerFeedbackPlayer = useMemo(
+    () =>
+      trainerFeedbackPlayerOptions.find((player) => player.id === selectedTrainerFeedbackPlayerId) ??
+      null,
+    [selectedTrainerFeedbackPlayerId, trainerFeedbackPlayerOptions],
+  );
+
+  const selectedTrainerActivityFeedbackPlayerName = useMemo(() => {
+    if (!selectedTrainerActivityFeedback) return 'Spiller';
+    return trainerFeedbackPlayerNamesById[selectedTrainerActivityFeedback.playerId] || 'Spiller';
+  }, [selectedTrainerActivityFeedback, trainerFeedbackPlayerNamesById]);
+
+  const latestPlayerTrainerFeedback = useMemo(
+    () => playerTrainerFeedback[0] ?? null,
+    [playerTrainerFeedback],
+  );
+
+  const shouldShowTrainerFeedbackSection =
+    !isEditing && isTrainerProfile && isTrainerOwnedActivity;
+  const shouldShowPlayerTrainerFeedbackSection =
+    !isEditing && isPlayerProfile && !isPlayerTrainerFeedbackLoading && playerTrainerFeedback.length > 0;
+
+  const handleOpenTrainerFeedbackModal = useCallback(() => {
+    if (!trainerFeedbackPlayerOptions.length) {
+      Alert.alert('Ingen spillere', 'Aktiviteten har ingen tilknyttede spillere endnu.');
+      return;
+    }
+
+    setSelectedTrainerFeedbackPlayerId((current) => {
+      if (current && trainerFeedbackPlayerOptions.some((player) => player.id === current)) {
+        return current;
+      }
+      return trainerFeedbackPlayerOptions[0].id;
+    });
+    setTrainerFeedbackModalVisible(true);
+  }, [trainerFeedbackPlayerOptions]);
+
+  const handleCloseTrainerFeedbackModal = useCallback(() => {
+    if (isTrainerFeedbackSending) return;
+    setTrainerFeedbackModalVisible(false);
+    setTrainerFeedbackInput('');
+    setSelectedTrainerFeedbackPlayerId(null);
+  }, [isTrainerFeedbackSending]);
+
+  const handleOpenTrainerActivityFeedbackModal = useCallback((feedback: TrainerActivityFeedback) => {
+    setSelectedTrainerActivityFeedback(feedback);
+    setTrainerActivityFeedbackModalVisible(true);
+  }, []);
+
+  const handleCloseTrainerActivityFeedbackModal = useCallback(() => {
+    setTrainerActivityFeedbackModalVisible(false);
+    setSelectedTrainerActivityFeedback(null);
+  }, []);
+
+  const handleOpenPlayerTrainerFeedbackModal = useCallback((feedback: TrainerActivityFeedback) => {
+    setSelectedPlayerTrainerFeedback(feedback);
+    setPlayerTrainerFeedbackModalVisible(true);
+  }, []);
+
+  const handleClosePlayerTrainerFeedbackModal = useCallback(() => {
+    setPlayerTrainerFeedbackModalVisible(false);
+    setSelectedPlayerTrainerFeedback(null);
+  }, []);
+
+  const handleSendTrainerFeedback = useCallback(async () => {
+    const playerId = normalizeId(selectedTrainerFeedbackPlayerId);
+    const feedbackText = trainerFeedbackInput.trim();
+
+    if (!playerId) {
+      Alert.alert('Vælg spiller', 'Vælg en spiller, før du sender feedback.');
+      return;
+    }
+
+    if (!feedbackText) {
+      Alert.alert('Skriv feedback', 'Skriv feedback, før du sender.');
+      return;
+    }
+
+    setIsTrainerFeedbackSending(true);
+    try {
+      const result = await sendTrainerFeedback({
+        activityId: String(activity.id),
+        playerId,
+        feedbackText,
+      });
+      setTrainerFeedbackModalVisible(false);
+      setTrainerFeedbackInput('');
+      setSelectedTrainerFeedbackPlayerId(null);
+      setTrainerActivityFeedback((current) =>
+        sortTrainerFeedbackByUpdatedAtDesc([
+          result.feedback,
+          ...current.filter((entry) => entry.id !== result.feedback.id),
+        ]),
+      );
+      const mailStatus = result.delivery?.mail?.status;
+      const pushStatus = result.delivery?.push?.status;
+      if (mailStatus === 'sent' && pushStatus === 'sent') {
+        Alert.alert('Feedback sendt', 'Spilleren har modtaget feedbacken.');
+      } else {
+        Alert.alert(
+          'Feedback gemt',
+          'Feedbacken blev gemt, men mindst én notifikation kunne ikke bekræftes sendt.',
+        );
+      }
+    } catch (error: any) {
+      console.error('[ActivityDetails] trainer feedback send failed', error);
+      Alert.alert('Kunne ikke sende', error?.message || 'Prøv igen senere.');
+    } finally {
+      setIsTrainerFeedbackSending(false);
+    }
+  }, [activity.id, selectedTrainerFeedbackPlayerId, trainerFeedbackInput]);
+
   const taskListItems = useMemo<TaskListItem[]>(() => {
     const items: TaskListItem[] = [];
     if (showIntensityTaskRow) {
@@ -4162,6 +4457,166 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
             </View>
           </View>
         ) : null}
+
+        {shouldShowTrainerFeedbackSection ? (
+          <View style={[styles.v2CardWrap, { marginTop: 12 }]} testID="trainer-feedback-section">
+            <View style={[styles.activityAssignCard, { backgroundColor: isDark ? '#ffffff0f' : '#ffffff' }]}>
+              <View style={styles.trainerFeedbackHeaderRow}>
+                <Text style={[styles.activityAssignTitle, { color: textColor }]}>Spiller feedback</Text>
+                <TouchableOpacity
+                  style={[
+                    styles.trainerFeedbackAddButton,
+                    {
+                      backgroundColor: trainerFeedbackPlayerOptions.length ? primaryColor : fieldBackgroundColor,
+                      borderColor: trainerFeedbackPlayerOptions.length ? primaryColor : fieldBorderColor,
+                    },
+                  ]}
+                  activeOpacity={0.8}
+                  onPress={handleOpenTrainerFeedbackModal}
+                  testID="trainer-feedback-add-button"
+                >
+                  <IconSymbol ios_icon_name="plus" android_material_icon_name="add" size={18} color={trainerFeedbackPlayerOptions.length ? '#fff' : textSecondaryColor} />
+                </TouchableOpacity>
+              </View>
+              <Text style={[styles.activityAssignMessage, { color: textSecondaryColor }]}>
+                Send individuel feedback til en spiller på denne aktivitet.
+              </Text>
+              <Text style={[styles.activityAssignSummary, { color: textSecondaryColor }]}>
+                {trainerFeedbackPlayerOptions.length
+                  ? `${trainerFeedbackPlayerOptions.length} ${trainerFeedbackPlayerOptions.length === 1 ? 'spiller er' : 'spillere er'} tilknyttet`
+                  : 'Ingen spillere tilknyttet endnu'}
+              </Text>
+              {isTrainerActivityFeedbackLoading ? (
+                <Text style={[styles.activityAssignSummary, { color: textSecondaryColor }]}>
+                  Henter sendt feedback...
+                </Text>
+              ) : trainerActivityFeedback.length ? (
+                <View style={styles.trainerFeedbackList}>
+                  {trainerActivityFeedback.map((feedback, index) => {
+                    const playerName = trainerFeedbackPlayerNamesById[feedback.playerId] || 'Spiller';
+                    const feedbackMeta = feedback.updatedAt
+                      ? `Opdateret ${formatShortDate(feedback.updatedAt)}`
+                      : 'Sendt feedback';
+
+                    return (
+                      <TouchableOpacity
+                        key={feedback.id}
+                        style={[
+                          styles.trainerFeedbackListItem,
+                          {
+                            backgroundColor: fieldBackgroundColor,
+                            borderColor: fieldBorderColor,
+                            marginTop: index === 0 ? 0 : 10,
+                          },
+                        ]}
+                        activeOpacity={0.8}
+                        onPress={() => handleOpenTrainerActivityFeedbackModal(feedback)}
+                        testID={`trainer-feedback-open-modal-${feedback.id}`}
+                      >
+                        <View style={styles.trainerFeedbackListItemTextWrap}>
+                          <Text style={[styles.trainerFeedbackListItemTitle, { color: textColor }]}>
+                            {playerName}
+                          </Text>
+                          <Text
+                            style={[styles.trainerFeedbackListItemMeta, { color: textSecondaryColor }]}
+                          >
+                            {feedbackMeta}
+                          </Text>
+                        </View>
+                        <IconSymbol
+                          ios_icon_name="chevron.right"
+                          android_material_icon_name="chevron_right"
+                          size={18}
+                          color={textSecondaryColor}
+                        />
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              ) : null}
+            </View>
+          </View>
+        ) : null}
+
+        {shouldShowPlayerTrainerFeedbackSection ? (
+          <View style={[styles.v2CardWrap, { marginTop: 12 }]} testID="player-trainer-feedback-section">
+            <View style={[styles.activityAssignCard, { backgroundColor: isDark ? '#ffffff0f' : '#ffffff' }]}>
+              <Text style={[styles.activityAssignTitle, { color: textColor }]}>Feedback fra træner</Text>
+              {playerTrainerFeedback.length === 1 && latestPlayerTrainerFeedback ? (
+                <>
+                  <Text style={[styles.activityAssignMessage, { color: textSecondaryColor }]}>
+                    {latestPlayerTrainerFeedback.updatedAt
+                      ? `Opdateret ${formatShortDate(latestPlayerTrainerFeedback.updatedAt)}`
+                      : 'Du har modtaget feedback på denne aktivitet.'}
+                  </Text>
+                  <Text style={[styles.trainerFeedbackPreviewText, { color: textColor }]} numberOfLines={3}>
+                    {latestPlayerTrainerFeedback.feedbackText}
+                  </Text>
+                  <TouchableOpacity
+                    style={[styles.activityAssignButton, { backgroundColor: primaryColor }]}
+                    activeOpacity={0.8}
+                    onPress={() => handleOpenPlayerTrainerFeedbackModal(latestPlayerTrainerFeedback)}
+                    testID="player-trainer-feedback-open-modal"
+                  >
+                    <Text style={styles.activityAssignButtonText}>Læs feedback</Text>
+                  </TouchableOpacity>
+                </>
+              ) : (
+                <>
+                  <Text style={[styles.activityAssignMessage, { color: textSecondaryColor }]}>
+                    {`${playerTrainerFeedback.length} feedbackbeskeder på denne aktivitet.`}
+                  </Text>
+                  <View style={styles.trainerFeedbackList}>
+                    {playerTrainerFeedback.map((feedback, index) => {
+                      const feedbackLabel = `Feedback ${index + 1}`;
+                      const feedbackMeta = feedback.updatedAt
+                        ? `Opdateret ${formatShortDate(feedback.updatedAt)}`
+                        : 'Modtaget feedback';
+
+                      return (
+                        <TouchableOpacity
+                          key={feedback.id}
+                          style={[
+                            styles.trainerFeedbackListItem,
+                            {
+                              backgroundColor: fieldBackgroundColor,
+                              borderColor: fieldBorderColor,
+                              marginTop: index === 0 ? 0 : 10,
+                            },
+                          ]}
+                          activeOpacity={0.8}
+                          onPress={() => handleOpenPlayerTrainerFeedbackModal(feedback)}
+                          testID={
+                            index === 0
+                              ? 'player-trainer-feedback-open-modal'
+                              : `player-trainer-feedback-open-modal-${feedback.id}`
+                          }
+                        >
+                          <View style={styles.trainerFeedbackListItemTextWrap}>
+                            <Text style={[styles.trainerFeedbackListItemTitle, { color: textColor }]}>
+                              {feedbackLabel}
+                            </Text>
+                            <Text
+                              style={[styles.trainerFeedbackListItemMeta, { color: textSecondaryColor }]}
+                            >
+                              {feedbackMeta}
+                            </Text>
+                          </View>
+                          <IconSymbol
+                            ios_icon_name="chevron.right"
+                            android_material_icon_name="chevron_right"
+                            size={18}
+                            color={textSecondaryColor}
+                          />
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </View>
+                </>
+              )}
+            </View>
+          </View>
+        ) : null}
       </View>
     );
 
@@ -4201,6 +4656,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
     fieldBorderColor,
     handleAddTask,
     handleOpenAssignActivityModal,
+    handleOpenTrainerFeedbackModal,
     handleDateChange,
     handleEndDateChange,
     handleEndTimeChange,
@@ -4211,7 +4667,10 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
     isDark,
     isEditing,
     isTrainerProfile,
+    shouldShowTrainerFeedbackSection,
+    shouldShowPlayerTrainerFeedbackSection,
     isInternalActivity,
+    playerTrainerFeedback,
     recurrenceType,
     renderCategorySelector,
     renderIntensitySection,
@@ -4227,11 +4686,18 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
     latestCategoryFeedback,
     isLatestCategoryFeedbackLoading,
     isLatestFeedbackExpanded,
-      textColor,
-      textSecondaryColor,
-      toggleDay,
-      shouldShowActivityIntensityField,
-      currentActivityIntensity,
+    textColor,
+    textSecondaryColor,
+    toggleDay,
+    shouldShowActivityIntensityField,
+    currentActivityIntensity,
+    handleOpenPlayerTrainerFeedbackModal,
+    handleOpenTrainerActivityFeedbackModal,
+    isTrainerActivityFeedbackLoading,
+    latestPlayerTrainerFeedback,
+    trainerActivityFeedback,
+    trainerFeedbackPlayerOptions,
+    trainerFeedbackPlayerNamesById,
   ]);
 
   const listHeaderComponent = useMemo(() => renderListHeader(), [renderListHeader]);
@@ -4531,7 +4997,11 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
   }
 
   return (
-    <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={[styles.container, { backgroundColor: bgColor }]}>
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      style={[styles.container, { backgroundColor: bgColor }]}
+      testID="activity.details.screen"
+    >
       <LinearGradient colors={headerGradientColors} style={[styles.header, styles.v2Topbar, { paddingTop: insets.top + 8 }]}>
         <View style={styles.headerChevronWrap} pointerEvents="box-none">
           <TouchableOpacity
@@ -4772,6 +5242,171 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
               <Text style={[styles.intensityScopeModalCancelText, { color: textSecondaryColor }]}>
                 {isTemplateTaskSaving ? 'Opretter...' : 'Luk'}
               </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+
+      <Modal
+        visible={trainerFeedbackModalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={handleCloseTrainerFeedbackModal}
+      >
+        <View style={styles.intensityScopeModalBackdrop}>
+          <View style={[styles.templateTaskModalCard, { backgroundColor: cardBgColor }]}>
+            <Text style={[styles.templateTaskModalTitle, { color: textColor }]}>Spiller feedback</Text>
+            <Text style={[styles.templateTaskModalSubtitle, { color: textSecondaryColor }]}>
+              Vælg en spiller og skriv din feedback.
+            </Text>
+
+            <View
+              style={[
+                styles.trainerFeedbackPicker,
+                { borderColor: fieldBorderColor, backgroundColor: fieldBackgroundColor },
+              ]}
+              testID="trainer-feedback-player-picker"
+            >
+              <FlatList
+                data={trainerFeedbackPlayerOptions}
+                keyExtractor={(item) => item.id}
+                keyboardShouldPersistTaps="handled"
+                renderItem={({ item }) => {
+                  const isSelected = item.id === selectedTrainerFeedbackPlayerId;
+                  return (
+                    <TouchableOpacity
+                      style={[
+                        styles.trainerFeedbackPlayerRow,
+                        {
+                          borderColor: isSelected ? primaryColor : fieldBorderColor,
+                          backgroundColor: isSelected ? (isDark ? '#13253a' : '#eef6ff') : cardBgColor,
+                        },
+                      ]}
+                      activeOpacity={0.8}
+                      onPress={() => setSelectedTrainerFeedbackPlayerId(item.id)}
+                    >
+                      <Text style={[styles.trainerFeedbackPlayerName, { color: textColor }]}>{item.name}</Text>
+                      {isSelected ? (
+                        <IconSymbol
+                          ios_icon_name="checkmark.circle.fill"
+                          android_material_icon_name="check_circle"
+                          size={18}
+                          color={primaryColor}
+                        />
+                      ) : null}
+                    </TouchableOpacity>
+                  );
+                }}
+              />
+            </View>
+
+            <TextInput
+              style={[
+                styles.trainerFeedbackInput,
+                { backgroundColor: fieldBackgroundColor, borderColor: fieldBorderColor, color: textColor },
+              ]}
+              value={trainerFeedbackInput}
+              onChangeText={setTrainerFeedbackInput}
+              editable={!isTrainerFeedbackSending}
+              multiline
+              placeholder={
+                selectedTrainerFeedbackPlayer
+                  ? `Skriv feedback til ${selectedTrainerFeedbackPlayer.name}`
+                  : 'Skriv feedback'
+              }
+              placeholderTextColor={textSecondaryColor}
+              testID="trainer-feedback-input"
+            />
+
+            <TouchableOpacity
+              style={[
+                styles.activityAssignButton,
+                {
+                  backgroundColor:
+                    isTrainerFeedbackSending || !selectedTrainerFeedbackPlayerId || !trainerFeedbackInput.trim()
+                      ? fieldBorderColor
+                      : primaryColor,
+                },
+              ]}
+              activeOpacity={0.8}
+              disabled={isTrainerFeedbackSending || !selectedTrainerFeedbackPlayerId || !trainerFeedbackInput.trim()}
+              onPress={() => {
+                void handleSendTrainerFeedback();
+              }}
+              testID="trainer-feedback-send-button"
+            >
+              {isTrainerFeedbackSending ? (
+                <ActivityIndicator size="small" color="#fff" />
+              ) : (
+                <Text style={styles.activityAssignButtonText}>Send feedback</Text>
+              )}
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.intensityScopeModalCancelButton}
+              onPress={handleCloseTrainerFeedbackModal}
+              activeOpacity={0.85}
+              disabled={isTrainerFeedbackSending}
+            >
+              <Text style={[styles.intensityScopeModalCancelText, { color: textSecondaryColor }]}>Luk</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+
+      <Modal
+        visible={playerTrainerFeedbackModalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={handleClosePlayerTrainerFeedbackModal}
+      >
+        <View style={styles.intensityScopeModalBackdrop}>
+          <View style={[styles.intensityScopeModalCard, { backgroundColor: cardBgColor }]}>
+            <Text style={[styles.intensityScopeModalTitle, { color: textColor }]}>Feedback fra træner</Text>
+            {selectedPlayerTrainerFeedback?.updatedAt ? (
+              <Text style={[styles.templateTaskModalSubtitle, { color: textSecondaryColor, marginBottom: 12 }]}>
+                {`Opdateret ${formatShortDate(selectedPlayerTrainerFeedback.updatedAt)}`}
+              </Text>
+            ) : null}
+            <Text style={[styles.trainerFeedbackModalText, { color: textColor }]}>
+              {selectedPlayerTrainerFeedback?.feedbackText}
+            </Text>
+            <TouchableOpacity
+              style={[styles.activityAssignButton, { backgroundColor: primaryColor, marginTop: 16 }]}
+              onPress={handleClosePlayerTrainerFeedbackModal}
+              activeOpacity={0.85}
+            >
+              <Text style={styles.activityAssignButtonText}>Luk</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+
+      <Modal
+        visible={trainerActivityFeedbackModalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={handleCloseTrainerActivityFeedbackModal}
+      >
+        <View style={styles.intensityScopeModalBackdrop}>
+          <View style={[styles.intensityScopeModalCard, { backgroundColor: cardBgColor }]}>
+            <Text style={[styles.intensityScopeModalTitle, { color: textColor }]}>
+              {`Feedback til ${selectedTrainerActivityFeedbackPlayerName}`}
+            </Text>
+            {selectedTrainerActivityFeedback?.updatedAt ? (
+              <Text style={[styles.templateTaskModalSubtitle, { color: textSecondaryColor, marginBottom: 12 }]}>
+                {`Opdateret ${formatShortDate(selectedTrainerActivityFeedback.updatedAt)}`}
+              </Text>
+            ) : null}
+            <Text style={[styles.trainerFeedbackModalText, { color: textColor }]}>
+              {selectedTrainerActivityFeedback?.feedbackText}
+            </Text>
+            <TouchableOpacity
+              style={[styles.activityAssignButton, { backgroundColor: primaryColor, marginTop: 16 }]}
+              onPress={handleCloseTrainerActivityFeedbackModal}
+              activeOpacity={0.85}
+            >
+              <Text style={styles.activityAssignButtonText}>Luk</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -5285,6 +5920,19 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '700',
   },
+  trainerFeedbackHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  trainerFeedbackAddButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+  },
   activityAssignMessage: {
     marginTop: 6,
     fontSize: 14,
@@ -5294,6 +5942,31 @@ const styles = StyleSheet.create({
     marginTop: 8,
     fontSize: 13,
     fontWeight: '600',
+  },
+  trainerFeedbackList: {
+    marginTop: 12,
+  },
+  trainerFeedbackListItem: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  trainerFeedbackListItemTextWrap: {
+    flex: 1,
+    paddingRight: 12,
+  },
+  trainerFeedbackListItemTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  trainerFeedbackListItemMeta: {
+    marginTop: 2,
+    fontSize: 12,
+    fontWeight: '500',
   },
   activityAssignButton: {
     marginTop: 12,
@@ -5307,6 +5980,11 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 14,
     fontWeight: '800',
+  },
+  trainerFeedbackPreviewText: {
+    marginTop: 12,
+    fontSize: 14,
+    lineHeight: 20,
   },
   v2StickyCtaWrap: {
     position: 'absolute',
@@ -5684,6 +6362,40 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '500',
     paddingVertical: 12,
+  },
+  trainerFeedbackPicker: {
+    borderWidth: 1,
+    borderRadius: 12,
+    maxHeight: 190,
+    marginBottom: 12,
+    padding: 8,
+  },
+  trainerFeedbackPlayerRow: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    marginBottom: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  trainerFeedbackPlayerName: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  trainerFeedbackInput: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    fontSize: 15,
+    minHeight: 120,
+    textAlignVertical: 'top',
+  },
+  trainerFeedbackModalText: {
+    fontSize: 15,
+    lineHeight: 22,
   },
   headerChevronWrap: {
     position: 'absolute',

--- a/e2e/flows/notifications_permission_smoke.yaml
+++ b/e2e/flows/notifications_permission_smoke.yaml
@@ -166,7 +166,7 @@ tags:
           id: '^home\.activityCardButton$'
       - extendedWaitUntil:
           visible:
-            id: '^activity\.details\.task\.loaded\..+$'
+            id: '^activity\.details\.screen$'
           timeout: 15000
       - assertNotVisible:
           id: '^activity\.details\.taskLookup\.error$'

--- a/e2e/flows/role_based_ui_smoke.yaml
+++ b/e2e/flows/role_based_ui_smoke.yaml
@@ -45,6 +45,28 @@ tags:
     timeout: 15000
 - assertNotVisible:
     id: '^library\.createExerciseButton$'
+- openLink: 'footballcoach:///(tabs)/(home)'
+- extendedWaitUntil:
+    visible:
+      id: '^home\.screen$'
+    timeout: 15000
+- runFlow:
+    when:
+      visible:
+        id: '^home\.activityCardButton$'
+    commands:
+      - tapOn:
+          id: '^home\.activityCardButton$'
+          index: 0
+          point: 50%,12%
+      - extendedWaitUntil:
+          visible:
+            id: '^activity\.details\.screen$'
+          timeout: 15000
+      - assertNotVisible:
+          id: '^trainer-feedback-section$'
+      - assertNotVisible:
+          id: '^trainer-feedback-add-button$'
 
 # Trainer: trainer-only UI skal vises
 - openLink: 'footballcoach:///(tabs)/profile'
@@ -93,6 +115,33 @@ tags:
 - assertVisible:
     id: '^profile\.subscriptionPlanBadgeText$'
     text: '(?i).*træner.*'
+- openLink: 'footballcoach:///(tabs)/(home)'
+- extendedWaitUntil:
+    visible:
+      id: '^home\.screen$'
+    timeout: 15000
+- runFlow:
+    when:
+      visible:
+        id: '^home\.activityCardButton$'
+    commands:
+      - tapOn:
+          id: '^home\.activityCardButton$'
+          index: 0
+          point: 50%,12%
+      - extendedWaitUntil:
+          visible:
+            id: '^activity\.details\.screen$'
+          timeout: 15000
+      - assertVisible:
+          id: '^trainer-feedback-section$'
+      - assertVisible:
+          id: '^trainer-feedback-add-button$'
+- openLink: 'footballcoach:///(tabs)/profile'
+- extendedWaitUntil:
+    visible:
+      id: '^profile\.teamPlayersSection\.toggle$'
+    timeout: 15000
 - assertVisible:
     id: '^profile\.teamPlayersSection\.toggle$'
 - tapOn:

--- a/integrations/supabase/types.ts
+++ b/integrations/supabase/types.ts
@@ -1553,6 +1553,39 @@ export type Database = {
           },
         ]
       }
+      trainer_activity_feedback: {
+        Row: {
+          activity_context_id: string
+          activity_context_type: string
+          created_at: string
+          feedback_text: string
+          id: string
+          player_id: string
+          trainer_id: string
+          updated_at: string
+        }
+        Insert: {
+          activity_context_id: string
+          activity_context_type: string
+          created_at?: string
+          feedback_text: string
+          id?: string
+          player_id: string
+          trainer_id: string
+          updated_at?: string
+        }
+        Update: {
+          activity_context_id?: string
+          activity_context_type?: string
+          created_at?: string
+          feedback_text?: string
+          id?: string
+          player_id?: string
+          trainer_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       trophies: {
         Row: {
           completed_tasks: number

--- a/services/trainerFeedbackService.ts
+++ b/services/trainerFeedbackService.ts
@@ -1,0 +1,164 @@
+import { supabase } from '@/integrations/supabase/client';
+import type { Activity, TrainerActivityFeedback } from '@/types';
+
+type TrainerFeedbackActivityContext = {
+  activityContextType: 'internal' | 'external';
+  activityContextId: string;
+};
+
+function normalizeId(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+}
+
+function pickRowValue(row: Record<string, unknown>, snakeKey: string, camelKey: string): unknown {
+  return row[snakeKey] ?? row[camelKey];
+}
+
+export function mapTrainerFeedbackRow(row: any): TrainerActivityFeedback {
+  const normalizedRow = (row ?? {}) as Record<string, unknown>;
+
+  return {
+    id: String(normalizedRow.id ?? ''),
+    activityContextType:
+      pickRowValue(normalizedRow, 'activity_context_type', 'activityContextType') === 'external'
+        ? 'external'
+        : 'internal',
+    activityContextId: String(
+      pickRowValue(normalizedRow, 'activity_context_id', 'activityContextId') ?? '',
+    ),
+    playerId: String(pickRowValue(normalizedRow, 'player_id', 'playerId') ?? ''),
+    trainerId: String(pickRowValue(normalizedRow, 'trainer_id', 'trainerId') ?? ''),
+    feedbackText: String(pickRowValue(normalizedRow, 'feedback_text', 'feedbackText') ?? ''),
+    createdAt: String(pickRowValue(normalizedRow, 'created_at', 'createdAt') ?? ''),
+    updatedAt: String(pickRowValue(normalizedRow, 'updated_at', 'updatedAt') ?? ''),
+  };
+}
+
+export function resolveTrainerFeedbackActivityContext(
+  activity: Activity | Record<string, unknown> | null | undefined
+): TrainerFeedbackActivityContext | null {
+  if (!activity) return null;
+  const activityAny = activity as any;
+
+  const isExternal = activityAny.isExternal === true || activityAny.is_external === true;
+  if (isExternal) {
+    const externalEventId = normalizeId(
+      activityAny.externalEventId ?? activityAny.external_event_id
+    );
+    if (!externalEventId) return null;
+    return {
+      activityContextType: 'external',
+      activityContextId: externalEventId,
+    };
+  }
+
+  const sourceActivityId = normalizeId(
+    activityAny.sourceActivityId ?? activityAny.source_activity_id
+  );
+  const internalActivityId = normalizeId(activityAny.id);
+  const activityContextId = sourceActivityId || internalActivityId;
+  if (!activityContextId) return null;
+
+  return {
+    activityContextType: 'internal',
+    activityContextId,
+  };
+}
+
+export async function fetchTrainerFeedbackForTrainerActivity(args: {
+  activity: Activity | Record<string, unknown> | null | undefined;
+  trainerId: string;
+}): Promise<TrainerActivityFeedback[]> {
+  const trainerId = normalizeId(args.trainerId);
+  const context = resolveTrainerFeedbackActivityContext(args.activity);
+
+  if (!trainerId || !context) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from('trainer_activity_feedback')
+    .select('*')
+    .eq('trainer_id', trainerId)
+    .eq('activity_context_type', context.activityContextType)
+    .eq('activity_context_id', context.activityContextId)
+    .order('updated_at', { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return Array.isArray(data) ? data.map((row) => mapTrainerFeedbackRow(row)) : [];
+}
+
+export async function fetchTrainerFeedbackForPlayerActivity(args: {
+  activity: Activity | Record<string, unknown> | null | undefined;
+  playerId: string;
+}): Promise<TrainerActivityFeedback[]> {
+  const playerId = normalizeId(args.playerId);
+  const context = resolveTrainerFeedbackActivityContext(args.activity);
+
+  if (!playerId || !context) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from('trainer_activity_feedback')
+    .select('*')
+    .eq('player_id', playerId)
+    .eq('activity_context_type', context.activityContextType)
+    .eq('activity_context_id', context.activityContextId)
+    .order('updated_at', { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return Array.isArray(data) ? data.map((row) => mapTrainerFeedbackRow(row)) : [];
+}
+
+export async function sendTrainerFeedback(args: {
+  activityId: string;
+  playerId: string;
+  feedbackText: string;
+}): Promise<{
+  feedback: TrainerActivityFeedback;
+  delivery: {
+    mail: {
+      status: 'sent' | 'skipped' | 'failed';
+      provider: 'aws_ses' | 'none';
+      warning: string | null;
+    };
+    push: {
+      status: 'sent' | 'skipped' | 'failed';
+      tokenCount: number;
+      warning: string | null;
+    };
+  };
+}> {
+  const { data, error } = await supabase.functions.invoke('sendTrainerFeedback', {
+    body: {
+      activityId: normalizeId(args.activityId),
+      playerId: normalizeId(args.playerId),
+      feedbackText: String(args.feedbackText ?? '').trim(),
+    },
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  const payload = (data as any)?.data ?? data;
+  if (!payload?.feedback) {
+    throw new Error('Trainer feedback response was missing feedback payload.');
+  }
+
+  return {
+    feedback: mapTrainerFeedbackRow(payload.feedback),
+    delivery: {
+      mail: payload.delivery?.mail,
+      push: payload.delivery?.push,
+    },
+  };
+}

--- a/supabase/functions/_shared/trainerFeedbackDelivery.ts
+++ b/supabase/functions/_shared/trainerFeedbackDelivery.ts
@@ -1,0 +1,516 @@
+// @ts-ignore Deno edge functions require explicit file extensions for relative imports.
+import { AppError } from './http.ts';
+
+const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
+
+type QueryBuilder<T> = PromiseLike<{ data: T[] | null; error: unknown | null }> & {
+  select: (columns: string) => QueryBuilder<T>;
+  eq: (column: string, value: unknown) => QueryBuilder<T>;
+};
+
+type PushDeliveryClient = {
+  from: (table: string) => QueryBuilder<{ expo_push_token: string | null }>;
+};
+
+export type TrainerFeedbackPushPayload = {
+  title: string;
+  body: string;
+  data: Record<string, unknown>;
+};
+
+export type TrainerFeedbackEmailConfig = {
+  appName: string;
+  appScheme: string;
+  fromEmail: string;
+  fromName: string;
+  awsRegion: string;
+  awsAccessKeyId: string;
+  awsSecretAccessKey: string;
+  awsSessionToken: string | null;
+};
+
+export type TrainerFeedbackEmailContent = {
+  subject: string;
+  html: string;
+  text: string;
+};
+
+export type TrainerFeedbackPushDeliveryResult = {
+  status: 'sent' | 'skipped' | 'failed';
+  tokenCount: number;
+  warning: string | null;
+};
+
+export type TrainerFeedbackEmailDeliveryResult = {
+  status: 'sent' | 'skipped' | 'failed';
+  provider: 'aws_ses' | 'none';
+  warning: string | null;
+};
+
+type TrainerFeedbackEmailConfigResolution = {
+  config: TrainerFeedbackEmailConfig | null;
+  missing: string[];
+};
+
+function getEnv(name: string): string | null {
+  const deno = (globalThis as { Deno?: { env?: { get: (key: string) => string | undefined } } }).Deno;
+  if (deno?.env) {
+    return deno.env.get(name)?.trim() ?? null;
+  }
+
+  const nodeProcess = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+  if (nodeProcess?.env) {
+    return nodeProcess.env[name]?.trim() ?? null;
+  }
+
+  return null;
+}
+
+function optionalEnv(primary: string, fallback: string | null): string {
+  return getEnv(primary) ?? fallback ?? '';
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function sanitizeLabel(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : fallback;
+}
+
+function truncate(value: string, maxLength: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+function formatFeedbackHtml(feedbackText: string): string {
+  return escapeHtml(feedbackText).replace(/\n/g, '<br />');
+}
+
+export function buildTrainerFeedbackPath(activityId: string): string {
+  const normalizedActivityId = String(activityId ?? '').trim();
+  if (!normalizedActivityId) {
+    throw new Error('Missing activityId for trainer feedback deeplink.');
+  }
+
+  const params = new URLSearchParams({
+    id: normalizedActivityId,
+    activityId: normalizedActivityId,
+  });
+  return `/activity-details?${params.toString()}`;
+}
+
+export function buildTrainerFeedbackAppUrl(activityId: string, appScheme = 'footballcoach'): string {
+  const normalizedScheme = sanitizeLabel(appScheme, 'footballcoach');
+  return new URL(buildTrainerFeedbackPath(activityId), `${normalizedScheme}://`).toString();
+}
+
+export function buildTrainerFeedbackPushPayload(args: {
+  activityId: string;
+  activityTitle?: string | null;
+  trainerName?: string | null;
+  feedbackText: string;
+}): TrainerFeedbackPushPayload {
+  const trainerName = sanitizeLabel(args.trainerName, 'Din træner');
+  const activityTitle = sanitizeLabel(args.activityTitle, 'aktiviteten');
+  const feedbackPreview = truncate(String(args.feedbackText ?? ''), 120);
+
+  return {
+    title: 'Ny feedback fra træner',
+    body: `${trainerName} har sendt feedback på ${activityTitle}.`,
+    data: {
+      type: 'trainer-feedback',
+      activityId: String(args.activityId ?? '').trim(),
+      url: buildTrainerFeedbackPath(args.activityId),
+      feedbackPreview,
+    },
+  };
+}
+
+export function buildTrainerFeedbackEmailContent(
+  args: {
+    activityId: string;
+    activityTitle?: string | null;
+    trainerName?: string | null;
+    feedbackText: string;
+  },
+  config: Pick<TrainerFeedbackEmailConfig, 'appName' | 'appScheme'>
+): TrainerFeedbackEmailContent {
+  const trainerName = sanitizeLabel(args.trainerName, 'Din træner');
+  const activityTitle = sanitizeLabel(args.activityTitle, 'aktiviteten');
+  const appName = sanitizeLabel(config.appName, 'Footy Trainer');
+  const activityUrl = buildTrainerFeedbackAppUrl(args.activityId, config.appScheme);
+  const safeTrainerName = escapeHtml(trainerName);
+  const safeActivityTitle = escapeHtml(activityTitle);
+  const safeAppName = escapeHtml(appName);
+  const safeActivityUrl = escapeHtml(activityUrl);
+  const safeFeedbackText = formatFeedbackHtml(String(args.feedbackText ?? '').trim());
+
+  return {
+    subject: 'Ny feedback fra din træner',
+    html: `
+      <div style="font-family: Arial, sans-serif; line-height: 1.5; color: #111827;">
+        <p>Hej,</p>
+        <p>Du har modtaget ny feedback fra <strong>${safeTrainerName}</strong> i ${safeAppName}.</p>
+        <p><strong>Aktivitet:</strong> ${safeActivityTitle}</p>
+        <div style="margin: 16px 0; padding: 16px; border-radius: 12px; background: #f3f4f6;">
+          <div style="font-weight: 700; margin-bottom: 8px;">Feedback</div>
+          <div>${safeFeedbackText}</div>
+        </div>
+        <p style="margin: 24px 0;">
+          <a
+            href="${safeActivityUrl}"
+            style="display: inline-block; background: #111827; color: #ffffff; text-decoration: none; padding: 12px 18px; border-radius: 8px;"
+          >
+            Åbn aktivitet i appen
+          </a>
+        </p>
+        <p>Hvis knappen ikke virker, kan du bruge dette link direkte:</p>
+        <p><a href="${safeActivityUrl}">${safeActivityUrl}</a></p>
+      </div>
+    `.trim(),
+    text: [
+      `Du har modtaget ny feedback fra ${trainerName} i ${appName}.`,
+      `Aktivitet: ${activityTitle}`,
+      '',
+      'Feedback:',
+      String(args.feedbackText ?? '').trim(),
+      '',
+      `Åbn aktivitet i appen: ${activityUrl}`,
+    ].join('\n'),
+  };
+}
+
+export function getTrainerFeedbackEmailConfigFromEnv(): TrainerFeedbackEmailConfigResolution {
+  const fromEmail =
+    getEnv('TRAINER_FEEDBACK_FROM_EMAIL') ??
+    getEnv('CLUB_INVITE_FROM_EMAIL');
+  const requiredEnv = {
+    fromEmail,
+    awsRegion: getEnv('AWS_SES_REGION'),
+    awsAccessKeyId: getEnv('AWS_SES_ACCESS_KEY_ID'),
+    awsSecretAccessKey: getEnv('AWS_SES_SECRET_ACCESS_KEY'),
+  } as const;
+
+  const missing = Object.entries(requiredEnv)
+    .filter(([, value]) => !value)
+    .map(([key]) => {
+      switch (key) {
+        case 'fromEmail':
+          return 'TRAINER_FEEDBACK_FROM_EMAIL/CLUB_INVITE_FROM_EMAIL';
+        case 'awsRegion':
+          return 'AWS_SES_REGION';
+        case 'awsAccessKeyId':
+          return 'AWS_SES_ACCESS_KEY_ID';
+        case 'awsSecretAccessKey':
+          return 'AWS_SES_SECRET_ACCESS_KEY';
+        default:
+          return key;
+      }
+    });
+
+  if (missing.length > 0) {
+    return {
+      config: null,
+      missing,
+    };
+  }
+
+  return {
+    config: {
+      appName: optionalEnv('TRAINER_FEEDBACK_APP_NAME', getEnv('CLUB_INVITE_APP_NAME') ?? 'Footy Trainer'),
+      appScheme: optionalEnv('TRAINER_FEEDBACK_APP_SCHEME', 'footballcoach'),
+      fromEmail: requiredEnv.fromEmail!,
+      fromName: optionalEnv('TRAINER_FEEDBACK_FROM_NAME', getEnv('CLUB_INVITE_FROM_NAME') ?? 'Footy Trainer'),
+      awsRegion: requiredEnv.awsRegion!,
+      awsAccessKeyId: requiredEnv.awsAccessKeyId!,
+      awsSecretAccessKey: requiredEnv.awsSecretAccessKey!,
+      awsSessionToken: getEnv('AWS_SES_SESSION_TOKEN'),
+    },
+    missing: [],
+  };
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const encoded = new TextEncoder().encode(value);
+  const hash = await crypto.subtle.digest('SHA-256', encoded);
+  return toHex(hash);
+}
+
+async function hmacSha256(key: Uint8Array, value: string): Promise<Uint8Array> {
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    Uint8Array.from(key).buffer,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(value));
+  return new Uint8Array(signature);
+}
+
+function formatAmzDate(date: Date): { amzDate: string; dateStamp: string } {
+  const iso = date.toISOString().replace(/[:-]|\.\d{3}/g, '');
+  return {
+    amzDate: iso,
+    dateStamp: iso.slice(0, 8),
+  };
+}
+
+async function createAwsSesAuthorizationHeader(
+  payload: string,
+  headers: Record<string, string>,
+  signingDate: { amzDate: string; dateStamp: string },
+  config: Pick<TrainerFeedbackEmailConfig, 'awsAccessKeyId' | 'awsSecretAccessKey' | 'awsRegion'>
+): Promise<string> {
+  const canonicalHeaders = Object.entries(headers)
+    .map(([key, value]) => [key.toLowerCase(), value.trim().replace(/\s+/g, ' ')] as const)
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  const signedHeaders = canonicalHeaders.map(([key]) => key).join(';');
+  const canonicalHeadersString = canonicalHeaders
+    .map(([key, value]) => `${key}:${value}\n`)
+    .join('');
+
+  const canonicalRequest = [
+    'POST',
+    '/v2/email/outbound-emails',
+    '',
+    canonicalHeadersString,
+    signedHeaders,
+    await sha256Hex(payload),
+  ].join('\n');
+
+  const credentialScope = `${signingDate.dateStamp}/${config.awsRegion}/ses/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    signingDate.amzDate,
+    credentialScope,
+    await sha256Hex(canonicalRequest),
+  ].join('\n');
+
+  const secretKey = new TextEncoder().encode(`AWS4${config.awsSecretAccessKey}`);
+  const dateKey = await hmacSha256(secretKey, signingDate.dateStamp);
+  const regionKey = await hmacSha256(dateKey, config.awsRegion);
+  const serviceKey = await hmacSha256(regionKey, 'ses');
+  const signingKey = await hmacSha256(serviceKey, 'aws4_request');
+  const signature = toHex(Uint8Array.from(await hmacSha256(signingKey, stringToSign)).buffer);
+
+  return [
+    `AWS4-HMAC-SHA256 Credential=${config.awsAccessKeyId}/${credentialScope}`,
+    `SignedHeaders=${signedHeaders}`,
+    `Signature=${signature}`,
+  ].join(', ');
+}
+
+async function sendWithAwsSes(
+  content: TrainerFeedbackEmailContent,
+  recipientEmail: string,
+  config: Pick<
+    TrainerFeedbackEmailConfig,
+    'fromEmail' | 'fromName' | 'awsRegion' | 'awsAccessKeyId' | 'awsSecretAccessKey' | 'awsSessionToken'
+  >
+): Promise<void> {
+  const payload = JSON.stringify({
+    FromEmailAddress: `${config.fromName} <${config.fromEmail}>`,
+    Destination: {
+      ToAddresses: [recipientEmail],
+    },
+    Content: {
+      Simple: {
+        Subject: {
+          Data: content.subject,
+          Charset: 'UTF-8',
+        },
+        Body: {
+          Html: {
+            Data: content.html,
+            Charset: 'UTF-8',
+          },
+          Text: {
+            Data: content.text,
+            Charset: 'UTF-8',
+          },
+        },
+      },
+    },
+  });
+
+  const payloadHash = await sha256Hex(payload);
+  const signingDate = formatAmzDate(new Date());
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    host: `email.${config.awsRegion}.amazonaws.com`,
+    'x-amz-content-sha256': payloadHash,
+    'x-amz-date': signingDate.amzDate,
+  };
+
+  if (config.awsSessionToken) {
+    headers['x-amz-security-token'] = config.awsSessionToken;
+  }
+
+  headers.authorization = await createAwsSesAuthorizationHeader(payload, headers, signingDate, config);
+
+  const response = await fetch(`https://email.${config.awsRegion}.amazonaws.com/v2/email/outbound-emails`, {
+    method: 'POST',
+    headers: {
+      Authorization: headers.authorization,
+      'Content-Type': headers['content-type'],
+      Host: headers.host,
+      'X-Amz-Content-Sha256': headers['x-amz-content-sha256'],
+      'X-Amz-Date': headers['x-amz-date'],
+      ...(config.awsSessionToken ? { 'X-Amz-Security-Token': config.awsSessionToken } : {}),
+    },
+    body: payload,
+  });
+
+  if (!response.ok) {
+    const failureBody = await response.text();
+    const normalizedMessage = failureBody.replace(/\s+/g, ' ').trim();
+    throw new AppError(
+      'INTERNAL_ERROR',
+      normalizedMessage ? `Could not send trainer feedback email: ${normalizedMessage}` : 'Could not send trainer feedback email.',
+      500
+    );
+  }
+}
+
+export async function deliverTrainerFeedbackEmail(
+  recipientEmail: string,
+  args: {
+    activityId: string;
+    activityTitle?: string | null;
+    trainerName?: string | null;
+    feedbackText: string;
+  },
+  options?: {
+    config?: TrainerFeedbackEmailConfig;
+  }
+): Promise<TrainerFeedbackEmailDeliveryResult> {
+  const configResolution = options?.config
+    ? { config: options.config, missing: [] }
+    : getTrainerFeedbackEmailConfigFromEnv();
+  const config = configResolution.config;
+
+  if (!config) {
+    return {
+      status: 'skipped',
+      provider: 'none',
+      warning: `Trainer feedback email skipped: missing ${configResolution.missing.join(', ')}.`,
+    };
+  }
+
+  const content = buildTrainerFeedbackEmailContent(args, config);
+
+  try {
+    await sendWithAwsSes(content, recipientEmail, config);
+    return {
+      status: 'sent',
+      provider: 'aws_ses',
+      warning: null,
+    };
+  } catch (error) {
+    console.error('[trainer-feedback-delivery] email failed', error);
+    return {
+      status: 'failed',
+      provider: 'aws_ses',
+      warning:
+        error instanceof AppError
+          ? `Trainer feedback email send failed: ${error.message}`
+          : 'Trainer feedback email send failed.',
+    };
+  }
+}
+
+export async function deliverTrainerFeedbackPush(
+  client: PushDeliveryClient,
+  userId: string,
+  payload: TrainerFeedbackPushPayload
+): Promise<TrainerFeedbackPushDeliveryResult> {
+  try {
+    const builder = client
+      .from('user_push_tokens')
+      .select('expo_push_token')
+      .eq('user_id', userId);
+    const { data: tokenRows, error: tokenError } = await builder;
+
+    if (tokenError) {
+      console.error('[trainer-feedback-delivery] failed to load push tokens', tokenError);
+      return {
+        status: 'failed',
+        tokenCount: 0,
+        warning: 'Could not load push tokens.',
+      };
+    }
+
+    const tokens = (tokenRows ?? [])
+      .map((row: any) => row?.expo_push_token)
+      .filter((token: unknown): token is string => typeof token === 'string' && token.startsWith('ExponentPushToken'));
+
+    if (!tokens.length) {
+      return {
+        status: 'skipped',
+        tokenCount: 0,
+        warning: 'No push tokens for player.',
+      };
+    }
+
+    const messages = tokens.map((to) => ({
+      to,
+      sound: 'default',
+      title: payload.title,
+      body: payload.body,
+      data: payload.data,
+      priority: 'high',
+    }));
+
+    const pushResponse = await fetch(EXPO_PUSH_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(messages),
+    });
+
+    if (!pushResponse.ok) {
+      const pushText = await pushResponse.text();
+      console.error('[trainer-feedback-delivery] expo push failed', {
+        status: pushResponse.status,
+        body: pushText,
+      });
+      return {
+        status: 'failed',
+        tokenCount: tokens.length,
+        warning: 'Expo push send failed.',
+      };
+    }
+
+    return {
+      status: 'sent',
+      tokenCount: tokens.length,
+      warning: null,
+    };
+  } catch (error) {
+    console.error('[trainer-feedback-delivery] unexpected push failure', error);
+    return {
+      status: 'failed',
+      tokenCount: 0,
+      warning: 'Unexpected push error.',
+    };
+  }
+}

--- a/supabase/functions/sendTrainerFeedback/index.ts
+++ b/supabase/functions/sendTrainerFeedback/index.ts
@@ -1,0 +1,406 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { requireAuthContext } from '../_shared/auth.ts';
+import {
+  buildTrainerFeedbackPushPayload,
+  deliverTrainerFeedbackEmail,
+  deliverTrainerFeedbackPush,
+} from '../_shared/trainerFeedbackDelivery.ts';
+import {
+  AppError,
+  optionsResponse,
+  readJsonBody,
+  responseFromError,
+  successResponse,
+} from '../_shared/http.ts';
+
+type RequestBody = {
+  activityId?: unknown;
+  playerId?: unknown;
+  feedbackText?: unknown;
+};
+
+type ActivityContext = {
+  activityContextType: 'internal' | 'external';
+  activityContextId: string;
+  activityTitle: string;
+  recipientActivityId: string;
+};
+
+function normalizeId(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+}
+
+function requireId(label: string, value: unknown): string {
+  const normalized = normalizeId(value);
+  if (!normalized) {
+    throw new AppError('VALIDATION_ERROR', `Missing ${label}.`, 400);
+  }
+  return normalized;
+}
+
+function requireFeedbackText(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new AppError('VALIDATION_ERROR', 'feedbackText must be a string.', 400);
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new AppError('VALIDATION_ERROR', 'feedbackText cannot be empty.', 400);
+  }
+
+  return normalized;
+}
+
+async function requireTrainerRole(serviceClient: any, userId: string): Promise<void> {
+  const { data, error } = await serviceClient
+    .from('user_roles')
+    .select('role')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new AppError('INTERNAL_ERROR', 'Could not resolve user role.', 500);
+  }
+
+  const role = typeof data?.role === 'string' ? data.role.toLowerCase() : '';
+  if (role !== 'trainer' && role !== 'admin') {
+    throw new AppError('FORBIDDEN', 'Only trainers can send player feedback.', 403);
+  }
+}
+
+async function resolveTrainerName(serviceClient: any, userId: string, fallbackEmail: string | null): Promise<string> {
+  try {
+    const { data } = await serviceClient
+      .from('profiles')
+      .select('full_name')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    const fullName = typeof data?.full_name === 'string' ? data.full_name.trim() : '';
+    if (fullName) return fullName;
+  } catch {
+    // Fall through to email fallback.
+  }
+
+  const emailPrefix = typeof fallbackEmail === 'string' ? fallbackEmail.split('@')[0]?.trim() : '';
+  return emailPrefix || 'Din træner';
+}
+
+async function resolvePlayerEmail(serviceClient: any, playerId: string): Promise<string> {
+  const { data, error } = await serviceClient.auth.admin.getUserById(playerId);
+  if (error) {
+    throw new AppError('INTERNAL_ERROR', 'Could not resolve player email.', 500);
+  }
+
+  const email = typeof data?.user?.email === 'string' ? data.user.email.trim().toLowerCase() : '';
+  if (!email) {
+    throw new AppError('INTERNAL_ERROR', 'Player email is missing.', 500);
+  }
+
+  return email;
+}
+
+async function resolveInternalActivityContext(args: {
+  serviceClient: any;
+  trainerId: string;
+  activityId: string;
+  playerId: string;
+}): Promise<ActivityContext | null> {
+  const { serviceClient, trainerId, activityId, playerId } = args;
+  const { data: activityRow, error: activityError } = await serviceClient
+    .from('activities')
+    .select('id, title, user_id, is_external, source_activity_id')
+    .eq('id', activityId)
+    .maybeSingle();
+
+  if (activityError) {
+    throw new AppError('INTERNAL_ERROR', 'Could not load activity.', 500);
+  }
+
+  if (!activityRow || activityRow.is_external === true) {
+    return null;
+  }
+
+  let sourceActivityId = '';
+  let activityTitle = typeof activityRow.title === 'string' ? activityRow.title.trim() : 'Aktivitet';
+
+  if (activityRow.user_id === trainerId && !activityRow.source_activity_id) {
+    sourceActivityId = String(activityRow.id);
+  } else if (activityRow.source_activity_id) {
+    const { data: sourceRow, error: sourceError } = await serviceClient
+      .from('activities')
+      .select('id, title, user_id, is_external')
+      .eq('id', activityRow.source_activity_id)
+      .eq('user_id', trainerId)
+      .eq('is_external', false)
+      .maybeSingle();
+
+    if (sourceError) {
+      throw new AppError('INTERNAL_ERROR', 'Could not load source activity.', 500);
+    }
+
+    if (!sourceRow) {
+      return null;
+    }
+
+    sourceActivityId = String(sourceRow.id);
+    activityTitle = typeof sourceRow.title === 'string' && sourceRow.title.trim() ? sourceRow.title.trim() : activityTitle;
+  } else {
+    return null;
+  }
+
+  const { data: recipientRow, error: recipientError } = await serviceClient
+    .from('activities')
+    .select('id')
+    .eq('source_activity_id', sourceActivityId)
+    .eq('user_id', playerId)
+    .eq('is_external', false)
+    .maybeSingle();
+
+  if (recipientError) {
+    throw new AppError('INTERNAL_ERROR', 'Could not resolve player activity.', 500);
+  }
+
+  if (!recipientRow?.id) {
+    throw new AppError('FORBIDDEN', 'Player is not attached to this activity.', 403);
+  }
+
+  return {
+    activityContextType: 'internal',
+    activityContextId: sourceActivityId,
+    activityTitle,
+    recipientActivityId: String(recipientRow.id),
+  };
+}
+
+async function resolveExternalActivityContext(args: {
+  serviceClient: any;
+  trainerId: string;
+  activityId: string;
+  playerId: string;
+}): Promise<ActivityContext | null> {
+  const { serviceClient, trainerId, activityId, playerId } = args;
+
+  const { data: localMetaRow, error: localMetaError } = await serviceClient
+    .from('events_local_meta')
+    .select(`
+      id,
+      user_id,
+      external_event_id,
+      source_local_meta_id,
+      local_title_override,
+      events_external (
+        id,
+        title
+      )
+    `)
+    .eq('id', activityId)
+    .maybeSingle();
+
+  if (localMetaError) {
+    throw new AppError('INTERNAL_ERROR', 'Could not load external activity.', 500);
+  }
+
+  let externalEventId = '';
+  let activityTitle = 'Aktivitet';
+
+  if (localMetaRow) {
+    activityTitle =
+      typeof localMetaRow.local_title_override === 'string' && localMetaRow.local_title_override.trim()
+        ? localMetaRow.local_title_override.trim()
+        : typeof localMetaRow.events_external?.title === 'string' && localMetaRow.events_external.title.trim()
+          ? localMetaRow.events_external.title.trim()
+          : activityTitle;
+
+    if (localMetaRow.user_id === trainerId && localMetaRow.external_event_id) {
+      externalEventId = String(localMetaRow.external_event_id);
+    } else if (localMetaRow.source_local_meta_id) {
+      const { data: sourceMetaRow, error: sourceMetaError } = await serviceClient
+        .from('events_local_meta')
+        .select(`
+          id,
+          user_id,
+          external_event_id,
+          local_title_override,
+          events_external (
+            id,
+            title
+          )
+        `)
+        .eq('id', localMetaRow.source_local_meta_id)
+        .eq('user_id', trainerId)
+        .maybeSingle();
+
+      if (sourceMetaError) {
+        throw new AppError('INTERNAL_ERROR', 'Could not load source external activity.', 500);
+      }
+
+      if (!sourceMetaRow?.external_event_id) {
+        return null;
+      }
+
+      externalEventId = String(sourceMetaRow.external_event_id);
+      activityTitle =
+        typeof sourceMetaRow.local_title_override === 'string' && sourceMetaRow.local_title_override.trim()
+          ? sourceMetaRow.local_title_override.trim()
+          : typeof sourceMetaRow.events_external?.title === 'string' && sourceMetaRow.events_external.title.trim()
+            ? sourceMetaRow.events_external.title.trim()
+            : activityTitle;
+    }
+  }
+
+  if (!externalEventId) {
+    const { data: externalEventRow, error: externalEventError } = await serviceClient
+      .from('events_external')
+      .select(`
+        id,
+        title,
+        provider_calendar_id,
+        external_calendars!inner (
+          id,
+          user_id
+        )
+      `)
+      .eq('id', activityId)
+      .maybeSingle();
+
+    if (externalEventError) {
+      throw new AppError('INTERNAL_ERROR', 'Could not load source external event.', 500);
+    }
+
+    if (!externalEventRow || externalEventRow.external_calendars?.user_id !== trainerId) {
+      return null;
+    }
+
+    externalEventId = String(externalEventRow.id);
+    activityTitle =
+      typeof externalEventRow.title === 'string' && externalEventRow.title.trim()
+        ? externalEventRow.title.trim()
+        : activityTitle;
+  }
+
+  const { data: recipientRow, error: recipientError } = await serviceClient
+    .from('events_local_meta')
+    .select('id')
+    .eq('external_event_id', externalEventId)
+    .eq('user_id', playerId)
+    .maybeSingle();
+
+  if (recipientError) {
+    throw new AppError('INTERNAL_ERROR', 'Could not resolve player external activity.', 500);
+  }
+
+  if (!recipientRow?.id) {
+    throw new AppError('FORBIDDEN', 'Player is not attached to this activity.', 403);
+  }
+
+  return {
+    activityContextType: 'external',
+    activityContextId: externalEventId,
+    activityTitle,
+    recipientActivityId: String(recipientRow.id),
+  };
+}
+
+async function resolveActivityContext(args: {
+  serviceClient: any;
+  trainerId: string;
+  activityId: string;
+  playerId: string;
+}): Promise<ActivityContext> {
+  const internalContext = await resolveInternalActivityContext(args);
+  if (internalContext) return internalContext;
+
+  const externalContext = await resolveExternalActivityContext(args);
+  if (externalContext) return externalContext;
+
+  throw new AppError('FORBIDDEN', 'Activity not found or not allowed for this trainer.', 403);
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return optionsResponse();
+  }
+
+  try {
+    const { serviceClient, userId, userEmail } = await requireAuthContext(req);
+    await requireTrainerRole(serviceClient, userId);
+
+    const body = (await readJsonBody(req)) as RequestBody;
+    const activityId = requireId('activityId', body.activityId);
+    const playerId = requireId('playerId', body.playerId);
+    const feedbackText = requireFeedbackText(body.feedbackText);
+
+    if (playerId === userId) {
+      throw new AppError('VALIDATION_ERROR', 'Trainer feedback cannot target the trainer.', 400);
+    }
+
+    const activityContext = await resolveActivityContext({
+      serviceClient,
+      trainerId: userId,
+      activityId,
+      playerId,
+    });
+
+    const { data: savedRow, error: saveError } = await serviceClient
+      .from('trainer_activity_feedback')
+      .upsert(
+        {
+          activity_context_type: activityContext.activityContextType,
+          activity_context_id: activityContext.activityContextId,
+          player_id: playerId,
+          trainer_id: userId,
+          feedback_text: feedbackText,
+        },
+        {
+          onConflict: 'activity_context_type,activity_context_id,player_id,trainer_id',
+        }
+      )
+      .select('*')
+      .single();
+
+    if (saveError || !savedRow) {
+      throw new AppError('INTERNAL_ERROR', 'Could not save trainer feedback.', 500);
+    }
+
+    const trainerName = await resolveTrainerName(serviceClient, userId, userEmail);
+    const playerEmail = await resolvePlayerEmail(serviceClient, playerId);
+
+    const pushPayload = buildTrainerFeedbackPushPayload({
+      activityId: activityContext.recipientActivityId,
+      activityTitle: activityContext.activityTitle,
+      trainerName,
+      feedbackText,
+    });
+
+    const [mailDelivery, pushDelivery] = await Promise.all([
+      deliverTrainerFeedbackEmail(playerEmail, {
+        activityId: activityContext.recipientActivityId,
+        activityTitle: activityContext.activityTitle,
+        trainerName,
+        feedbackText,
+      }),
+      deliverTrainerFeedbackPush(serviceClient, playerId, pushPayload),
+    ]);
+
+    return successResponse({
+      feedback: {
+        id: String(savedRow.id),
+        activityContextType: String(savedRow.activity_context_type),
+        activityContextId: String(savedRow.activity_context_id),
+        playerId: String(savedRow.player_id),
+        trainerId: String(savedRow.trainer_id),
+        feedbackText: String(savedRow.feedback_text),
+        createdAt: String(savedRow.created_at),
+        updatedAt: String(savedRow.updated_at),
+      },
+      delivery: {
+        mail: mailDelivery,
+        push: pushDelivery,
+      },
+    });
+  } catch (error) {
+    return responseFromError(error);
+  }
+});

--- a/supabase/migrations/20260313120000_trainer_activity_feedback.sql
+++ b/supabase/migrations/20260313120000_trainer_activity_feedback.sql
@@ -1,0 +1,49 @@
+create table if not exists public.trainer_activity_feedback (
+  id uuid primary key default gen_random_uuid(),
+  activity_context_type text not null
+    check (activity_context_type in ('internal', 'external')),
+  activity_context_id uuid not null,
+  player_id uuid not null references auth.users(id) on delete cascade,
+  trainer_id uuid not null references auth.users(id) on delete cascade,
+  feedback_text text not null
+    check (length(btrim(feedback_text)) > 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint trainer_activity_feedback_context_player_trainer_key
+    unique (activity_context_type, activity_context_id, player_id, trainer_id)
+);
+
+create index if not exists trainer_activity_feedback_player_context_idx
+  on public.trainer_activity_feedback (player_id, activity_context_type, activity_context_id);
+
+create index if not exists trainer_activity_feedback_trainer_context_idx
+  on public.trainer_activity_feedback (trainer_id, activity_context_type, activity_context_id);
+
+alter table public.trainer_activity_feedback enable row level security;
+
+drop policy if exists "Players can read own trainer feedback" on public.trainer_activity_feedback;
+create policy "Players can read own trainer feedback"
+  on public.trainer_activity_feedback
+  for select
+  using (player_id = auth.uid());
+
+drop policy if exists "Trainers can read own trainer feedback" on public.trainer_activity_feedback;
+create policy "Trainers can read own trainer feedback"
+  on public.trainer_activity_feedback
+  for select
+  using (trainer_id = auth.uid());
+
+drop policy if exists "Service role can manage trainer feedback" on public.trainer_activity_feedback;
+create policy "Service role can manage trainer feedback"
+  on public.trainer_activity_feedback
+  using ((auth.jwt() ->> 'role') = 'service_role')
+  with check ((auth.jwt() ->> 'role') = 'service_role');
+
+drop trigger if exists update_trainer_activity_feedback_timestamp on public.trainer_activity_feedback;
+create trigger update_trainer_activity_feedback_timestamp
+  before update on public.trainer_activity_feedback
+  for each row
+  execute function public.trigger_update_timestamp();
+
+grant select on public.trainer_activity_feedback to authenticated;
+grant all on public.trainer_activity_feedback to service_role;

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,6 +18,11 @@ export interface Activity {
   externalCategory?: string;
   seriesId?: string;
   seriesInstanceDate?: Date;
+  sourceActivityId?: string | null;
+  source_activity_id?: string | null;
+  user_id?: string | null;
+  player_id?: string | null;
+  team_id?: string | null;
 }
 
 export interface ActivityCategory {
@@ -173,6 +178,17 @@ export interface TaskTemplateSelfFeedback {
   activityId: string;
   rating?: number | null;
   note?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TrainerActivityFeedback {
+  id: string;
+  activityContextType: 'internal' | 'external';
+  activityContextId: string;
+  playerId: string;
+  trainerId: string;
+  feedbackText: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
Closes #255

## Summary
Implementerer end-to-end feature til “Feedback fra træner”.

Det inkluderer:
- trainer-UI på aktivitetssiden til at oprette feedback pr. spiller
- persistence pr. `activity + player + trainer` med timestamps
- server-side mail + push + activity deeplink
- player-UI til at læse feedback på aktiviteten
- QA-opfølgninger på login-view og player read-path for flere feedbacks

## Changes
### Trainer flow
- Tilføjer `Spiller feedback`-boks på trainerens aktivitet
- Tilføjer add-flow med spillerpicker, tekstfelt og send
- Viser eksisterende sendt feedback som klikbare rækker med modal

### Player flow
- Tilføjer `Feedback fra træner`-boks på spillerens aktivitet
- Viser kun boksen når der findes feedback
- Understøtter nu flere feedbacks på samme aktivitet for samme spiller
- Åbner valgt feedback i modal

### Backend
- Tilføjer `trainer_activity_feedback` migration med RLS
- Tilføjer `sendTrainerFeedback` edge function
- Genbruger eksisterende mail/push/deeplink-infrastruktur via shared delivery helper

### QA follow-ups
- Fjerner den brede scroll-lock workaround fra login-visningen
- Bevarer kun målrettede paste/input-props på loginfelterne
- Matcher player read-path med den faktiske datamodel i stedet for `maybeSingle()`

## Files of note
- `app/activity-details.tsx`
- `services/trainerFeedbackService.ts`
- `supabase/functions/sendTrainerFeedback/index.ts`
- `supabase/functions/_shared/trainerFeedbackDelivery.ts`
- `supabase/migrations/20260313120000_trainer_activity_feedback.sql`
- `app/(tabs)/profile.tsx`

## Testing
Kørt:
- `npm run typecheck`
- `npx eslint app/'(tabs)'/profile.tsx app/activity-details.tsx services/trainerFeedbackService.ts __tests__/profile.settings.notifications.test.tsx __tests__/trainerFeedbackService.test.ts __tests__/activity-details.trainer-feedback.screen.test.tsx`
- `npx jest __tests__/trainerFeedbackService.test.ts __tests__/activity-details.trainer-feedback.screen.test.tsx __tests__/profile.settings.notifications.test.tsx --runInBand`

Bemærkning:
- Jest passerer, men logger eksisterende ikke-failende RN/Expo test warnings (`act(...)`, `expo-notifications`, `expo-glass-effect`)

## Deploy notes
Efter merge kræver feature:
- database migration for `trainer_activity_feedback`
- deploy af edge function `sendTrainerFeedback`
