### PR TITLE
Fix task modal video hydration and playback

### DIFF
--- a/__tests__/activityCard.component.test.tsx
+++ b/__tests__/activityCard.component.test.tsx
@@ -1,11 +1,21 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
-
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import ActivityCard from '@/components/ActivityCard';
+
+const mockHydrateTaskForModal = jest.fn(async (task: any) => task);
+
+jest.mock('@/utils/taskModalContent', () => {
+  const actual = jest.requireActual('@/utils/taskModalContent');
+  return {
+    ...actual,
+    hydrateTaskForModal: (task: any) => mockHydrateTaskForModal(task),
+  };
+});
 
 const mockPush = jest.fn();
 const mockToggleTaskCompletion = jest.fn();
 const mockRefreshData = jest.fn();
+const mockTaskDetailsModal = jest.fn();
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({
@@ -32,7 +42,10 @@ jest.mock('@/components/IconSymbol', () => {
 jest.mock('@/components/TaskDetailsModal', () => {
   const React = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
-  return () => <View testID="task-details-modal" />;
+  return (props: any) => {
+    mockTaskDetailsModal(props);
+    return <View testID="task-details-modal" />;
+  };
 });
 
 jest.mock('@/contexts/FootballContext', () => ({
@@ -57,6 +70,8 @@ const baseActivity = {
 describe('ActivityCard completion UI', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockTaskDetailsModal.mockReset();
+    mockHydrateTaskForModal.mockImplementation(async (task: any) => task);
   });
 
   it('shows task as not completed initially', () => {
@@ -249,6 +264,62 @@ describe('ActivityCard completion UI', () => {
         taskInstanceId: 'feedback-task-route-1',
       },
     });
+  });
+
+  it('passes camelCase task videoUrl into the task modal', async () => {
+    const { getByTestId } = render(
+      <ActivityCard
+        activity={{
+          ...baseActivity,
+          tasks: [
+            {
+              id: 'task-video-1',
+              title: 'Førsteberøring',
+              completed: false,
+              videoUrl: 'focus/run.mp4',
+            },
+          ],
+        }}
+        resolvedDate={new Date('2026-01-01T10:00:00Z')}
+        showTasks
+      />
+    );
+
+    fireEvent.press(getByTestId('home.activityTaskButton.incomplete'));
+
+    await waitFor(() => {
+      expect(mockTaskDetailsModal).toHaveBeenCalled();
+      expect(mockTaskDetailsModal.mock.calls.at(-1)?.[0]?.videoUrl).toBe('focus/run.mp4');
+    });
+  });
+
+  it('opens the task modal immediately without waiting for hydration', () => {
+    mockHydrateTaskForModal.mockImplementation(
+      () => new Promise(() => {})
+    );
+
+    const { getByTestId } = render(
+      <ActivityCard
+        activity={{
+          ...baseActivity,
+          tasks: [
+            {
+              id: 'task-video-2',
+              title: 'Føring',
+              completed: false,
+              task_template_id: 'template-2',
+            },
+          ],
+        }}
+        resolvedDate={new Date('2026-01-01T10:00:00Z')}
+        showTasks
+      />
+    );
+
+    fireEvent.press(getByTestId('home.activityTaskButton.incomplete'));
+
+    expect(mockTaskDetailsModal).toHaveBeenCalled();
+    expect(mockTaskDetailsModal.mock.calls.at(-1)?.[0]?.title).toBe('Føring');
   });
 
   it('opens canonical intensity modal route from Home card', () => {

--- a/__tests__/smartVideoPlayer.component.test.tsx
+++ b/__tests__/smartVideoPlayer.component.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+import SmartVideoPlayer from '@/components/SmartVideoPlayer';
+
+const mockWebView = jest.fn();
+const mockOpenUrl = jest.fn();
+
+jest.mock('expo-linking', () => ({
+  openURL: (...args: any[]) => mockOpenUrl(...args),
+}));
+
+jest.mock('react-native-webview', () => ({
+  WebView: (props: any) => {
+    const React = jest.requireActual('react');
+    const { View } = jest.requireActual('react-native');
+    mockWebView(props);
+    return <View testID={props.testID ?? 'mock-webview'} />;
+  },
+}));
+
+describe('SmartVideoPlayer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders inline video playback for Supabase storage keys', () => {
+    const { getByTestId } = render(<SmartVideoPlayer url="focus/run.mp4" />);
+
+    expect(getByTestId('smart-video-player.webview')).toBeTruthy();
+    expect(mockWebView).toHaveBeenCalled();
+
+    const props = mockWebView.mock.calls.at(-1)?.[0];
+    expect(props?.source?.html).toContain('<video controls playsinline');
+    expect(props?.source?.html).toContain(
+      'https://lhpczofddvwcyrgotzha.supabase.co/storage/v1/object/public/drill-videos/focus/run.mp4'
+    );
+  });
+
+  it('shows a YouTube thumbnail and opens the original link when pressed', () => {
+    const { getByTestId } = render(
+      <SmartVideoPlayer url="https://www.youtube.com/watch?si=share-token&v=dQw4w9WgXcQ" />
+    );
+
+    expect(getByTestId('smart-video-player.thumbnail')).toBeTruthy();
+    fireEvent.press(getByTestId('smart-video-player.thumbnail'));
+
+    expect(mockOpenUrl).toHaveBeenCalledWith('https://www.youtube.com/watch?si=share-token&v=dQw4w9WgXcQ');
+  });
+});

--- a/__tests__/taskDetailsModal.component.test.tsx
+++ b/__tests__/taskDetailsModal.component.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import TaskDetailsModal from '@/components/TaskDetailsModal';
+
+const mockSmartVideoPlayer = jest.fn();
+
+jest.mock('expo-blur', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    BlurView: ({ children }: any) => <View>{children}</View>,
+  };
+});
+
+jest.mock('expo-linear-gradient', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    LinearGradient: ({ children }: any) => <View>{children}</View>,
+  };
+});
+
+jest.mock('@/components/IconSymbol', () => {
+  const React = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return {
+    IconSymbol: () => <Text>icon</Text>,
+  };
+});
+
+jest.mock('@/components/SmartVideoPlayer', () => {
+  const React = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  return (props: any) => {
+    mockSmartVideoPlayer(props);
+    return (
+      <View testID="mock.smartVideoPlayer">
+        <Text>{props.url}</Text>
+      </View>
+    );
+  };
+});
+
+describe('TaskDetailsModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows fallback text when the task has no details', () => {
+    const { getByText } = render(
+      <TaskDetailsModal
+        visible
+        title="Tom opgave"
+        categoryColor="#3B82F6"
+        isDark={false}
+        onClose={() => {}}
+        onComplete={() => {}}
+      />
+    );
+
+    expect(getByText('Ingen detaljer på denne opgave endnu.')).toBeTruthy();
+  });
+
+  it('renders video from a URL embedded in the description', () => {
+    const { getByTestId, queryByText } = render(
+      <TaskDetailsModal
+        visible
+        title="Videoopgave"
+        categoryColor="#3B82F6"
+        isDark={false}
+        description="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        onClose={() => {}}
+        onComplete={() => {}}
+      />
+    );
+
+    expect(getByTestId('mock.smartVideoPlayer')).toBeTruthy();
+    expect(mockSmartVideoPlayer.mock.calls.at(-1)?.[0]?.url).toBe(
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+    );
+    expect(queryByText('Beskrivelse')).toBeNull();
+  });
+
+  it('keeps ordinary links in the description instead of treating them as video', () => {
+    const { getByText, queryByTestId, queryByText } = render(
+      <TaskDetailsModal
+        visible
+        title="Guide"
+        categoryColor="#3B82F6"
+        isDark={false}
+        description="Laes mere her https://example.com/guide"
+        onClose={() => {}}
+        onComplete={() => {}}
+      />
+    );
+
+    expect(queryByTestId('mock.smartVideoPlayer')).toBeNull();
+    expect(getByText('Beskrivelse')).toBeTruthy();
+    expect(getByText('Laes mere her https://example.com/guide')).toBeTruthy();
+    expect(queryByText('Ingen detaljer på denne opgave endnu.')).toBeNull();
+  });
+});

--- a/__tests__/taskModalContent.test.ts
+++ b/__tests__/taskModalContent.test.ts
@@ -1,0 +1,70 @@
+import {
+  getTaskModalVideoUrl,
+  hydrateTaskForModal,
+  shouldHydrateTaskForModal,
+} from '@/utils/taskModalContent';
+
+const mockMaybeSingle = jest.fn();
+const mockEq = jest.fn(() => ({ maybeSingle: mockMaybeSingle }));
+const mockSelect = jest.fn(() => ({ eq: mockEq }));
+const mockFrom = jest.fn((_table?: string) => ({ select: mockSelect }));
+
+jest.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (table: string) => mockFrom(table),
+  },
+}));
+
+describe('taskModalContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reads video URL from either camelCase or snake_case fields', () => {
+    expect(getTaskModalVideoUrl({ videoUrl: 'focus/run.mp4' })).toBe('focus/run.mp4');
+    expect(getTaskModalVideoUrl({ video_url: 'focus/run.mp4' })).toBe('focus/run.mp4');
+  });
+
+  it('only hydrates when template-backed fields are missing', () => {
+    expect(
+      shouldHydrateTaskForModal({
+        task_template_id: 'template-1',
+        description: '',
+        video_url: null,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldHydrateTaskForModal({
+        task_template_id: 'template-1',
+        description: 'Beskrivelse',
+        video_url: 'focus/run.mp4',
+      })
+    ).toBe(false);
+  });
+
+  it('hydrates missing description and video from task template metadata', async () => {
+    mockMaybeSingle.mockResolvedValue({
+      data: {
+        id: 'template-1',
+        title: 'Teknik',
+        description: 'Se videoen og øv teknikken',
+        video_url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      },
+      error: null,
+    });
+
+    const hydrated = await hydrateTaskForModal({
+      id: 'task-1',
+      title: 'Teknik',
+      description: '',
+      task_template_id: 'template-1',
+      video_url: null,
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith('task_templates');
+    expect(hydrated.description).toBe('Se videoen og øv teknikken');
+    expect(hydrated.video_url).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+    expect((hydrated as any).videoUrl).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+  });
+});

--- a/__tests__/videoUrlParser.test.ts
+++ b/__tests__/videoUrlParser.test.ts
@@ -1,0 +1,27 @@
+import {
+  extractFirstPlayableVideoUrl,
+  isPlayableVideoUrl,
+  parseVideoUrl,
+} from '@/utils/videoUrlParser';
+
+describe('videoUrlParser', () => {
+  it('parses YouTube watch URLs even when v is not the first query parameter', () => {
+    const parsed = parseVideoUrl('https://www.youtube.com/watch?si=share-token&v=dQw4w9WgXcQ');
+
+    expect(parsed.platform).toBe('youtube');
+    expect(parsed.videoId).toBe('dQw4w9WgXcQ');
+    expect(parsed.thumbnailUrl).toBe('https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg');
+  });
+
+  it('parses YouTube live URLs', () => {
+    const parsed = parseVideoUrl('https://www.youtube.com/live/dQw4w9WgXcQ?feature=share');
+
+    expect(parsed.platform).toBe('youtube');
+    expect(parsed.videoId).toBe('dQw4w9WgXcQ');
+  });
+
+  it('does not treat ordinary links as playable video', () => {
+    expect(isPlayableVideoUrl('https://example.com/guide')).toBe(false);
+    expect(extractFirstPlayableVideoUrl('Laes mere her https://example.com/guide')).toBeNull();
+  });
+});

--- a/app/activity-details.tsx
+++ b/app/activity-details.tsx
@@ -49,6 +49,12 @@ import {
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import TaskDetailsModal from '@/components/TaskDetailsModal';
+import {
+  getTaskModalTemplateId,
+  getTaskModalVideoUrl,
+  hydrateTaskForModal,
+  shouldHydrateTaskForModal,
+} from '@/utils/taskModalContent';
 
 const FALLBACK_COLORS = {
   primary: '#3B82F6',
@@ -297,14 +303,6 @@ function parseTimeToDate(baseDate: Date, time?: string | null): Date {
   next.setHours(safeHours, safeMinutes, 0, 0);
   return next;
 }
-
-const getTaskVideoUrl = (task: any): string | null => {
-  if (!task) return null;
-  const camel = typeof task.videoUrl === 'string' ? task.videoUrl.trim() : '';
-  if (camel) return camel;
-  const snake = typeof task.video_url === 'string' ? task.video_url.trim() : '';
-  return snake || null;
-};
 
 const parseIntensityValue = (raw: any): number | null => {
   if (typeof raw === 'number' && Number.isFinite(raw)) return normalizeFivePointScore(raw);
@@ -828,7 +826,7 @@ export async function fetchActivityFromDatabase(activityId: string): Promise<Act
         const markerTemplateId = getMarkerTemplateId({ description: task.description, title: task.title });
         const feedbackTemplateId = directFeedbackTemplateId ?? markerTemplateId ?? null;
         const isFeedbackTask = Boolean(feedbackTemplateId) || isFeedbackTitle(task.title);
-        const resolvedVideo = getTaskVideoUrl(task);
+        const resolvedVideo = getTaskModalVideoUrl(task);
         const mapped: any = {
           id: task.id,
           title: task.title,
@@ -1040,7 +1038,7 @@ export async function fetchActivityFromDatabase(activityId: string): Promise<Act
         const markerTemplateId = getMarkerTemplateId({ description: task.description, title: task.title });
         const feedbackTemplateId = directFeedbackTemplateId ?? markerTemplateId ?? null;
         const isFeedbackTask = Boolean(feedbackTemplateId) || isFeedbackTitle(task.title);
-        const resolvedVideo = getTaskVideoUrl(task);
+        const resolvedVideo = getTaskModalVideoUrl(task);
         const mapped: any = {
           id: task.id,
           title: task.title,
@@ -1155,7 +1153,7 @@ export async function fetchActivityFromDatabase(activityId: string): Promise<Act
         const markerTemplateId = getMarkerTemplateId({ description: task.description, title: task.title });
         const feedbackTemplateId = directFeedbackTemplateId ?? markerTemplateId ?? null;
         const isFeedbackTask = Boolean(feedbackTemplateId) || isFeedbackTitle(task.title);
-        const resolvedVideo = getTaskVideoUrl(task);
+        const resolvedVideo = getTaskModalVideoUrl(task);
         const mapped: any = {
           id: task.id,
           title: task.title,
@@ -1824,11 +1822,40 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
   const [selectedNormalTask, setSelectedNormalTask] = useState<FeedbackTask | null>(null);
   const [isNormalTaskModalVisible, setIsNormalTaskModalVisible] = useState(false);
   const [isNormalTaskCompleting, setIsNormalTaskCompleting] = useState(false);
+  const normalTaskHydrationAttemptsRef = useRef<Set<string>>(new Set());
 
   const normalTaskVideoUrl = useMemo(
-    () => (selectedNormalTask ? getTaskVideoUrl(selectedNormalTask) : null),
+    () => (selectedNormalTask ? getTaskModalVideoUrl(selectedNormalTask) : null),
     [selectedNormalTask],
   );
+
+  useEffect(() => {
+    if (!isNormalTaskModalVisible || !selectedNormalTask) return;
+    if (!shouldHydrateTaskForModal(selectedNormalTask)) return;
+
+    const taskId = normalizeId(selectedNormalTask?.id) ?? 'no-task-id';
+    const templateId = getTaskModalTemplateId(selectedNormalTask) ?? 'no-template-id';
+    const hydrationKey = `${taskId}:${templateId}`;
+    if (normalTaskHydrationAttemptsRef.current.has(hydrationKey)) return;
+    normalTaskHydrationAttemptsRef.current.add(hydrationKey);
+
+    let cancelled = false;
+
+    void (async () => {
+      const hydratedTask = await hydrateTaskForModal(selectedNormalTask);
+      if (cancelled) return;
+      setSelectedNormalTask((current) => {
+        if (!current) return current;
+        const currentId = normalizeId(current?.id);
+        if (currentId !== taskId) return current;
+        return hydratedTask as FeedbackTask;
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isNormalTaskModalVisible, selectedNormalTask]);
 
   const handleNormalTaskComplete = useCallback(async () => {
     if (!selectedNormalTask) return;
@@ -2946,6 +2973,11 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
     [openCanonicalFeedbackModal],
   );
 
+  const openNormalTaskModal = useCallback((task: FeedbackTask) => {
+    setSelectedNormalTask(task);
+    setIsNormalTaskModalVisible(true);
+  }, []);
+
   const handleTaskRowPress = useCallback(
     (task: FeedbackTask) => {
       const templateId = resolveFeedbackTemplateId(task);
@@ -2964,10 +2996,9 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
         return;
       }
 
-      setSelectedNormalTask(task);
-      setIsNormalTaskModalVisible(true);
+      void openNormalTaskModal(task);
     },
-    [openTemplateFeedbackModal, resolveFeedbackTemplateId],
+    [openNormalTaskModal, openTemplateFeedbackModal, resolveFeedbackTemplateId],
   );
 
   const handleNormalTaskModalClose = useCallback(() => {
@@ -2975,6 +3006,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
     setIsNormalTaskModalVisible(false);
     setSelectedNormalTask(null);
     setPendingNormalTaskId(null);
+    normalTaskHydrationAttemptsRef.current.clear();
   }, [isNormalTaskCompleting]);
 
   const handleDeleteTask = useCallback(

--- a/components/ActivityCard.tsx
+++ b/components/ActivityCard.tsx
@@ -11,6 +11,12 @@ import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
 import { resolveActivityIntensityEnabled } from '@/utils/activityIntensity';
 import { getTaskDurationMinutes } from '@/utils/activityDuration';
 import { formatScoreOutOfFive, normalizeFivePointScore } from '@/utils/scoreScale';
+import {
+  getTaskModalTemplateId,
+  getTaskModalVideoUrl,
+  hydrateTaskForModal,
+  shouldHydrateTaskForModal,
+} from '@/utils/taskModalContent';
 
 interface ActivityCardProps {
   activity: any;
@@ -298,6 +304,7 @@ export default function ActivityCard({
   const [selectedTask, setSelectedTask] = useState<any | null>(null);
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
   const [isTaskModalSaving, setIsTaskModalSaving] = useState(false);
+  const modalHydrationAttemptsRef = useRef<Set<string>>(new Set());
 
   // Initialize and update optimistic tasks from activity (incl. external sources)
   useEffect(() => {
@@ -314,6 +321,34 @@ export default function ActivityCard({
     areTaskListsEqual,
     extractTasksFromActivity,
   ]);
+
+  useEffect(() => {
+    if (!isTaskModalOpen || !selectedTask) return;
+    if (!shouldHydrateTaskForModal(selectedTask)) return;
+
+    const taskId = normalizeId(selectedTask?.id ?? selectedTask?.task_id) ?? 'no-task-id';
+    const templateId = getTaskModalTemplateId(selectedTask) ?? 'no-template-id';
+    const hydrationKey = `${taskId}:${templateId}`;
+    if (modalHydrationAttemptsRef.current.has(hydrationKey)) return;
+    modalHydrationAttemptsRef.current.add(hydrationKey);
+
+    let cancelled = false;
+
+    void (async () => {
+      const hydratedTask = await hydrateTaskForModal(selectedTask);
+      if (cancelled) return;
+      setSelectedTask((current: any) => {
+        if (!current) return current;
+        const currentId = normalizeId(current?.id ?? current?.task_id);
+        if (currentId !== taskId) return current;
+        return hydratedTask;
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isTaskModalOpen, selectedTask]);
 
   const resolveFeedbackTemplateId = useCallback((task: any): string | null => {
     if (!task) return null;
@@ -526,6 +561,7 @@ export default function ActivityCard({
   const handleModalClose = useCallback(() => {
     setIsTaskModalOpen(false);
     setSelectedTask(null);
+    modalHydrationAttemptsRef.current.clear();
     Promise.resolve(refreshData()).catch(() => {});
   }, [refreshData]);
 
@@ -673,7 +709,7 @@ export default function ActivityCard({
             task_template_id: firstTask.task_template_id,
             feedback_template_id: firstTask.feedback_template_id,
             reminder_minutes: firstTask.reminder_minutes,
-            video_url: firstTask.video_url ?? null,
+            video_url: getTaskModalVideoUrl(firstTask),
             descriptionSnippet: typeof firstTask.description === 'string' ? firstTask.description.slice(0, 80) : null,
             keys: Object.keys(firstTask).slice(0, 20),
           }
@@ -689,7 +725,7 @@ export default function ActivityCard({
         return (
           hasTemplateOrFeedback(task) ||
           resolveReminderMinutes(task) !== null ||
-          (typeof task.video_url === 'string' && task.video_url.trim().length > 0)
+          getTaskModalVideoUrl(task) !== null
         );
       }
       return showTasks || hasTemplateOrFeedback(task);
@@ -1031,7 +1067,7 @@ export default function ActivityCard({
                         )}
                       </TouchableOpacity>
 
-                      {task.video_url && (
+                      {getTaskModalVideoUrl(task) && (
                         <View style={styles.videoIndicator}>
                           <IconSymbol
                             ios_icon_name="play.circle.fill"
@@ -1059,7 +1095,7 @@ export default function ActivityCard({
           isDark={isDark}
           description={typeof selectedTask?.description === 'string' ? selectedTask.description : undefined}
           reminderMinutes={resolveReminderMinutes(selectedTask)}
-          videoUrl={typeof selectedTask?.video_url === 'string' ? selectedTask.video_url : null}
+          videoUrl={getTaskModalVideoUrl(selectedTask)}
           completed={!!selectedTask?.completed}
           isSaving={isTaskModalSaving}
           onClose={handleModalClose}

--- a/components/SmartVideoPlayer.tsx
+++ b/components/SmartVideoPlayer.tsx
@@ -1,67 +1,99 @@
 
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { View, Image, Pressable, Text, StyleSheet } from 'react-native';
 import { WebView } from 'react-native-webview';
 import * as Linking from 'expo-linking';
+import { resolveVideoUrl } from '@/utils/videoKey';
+import { isDirectVideoUrl, parseVideoUrl } from '@/utils/videoUrlParser';
 
 export default function SmartVideoPlayer({ url }: { url?: string }) {
   const [playVimeo, setPlayVimeo] = useState(false);
-  
-  if (!url) return null;
 
-  if (isYouTube(url)) {
-    const id = ytId(url);
-    if (!id) return null;
+  const resolvedUrl = useMemo(() => resolveVideoUrl(url), [url]);
+  const parsedVideo = useMemo(
+    () => (resolvedUrl && /^https?:\/\//i.test(resolvedUrl) ? parseVideoUrl(resolvedUrl) : null),
+    [resolvedUrl]
+  );
+  const youtubeId = parsedVideo?.platform === 'youtube' ? parsedVideo.videoId : null;
+  const vimeoId = parsedVideo?.platform === 'vimeo' ? parsedVideo.videoId : null;
+  const inlineVideoHtml = useMemo(() => {
+    if (!resolvedUrl || !isDirectVideoUrl(resolvedUrl)) return null;
+    return buildVideoHtml(resolvedUrl);
+  }, [resolvedUrl]);
+  const vimeoHtml = useMemo(() => {
+    if (!resolvedUrl || !vimeoId) return null;
+    return buildVideoHtml(resolvedUrl, playVimeo);
+  }, [playVimeo, resolvedUrl, vimeoId]);
+  const thumbnailUrl = useMemo(() => {
+    if (parsedVideo?.platform === 'youtube') return parsedVideo.thumbnailUrl;
+    if (parsedVideo?.platform === 'vimeo' && vimeoId) return `https://vumbnail.com/${vimeoId}.jpg`;
+    return null;
+  }, [parsedVideo, vimeoId]);
+
+  useEffect(() => {
+    setPlayVimeo(false);
+  }, [resolvedUrl]);
+
+  if (!resolvedUrl) return null;
+
+  if (youtubeId && thumbnailUrl) {
     return (
       <Thumb
-        img={`https://img.youtube.com/vi/${id}/hqdefault.jpg`}
-        onPress={() => Linking.openURL(url)}
+        img={thumbnailUrl}
+        onPress={() => Linking.openURL(resolvedUrl)}
+        testID="smart-video-player.thumbnail"
       />
     );
   }
 
-  if (isVimeo(url)) {
-    const id = vimeoId(url);
-    if (!id) return null;
-
-    // CRITICAL FIX: WebView is always mounted, visibility controlled via opacity and height
+  if (vimeoHtml && thumbnailUrl) {
     return (
       <View style={styles.vimeoContainer}>
-        {/* Thumbnail overlay - shown when not playing */}
-        <View 
-          style={[
-            styles.thumbnailOverlay,
-            { 
-              opacity: playVimeo ? 0 : 1,
-              pointerEvents: playVimeo ? 'none' : 'auto'
-            }
-          ]}
+        <View
+          pointerEvents={playVimeo ? 'none' : 'auto'}
+          style={[styles.thumbnailOverlay, { opacity: playVimeo ? 0 : 1 }]}
         >
           <Thumb
-            img={`https://vumbnail.com/${id}.jpg`}
+            img={thumbnailUrl}
             onPress={() => setPlayVimeo(true)}
+            testID="smart-video-player.thumbnail"
           />
         </View>
 
-        {/* WebView - always mounted, visibility controlled via opacity */}
-        <View 
-          style={[
-            styles.webViewContainer,
-            { 
-              opacity: playVimeo ? 1 : 0,
-              height: playVimeo ? 220 : 0
-            }
-          ]}
+        <View
+          pointerEvents={playVimeo ? 'auto' : 'none'}
+          style={[styles.webViewContainer, { opacity: playVimeo ? 1 : 0, height: playVimeo ? 220 : 0 }]}
         >
           <WebView
-            source={{ uri: `https://player.vimeo.com/video/${id}` }}
+            testID="smart-video-player.webview"
+            source={{ html: vimeoHtml }}
             javaScriptEnabled
             domStorageEnabled
             allowsInlineMediaPlayback
             allowsFullscreenVideo
+            scrollEnabled={false}
+            bounces={false}
             style={styles.webView}
           />
         </View>
+      </View>
+    );
+  }
+
+  if (inlineVideoHtml) {
+    return (
+      <View style={styles.directVideoContainer}>
+        <WebView
+          testID="smart-video-player.webview"
+          source={{ html: inlineVideoHtml }}
+          javaScriptEnabled
+          domStorageEnabled
+          allowsInlineMediaPlayback
+          allowsFullscreenVideo
+          scrollEnabled={false}
+          bounces={false}
+          style={styles.webView}
+        />
       </View>
     );
   }
@@ -70,18 +102,85 @@ export default function SmartVideoPlayer({ url }: { url?: string }) {
 }
 
 /* helpers */
-const isYouTube = (u: string) =>
-  u.includes('youtu.be') || u.includes('youtube.com');
-const isVimeo = (u: string) => u.includes('vimeo.com');
-const ytId = (u: string) =>
-  u.split('v=')[1]?.split('&')[0] ||
-  u.split('youtu.be/')[1]?.split('?')[0];
-const vimeoId = (u: string) =>
-  u.split('vimeo.com/')[1]?.split('?')[0];
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function buildVideoHtml(videoUrl: string, autoPlay = false): string {
+  const parsedVideo = parseVideoUrl(videoUrl);
+  const youtubeId = parsedVideo.platform === 'youtube' ? parsedVideo.videoId : null;
+  const vimeoId = parsedVideo.platform === 'vimeo' ? parsedVideo.videoId : null;
+  const embedUrl = youtubeId
+    ? `https://www.youtube.com/embed/${youtubeId}?autoplay=${autoPlay ? 1 : 0}&playsinline=1&rel=0`
+    : vimeoId
+      ? `https://player.vimeo.com/video/${vimeoId}?autoplay=${autoPlay ? 1 : 0}&playsinline=1`
+      : null;
+
+  if (embedUrl) {
+    const safeEmbedUrl = escapeHtml(embedUrl);
+    return `<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        background: #000;
+      }
+      iframe {
+        width: 100%;
+        height: 100%;
+        border: 0;
+        background: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe src="${safeEmbedUrl}" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+  </body>
+</html>`;
+  }
+
+  const safeVideoUrl = escapeHtml(videoUrl);
+  return `<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        background: #000;
+      }
+      video {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        background: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <video controls playsinline webkit-playsinline preload="metadata">
+      <source src="${safeVideoUrl}" />
+    </video>
+  </body>
+</html>`;
+}
 
 /* ui */
-const Thumb = ({ img, onPress }: any) => (
-  <Pressable onPress={onPress} style={styles.thumbContainer}>
+const Thumb = ({ img, onPress, testID }: any) => (
+  <Pressable onPress={onPress} style={styles.thumbContainer} testID={testID}>
     <Image
       source={{ uri: img }}
       style={styles.thumbImage}
@@ -100,6 +199,11 @@ const styles = StyleSheet.create({
     height: 220,
     backgroundColor: '#000',
     position: 'relative',
+  },
+  directVideoContainer: {
+    height: 220,
+    backgroundColor: '#000',
+    overflow: 'hidden',
   },
   thumbnailOverlay: {
     position: 'absolute',

--- a/components/TaskDescriptionRenderer.tsx
+++ b/components/TaskDescriptionRenderer.tsx
@@ -2,88 +2,51 @@
 import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { colors } from '@/styles/commonStyles';
-import { parseVideoUrl, isValidVideoUrl } from '@/utils/videoUrlParser';
 import SmartVideoPlayer from '@/components/SmartVideoPlayer';
 import { stripAfterTrainingMarkers } from '@/utils/afterTrainingMarkers';
+import { extractFirstPlayableVideoUrl } from '@/utils/videoUrlParser';
 
 interface TaskDescriptionRendererProps {
   description: string;
   textColor: string;
 }
 
-/**
- * TaskDescriptionRenderer Component
- * 
- * Parses task descriptions and renders:
- * - Regular text as Text components
- * - Video URLs as embedded video players
- * 
- * CRITICAL FIXES FOR iOS:
- * 1. Broader regex to match ANY http(s) URL (not just .mp4/.mov/.avi)
- * 2. useMemo to force re-render when description changes
- * 3. key prop on VideoPlayer to force unmount/remount (iOS cache fix)
- */
 export function TaskDescriptionRenderer({ description, textColor }: TaskDescriptionRendererProps) {
   const sanitizedDescription = useMemo(() => {
     return stripAfterTrainingMarkers(description);
   }, [description]);
 
-  // CRITICAL FIX: Use useMemo to detect description changes and force re-render
   const videoUrl = useMemo(() => {
     if (!sanitizedDescription) {
       return null;
     }
-
-    // CRITICAL FIX: Broader regex that matches ANY http(s) URL
-    // This will match Supabase storage URLs, CDN URLs, YouTube, Vimeo, signed URLs, etc.
-    const videoUrlRegex = /(https?:\/\/[^\s]+)/i;
-    const match = sanitizedDescription.match(videoUrlRegex);
-    
-    return match ? match[0] : null;
+    return extractFirstPlayableVideoUrl(sanitizedDescription);
   }, [sanitizedDescription]);
+
+  const textWithoutVideoUrl = useMemo(() => {
+    if (!sanitizedDescription) return '';
+    if (!videoUrl) return sanitizedDescription.trim();
+    return sanitizedDescription.replace(videoUrl, '').trim();
+  }, [sanitizedDescription, videoUrl]);
 
   if (!sanitizedDescription) {
     return null;
   }
 
-  // If we found a video URL, render the video player
-  if (videoUrl && isValidVideoUrl(videoUrl)) {
-    return (
-      <View style={styles.container}>
+  return (
+    <View style={styles.container}>
+      {videoUrl ? (
         <View style={styles.videoThumbnail}>
           <SmartVideoPlayer url={videoUrl} />
         </View>
-        <Text style={[styles.videoLabel, { color: textColor }]}>
-          {getVideoLabel(videoUrl)}
+      ) : null}
+      {textWithoutVideoUrl ? (
+        <Text style={[styles.text, { color: textColor }]}>
+          {textWithoutVideoUrl}
         </Text>
-      </View>
-    );
-  }
-
-  return (
-    <View style={styles.container}>
-      <Text style={[styles.text, { color: textColor }]}>
-        {sanitizedDescription}
-      </Text>
+      ) : null}
     </View>
   );
-}
-
-/**
- * Get a friendly label for the video URL
- */
-function getVideoLabel(url: string): string {
-  // Check if it's a known platform (YouTube/Vimeo)
-  const videoInfo = parseVideoUrl(url);
-  
-  if (videoInfo.platform === 'youtube') {
-    return '▶️ YouTube Video';
-  } else if (videoInfo.platform === 'vimeo') {
-    return '▶️ Vimeo Video';
-  }
-  
-  // Generic video label for other URLs
-  return '▶️ Video';
 }
 
 const styles = StyleSheet.create({
@@ -98,10 +61,4 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     overflow: 'hidden',
   },
-  videoLabel: {
-    fontSize: 13,
-    fontWeight: '600',
-    marginTop: 6,
-  },
 });
-

--- a/components/TaskDetailsModal.tsx
+++ b/components/TaskDetailsModal.tsx
@@ -14,11 +14,14 @@ import { BlurView } from 'expo-blur';
 import { LinearGradient } from 'expo-linear-gradient';
 import SmartVideoPlayer from '@/components/SmartVideoPlayer';
 import { IconSymbol } from '@/components/IconSymbol';
+import { TaskDescriptionRenderer } from '@/components/TaskDescriptionRenderer';
 import * as CommonStyles from '@/styles/commonStyles';
+import { extractFirstPlayableVideoUrl, isPlayableVideoUrl } from '@/utils/videoUrlParser';
 
 const FALLBACK_COLORS = {
   primary: '#3B82F6',
 };
+const SECTION_TEXT_COLOR = '#20283E';
 
 const colors = ((CommonStyles as any)?.colors as typeof FALLBACK_COLORS | undefined) ?? FALLBACK_COLORS;
 
@@ -85,6 +88,20 @@ function TaskDetailsModalComponent({
   onComplete,
 }: TaskDetailsModalProps) {
   const base = useMemo(() => clampColorHex(categoryColor), [categoryColor]);
+  const trimmedVideoUrl =
+    typeof videoUrl === 'string' && isPlayableVideoUrl(videoUrl) ? videoUrl.trim() : null;
+  const derivedDescriptionVideoUrl = useMemo(() => extractFirstPlayableVideoUrl(description), [description]);
+  const resolvedVideoUrl = trimmedVideoUrl ?? derivedDescriptionVideoUrl;
+  const descriptionForDisplay = useMemo(() => {
+    if (typeof description !== 'string') return '';
+    const trimmed = description.trim();
+    if (!trimmed) return '';
+    if (!resolvedVideoUrl) return trimmed;
+    return trimmed.replace(resolvedVideoUrl, '').trim();
+  }, [description, resolvedVideoUrl]);
+  const hasDescription = descriptionForDisplay.length > 0;
+  const hasReminder = reminderMinutes !== null && reminderMinutes !== undefined;
+  const hasBodyContent = Boolean(resolvedVideoUrl || hasDescription || hasReminder);
 
   const disable = isSaving;
 
@@ -123,22 +140,22 @@ function TaskDetailsModalComponent({
                 contentContainerStyle={styles.bodyContent}
                 showsVerticalScrollIndicator={false}
               >
-                {videoUrl ? (
+                {resolvedVideoUrl ? (
                   <View style={styles.videoSection}>
                     <View style={styles.videoContainer}>
-                      <SmartVideoPlayer url={videoUrl} />
+                      <SmartVideoPlayer url={resolvedVideoUrl} />
                     </View>
                   </View>
                 ) : null}
 
-                {description ? (
+                {hasDescription ? (
                   <View style={styles.section}>
                     <Text style={styles.sectionLabel}>Beskrivelse</Text>
-                    <Text style={styles.sectionText}>{description}</Text>
+                    <TaskDescriptionRenderer description={descriptionForDisplay} textColor={SECTION_TEXT_COLOR} />
                   </View>
                 ) : null}
 
-                {reminderMinutes !== null && reminderMinutes !== undefined ? (
+                {hasReminder ? (
                   <View style={styles.section}>
                     <View style={styles.chip}>
                       <IconSymbol
@@ -149,6 +166,12 @@ function TaskDetailsModalComponent({
                       />
                       <Text style={styles.chipText}>{reminderMinutes} min før</Text>
                     </View>
+                  </View>
+                ) : null}
+
+                {!hasBodyContent ? (
+                  <View style={styles.emptyState}>
+                    <Text style={styles.emptyStateText}>Ingen detaljer på denne opgave endnu.</Text>
                   </View>
                 ) : null}
               </ScrollView>
@@ -247,7 +270,19 @@ const styles = StyleSheet.create({
     fontSize: 16,
     lineHeight: 22,
     fontWeight: '500',
-    color: '#20283E',
+    color: SECTION_TEXT_COLOR,
+  },
+  emptyState: {
+    marginTop: 12,
+    borderRadius: 18,
+    paddingVertical: 18,
+    paddingHorizontal: 16,
+    backgroundColor: 'rgba(240, 242, 247, 0.75)',
+  },
+  emptyStateText: {
+    fontSize: 15,
+    lineHeight: 21,
+    color: '#55607A',
   },
 
   videoSection: { marginTop: 6 },

--- a/utils/taskModalContent.ts
+++ b/utils/taskModalContent.ts
@@ -1,0 +1,90 @@
+import { supabase } from '@/integrations/supabase/client';
+import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
+
+function trimString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function getTaskModalVideoUrl(task: any): string | null {
+  if (!task) return null;
+  const camel = trimString(task.videoUrl);
+  if (camel) return camel;
+  const snake = trimString(task.video_url);
+  return snake || null;
+}
+
+export function shouldHydrateTaskForModal(task: any): boolean {
+  if (!task) return false;
+  const templateId = getTaskModalTemplateId(task);
+  if (!templateId) return false;
+  const hasLocalDescription = trimString(task.description).length > 0;
+  const hasLocalVideo = getTaskModalVideoUrl(task) !== null;
+  return !hasLocalDescription || !hasLocalVideo;
+}
+
+export function getTaskModalTemplateId(task: any): string | null {
+  if (!task) return null;
+
+  const directTemplateId = trimString(task.task_template_id ?? task.taskTemplateId);
+  if (directTemplateId) return directTemplateId;
+
+  const feedbackTemplateId = trimString(task.feedback_template_id ?? task.feedbackTemplateId);
+  if (feedbackTemplateId) return feedbackTemplateId;
+
+  const markerTemplateId =
+    parseTemplateIdFromMarker(typeof task.description === 'string' ? task.description : '') ||
+    parseTemplateIdFromMarker(typeof task.title === 'string' ? task.title : '');
+
+  return trimString(markerTemplateId) || null;
+}
+
+function normalizeTaskForModal<T extends Record<string, any>>(
+  task: T,
+  fallback: { title?: string | null; description?: string | null; video_url?: string | null }
+): T {
+  const localTitle = trimString(task.title);
+  const localDescription = trimString(task.description);
+  const localVideo = getTaskModalVideoUrl(task);
+
+  const nextTitle = localTitle || trimString(fallback.title) || String(task.title ?? '');
+  const nextDescription = localDescription || trimString(fallback.description);
+  const nextVideo = localVideo || trimString(fallback.video_url) || null;
+
+  return {
+    ...task,
+    title: nextTitle,
+    description: nextDescription,
+    video_url: nextVideo,
+    videoUrl: nextVideo ?? undefined,
+  };
+}
+
+export async function hydrateTaskForModal<T extends Record<string, any>>(task: T): Promise<T> {
+  if (!task) return task;
+
+  const templateId = getTaskModalTemplateId(task);
+
+  if (!shouldHydrateTaskForModal(task) || !templateId) {
+    return normalizeTaskForModal(task, {});
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('task_templates')
+      .select('id, title, description, video_url')
+      .eq('id', templateId)
+      .maybeSingle();
+
+    if (error || !data) {
+      return normalizeTaskForModal(task, {});
+    }
+
+    return normalizeTaskForModal(task, {
+      title: data.title ?? null,
+      description: data.description ?? null,
+      video_url: data.video_url ?? null,
+    });
+  } catch {
+    return normalizeTaskForModal(task, {});
+  }
+}

--- a/utils/videoUrlParser.ts
+++ b/utils/videoUrlParser.ts
@@ -16,6 +16,88 @@ export interface VideoInfo {
   thumbnailUrl: string | null;
 }
 
+const DIRECT_VIDEO_PATTERN = /\.(mp4|m4v|mov|webm|ogv|m3u8)(?:$|[?#])/i;
+
+function safeParseUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeHost(hostname: string): string {
+  return hostname.toLowerCase().replace(/^www\./, '').replace(/^m\./, '');
+}
+
+function sanitizeVideoId(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function parseYouTubeVideoId(url: string): string | null {
+  const parsed = safeParseUrl(url);
+  if (parsed) {
+    const host = normalizeHost(parsed.hostname);
+    if (host === 'youtu.be') {
+      return sanitizeVideoId(parsed.pathname.split('/').filter(Boolean)[0] ?? null);
+    }
+
+    if (host === 'youtube.com' || host === 'youtube-nocookie.com') {
+      const fromQuery = sanitizeVideoId(parsed.searchParams.get('v'));
+      if (fromQuery) return fromQuery;
+
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      if (!segments.length) return null;
+
+      if (segments[0] === 'embed' || segments[0] === 'shorts' || segments[0] === 'live') {
+        return sanitizeVideoId(segments[1] ?? null);
+      }
+    }
+  }
+
+  const regexFallbacks = [
+    /(?:youtu\.be\/)([^&\n?#/]+)/i,
+    /(?:youtube(?:-nocookie)?\.com\/embed\/)([^&\n?#/]+)/i,
+    /(?:youtube\.com\/shorts\/)([^&\n?#/]+)/i,
+    /(?:youtube\.com\/live\/)([^&\n?#/]+)/i,
+    /(?:[?&]v=)([^&\n?#/]+)/i,
+  ];
+
+  for (const pattern of regexFallbacks) {
+    const match = url.match(pattern);
+    if (match?.[1]) return sanitizeVideoId(match[1]);
+  }
+
+  return null;
+}
+
+function parseVimeoVideoId(url: string): string | null {
+  const parsed = safeParseUrl(url);
+  if (parsed) {
+    const host = normalizeHost(parsed.hostname);
+    if (host === 'vimeo.com' || host === 'player.vimeo.com') {
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      const firstNumeric = segments.find(segment => /^\d+$/.test(segment));
+      if (firstNumeric) return firstNumeric;
+    }
+  }
+
+  const regexFallbacks = [
+    /(?:player\.vimeo\.com\/video\/)(\d+)/i,
+    /(?:vimeo\.com\/video\/)(\d+)/i,
+    /(?:vimeo\.com\/)(\d+)/i,
+  ];
+
+  for (const pattern of regexFallbacks) {
+    const match = url.match(pattern);
+    if (match?.[1]) return sanitizeVideoId(match[1]);
+  }
+
+  return null;
+}
+
 /**
  * Parse video URL and extract platform information
  * Converts any valid YouTube or Vimeo URL to proper embed format
@@ -32,58 +114,55 @@ export function parseVideoUrl(url: string): VideoInfo {
 
   const trimmedUrl = url.trim();
 
-  // YouTube detection patterns
-  // Supports: youtube.com/watch?v=, youtu.be/, youtube.com/embed/, youtube.com/shorts/
-  const youtubePatterns = [
-    /(?:youtube\.com\/watch\?v=)([^&\n?#]+)/,
-    /(?:youtu\.be\/)([^&\n?#]+)/,
-    /(?:youtube\.com\/embed\/)([^&\n?#]+)/,
-    /(?:youtube\.com\/shorts\/)([^&\n?#]+)/,
-  ];
-
-  for (const pattern of youtubePatterns) {
-    const match = trimmedUrl.match(pattern);
-    if (match && match[1]) {
-      const videoId = match[1];
-      // Always return embed URL format
-      return {
-        platform: 'youtube',
-        videoId,
-        embedUrl: `https://www.youtube.com/embed/${videoId}`,
-        thumbnailUrl: `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`,
-      };
-    }
+  const youtubeId = parseYouTubeVideoId(trimmedUrl);
+  if (youtubeId) {
+    return {
+      platform: 'youtube',
+      videoId: youtubeId,
+      embedUrl: `https://www.youtube.com/embed/${youtubeId}`,
+      thumbnailUrl: `https://i.ytimg.com/vi/${youtubeId}/hqdefault.jpg`,
+    };
   }
 
-  // Vimeo detection patterns
-  // Supports: vimeo.com/{id}, vimeo.com/video/{id}, player.vimeo.com/video/{id}
-  const vimeoPatterns = [
-    /(?:vimeo\.com\/)(\d+)/,
-    /(?:vimeo\.com\/video\/)(\d+)/,
-    /(?:player\.vimeo\.com\/video\/)(\d+)/,
-  ];
-
-  for (const pattern of vimeoPatterns) {
-    const match = trimmedUrl.match(pattern);
-    if (match && match[1]) {
-      const videoId = match[1];
-      // Always return embed URL format
-      return {
-        platform: 'vimeo',
-        videoId,
-        embedUrl: `https://player.vimeo.com/video/${videoId}`,
-        thumbnailUrl: null, // Vimeo thumbnails require API call
-      };
-    }
+  const vimeoId = parseVimeoVideoId(trimmedUrl);
+  if (vimeoId) {
+    return {
+      platform: 'vimeo',
+      videoId: vimeoId,
+      embedUrl: `https://player.vimeo.com/video/${vimeoId}`,
+      thumbnailUrl: null,
+    };
   }
 
-  // URL is not a supported video platform
   return {
     platform: 'unsupported',
     videoId: null,
     embedUrl: null,
     thumbnailUrl: null,
   };
+}
+
+export function isDirectVideoUrl(url: string): boolean {
+  if (!url || !url.trim()) return false;
+  return DIRECT_VIDEO_PATTERN.test(url.trim());
+}
+
+export function isPlayableVideoUrl(url: string): boolean {
+  if (!url || !url.trim()) return false;
+  if (isDirectVideoUrl(url)) return true;
+  const videoInfo = parseVideoUrl(url);
+  return videoInfo.platform !== 'unsupported' && videoInfo.videoId !== null;
+}
+
+export function extractFirstPlayableVideoUrl(value?: string | null): string | null {
+  if (typeof value !== 'string') return null;
+  const matches = value.match(/https?:\/\/[^\s]+/gi) ?? [];
+  for (const candidate of matches) {
+    if (isPlayableVideoUrl(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixer video i task-modal fra både forsiden og aktivitetsdetaljer.

## What Changed
- Task-modalen åbner nu med det samme på lokal task-data i stedet for at vente på en async fetch.
- Manglende `description` og `video_url` hydreres bagefter fra `task_templates`, så modalen stadig får template-data når task-instansen mangler felterne.
- Video-detektion er strammet op, så kun afspilbare videoer behandles som video:
  - YouTube
  - Vimeo
  - Direkte videofiler
- Almindelige links i description bliver nu stående som tekst og gør ikke modalen tom.
- YouTube i modal viser thumbnail og åbner det originale link ved tryk.
- Fælles modal/video-fallback er samlet i ny helper for mindre duplikering.

## Why
Den tidligere løsning kunne:
- behandle enhver `http(s)`-URL som video
- fjerne normale links fra description
- gøre modalen tom, hvis URL’en ikke kunne afspilles
- forsinke modal-open bag en async Supabase-hentning

Denne PR retter begge regressions og gør modal-flowet mere robust.

## Tests
- `npm test -- --runInBand`
- `npm run typecheck`
- `npm run lint`

## Notes
- `npm run lint` har stadig en eksisterende warning i `__tests__/supabase-client-auth.test.ts`, men ingen nye lint-errors fra denne PR.
