### PR TITLE
fix: persist instagram task template links

### DIFF
--- a/__tests__/smartVideoPlayer.component.test.tsx
+++ b/__tests__/smartVideoPlayer.component.test.tsx
@@ -47,4 +47,14 @@ describe('SmartVideoPlayer', () => {
 
     expect(mockOpenUrl).toHaveBeenCalledWith('https://www.youtube.com/watch?si=share-token&v=dQw4w9WgXcQ');
   });
+
+  it('shows an external-link card for Instagram reels', () => {
+    const instagramUrl = 'https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=';
+    const { getByTestId } = render(<SmartVideoPlayer url={instagramUrl} />);
+
+    expect(getByTestId('smart-video-player.external-link')).toBeTruthy();
+    fireEvent.press(getByTestId('smart-video-player.external-link'));
+
+    expect(mockOpenUrl).toHaveBeenCalledWith(instagramUrl);
+  });
 });

--- a/__tests__/supabase-client-auth.test.ts
+++ b/__tests__/supabase-client-auth.test.ts
@@ -1,6 +1,6 @@
 const mockTrackStartupTelemetry = jest.fn().mockResolvedValue(undefined);
 
-const mockAuthStateChangeCallbacks: Array<(event: string, session: any) => void> = [];
+const mockAuthStateChangeCallbacks: ((event: string, session: any) => void)[] = [];
 const mockOriginalGetSession = jest.fn();
 const mockOriginalGetUser = jest.fn();
 const mockSignOut = jest.fn().mockResolvedValue({ error: null });

--- a/__tests__/tasks.screen.no-subtasks.test.tsx
+++ b/__tests__/tasks.screen.no-subtasks.test.tsx
@@ -168,4 +168,36 @@ describe('Tasks template editor without subtasks', () => {
 
     expect(getByText('Teknik, Styrke')).toBeTruthy();
   });
+
+  it('reopens a template with snake_case video_url populated in the editor', () => {
+    mockUseFootball.mockReturnValue({
+      tasks: [
+        {
+          id: 'template-ig-1',
+          title: 'Instagram template',
+          description: 'test',
+          completed: false,
+          isTemplate: true,
+          categoryIds: [],
+          subtasks: [],
+          video_url: 'https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=',
+          archivedAt: null,
+        },
+      ],
+      categories: [],
+      duplicateTask: jest.fn(),
+      deleteTask: jest.fn().mockResolvedValue(undefined),
+      refreshAll: jest.fn().mockResolvedValue(undefined),
+      refreshData: jest.fn().mockResolvedValue(undefined),
+      updateTask: jest.fn().mockResolvedValue(undefined),
+      isLoading: false,
+    });
+
+    const { getByDisplayValue, getByTestId } = render(<TasksScreen />);
+
+    fireEvent.press(getByTestId('tasks.folder.toggle.personal'));
+    fireEvent.press(getByTestId('tasks.template.card.template-ig-1'));
+
+    expect(getByDisplayValue('https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=')).toBeTruthy();
+  });
 });

--- a/__tests__/videoUrlParser.test.ts
+++ b/__tests__/videoUrlParser.test.ts
@@ -20,6 +20,17 @@ describe('videoUrlParser', () => {
     expect(parsed.videoId).toBe('dQw4w9WgXcQ');
   });
 
+  it('treats Instagram reel URLs as supported videos', () => {
+    const parsed = parseVideoUrl('https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=');
+
+    expect(parsed.platform).toBe('instagram');
+    expect(parsed.videoId).toBe('C7N2KQ2uV9x');
+    expect(isPlayableVideoUrl('https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=')).toBe(true);
+    expect(
+      extractFirstPlayableVideoUrl('Se denne video https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=')
+    ).toBe('https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=');
+  });
+
   it('does not treat ordinary links as playable video', () => {
     expect(isPlayableVideoUrl('https://example.com/guide')).toBe(false);
     expect(extractFirstPlayableVideoUrl('Laes mere her https://example.com/guide')).toBeNull();

--- a/app/(modals)/task-feedback-note.tsx
+++ b/app/(modals)/task-feedback-note.tsx
@@ -63,7 +63,16 @@ async function fetchEventsLocalMetaBy(
   const selectWithoutRowId = 'id, external_event_id';
 
   try {
-    const { data, error } = await supabase.from('events_local_meta').select(selectWithRowId).eq(column, value).maybeSingle();
+    const lookup =
+      column === 'external_event_row_id'
+        ? supabase
+            .from('events_local_meta')
+            .select(selectWithRowId)
+            .or(`external_event_row_id.eq.${value}`)
+            .maybeSingle()
+        : supabase.from('events_local_meta').select(selectWithRowId).eq(column, value).maybeSingle();
+
+    const { data, error } = await lookup;
 
     if (error) {
       const isMissingColumn = error?.code === '42703';
@@ -78,6 +87,10 @@ async function fetchEventsLocalMetaBy(
       }
 
       if (isMissingColumn && isMissingRowIdColumn) {
+        if (column === 'external_event_row_id') {
+          return null;
+        }
+
         const retry = await supabase
           .from('events_local_meta')
           .select(selectWithoutRowId)

--- a/app/(tabs)/tasks.tsx
+++ b/app/(tabs)/tasks.tsx
@@ -28,6 +28,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { taskService } from '@/services/taskService';
 import { forceRefreshNotificationQueue } from '@/utils/notificationScheduler';
 import { emitActivitiesRefreshRequested } from '@/utils/activityEvents';
+import { getTaskModalVideoUrl } from '@/utils/taskModalContent';
 
 // ✅ Robust import: undgå Hermes-crash hvis named export "colors" ikke findes
 import * as CommonStyles from '@/styles/commonStyles';
@@ -67,13 +68,24 @@ const normalizeTaskDurationValue = (value: unknown): number | null => {
 // Local helper function to validate video URLs
 function isValidVideoUrl(url?: string | null): boolean {
   if (!url) return false;
+  const normalizedUrl = url.toLowerCase();
 
   return (
-    url.includes("youtube.com") ||
-    url.includes("youtu.be") ||
-    url.includes("vimeo.com")
+    normalizedUrl.includes('youtube.com') ||
+    normalizedUrl.includes('youtu.be') ||
+    normalizedUrl.includes('vimeo.com') ||
+    normalizedUrl.includes('instagram.com')
   );
 }
+
+function getVideoSourceLabel(url?: string | null): string {
+  const normalizedUrl = String(url ?? '').toLowerCase();
+  if (normalizedUrl.includes('instagram.com')) return 'Instagram';
+  if (normalizedUrl.includes('vimeo.com')) return 'Vimeo';
+  if (normalizedUrl.includes('youtu')) return 'YouTube';
+  return 'Video';
+}
+
 function getYouTubeThumbnail(url: string): string | null {
   try {
     if (url.includes('youtu.be/')) {
@@ -245,7 +257,7 @@ export const TaskCard = React.memo(
     getCategoryNames: (categoryIds: string[]) => string;
     isArchived?: boolean;
   }) => {
-    const videoUrl = (task as any)?.videoUrl ?? null;
+    const videoUrl = getTaskModalVideoUrl(task);
     const ytThumb = typeof videoUrl === 'string' && videoUrl.includes('youtu') ? getYouTubeThumbnail(videoUrl) : null;
     const taskId = String((task as any)?.id ?? '');
 
@@ -292,7 +304,9 @@ export const TaskCard = React.memo(
             {ytThumb ? (
               <Image source={{ uri: ytThumb }} style={styles.videoThumbnail} resizeMode="cover" />
             ) : (
-              <View style={styles.videoThumbnailFallback} />
+              <View style={styles.videoThumbnailFallback}>
+                <Text style={styles.videoThumbnailFallbackLabel}>{getVideoSourceLabel(videoUrl)}</Text>
+              </View>
             )}
             <View style={styles.videoOverlay}>
               <IconSymbol ios_icon_name="play.circle.fill" android_material_icon_name="play_circle" size={56} color="#fff" />
@@ -514,7 +528,7 @@ export default function TasksScreen() {
     setSelectedTask(normalizedTask);
     setIsCreating(creating);
     setIsSaving(false);
-    setVideoUrl(String((task as any)?.videoUrl ?? ''));
+    setVideoUrl(getTaskModalVideoUrl(task) ?? '');
     setIsModalVisible(true);
   }, []);
 
@@ -732,7 +746,7 @@ export default function TasksScreen() {
 
   const openVideoModal = useCallback((url: string) => {
     if (!isValidVideoUrl(url)) {
-      Alert.alert('Fejl', 'Ugyldig video URL. Kun YouTube og Vimeo understøttes.');
+      Alert.alert('Fejl', 'Ugyldig video URL. Kun YouTube, Vimeo og Instagram understøttes.');
       return;
     }
     setSelectedVideoUrl(url);
@@ -1083,7 +1097,7 @@ export default function TasksScreen() {
                       style={[styles.input, { backgroundColor: bgColor, color: textColor }]}
                       value={videoUrl}
                       onChangeText={setVideoUrl}
-                      placeholder="https://youtube.com/... eller https://vimeo.com/..."
+                      placeholder="https://youtube.com/... eller https://vimeo.com/... eller https://instagram.com/..."
                       placeholderTextColor={textSecondaryColor}
                       autoCapitalize="none"
                       editable={!isSaving}
@@ -1100,7 +1114,7 @@ export default function TasksScreen() {
                     )}
 
                     {videoUrl.trim() && !isValidVideoUrl(videoUrl) && (
-                      <Text style={[styles.helperText, { color: colors.error }]}>⚠ Ugyldig video URL. Kun YouTube og Vimeo understøttes.</Text>
+                      <Text style={[styles.helperText, { color: colors.error }]}>⚠ Ugyldig video URL. Kun YouTube, Vimeo og Instagram understøttes.</Text>
                     )}
                   </View>
 
@@ -1518,7 +1532,8 @@ const styles = StyleSheet.create({
 
   videoThumbnailWrapper: { height: 180, borderRadius: 12, overflow: 'hidden', marginBottom: 12, backgroundColor: '#000' },
   videoThumbnail: { width: '100%', height: '100%' },
-  videoThumbnailFallback: { width: '100%', height: '100%', backgroundColor: '#000' },
+  videoThumbnailFallback: { width: '100%', height: '100%', backgroundColor: '#000', alignItems: 'center', justifyContent: 'center' },
+  videoThumbnailFallbackLabel: { color: '#fff', fontSize: 18, fontWeight: '700' },
   videoOverlay: { ...StyleSheet.absoluteFillObject, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.25)' },
 
   videoSection: { marginBottom: 16 },

--- a/components/SmartVideoPlayer.tsx
+++ b/components/SmartVideoPlayer.tsx
@@ -16,6 +16,7 @@ export default function SmartVideoPlayer({ url }: { url?: string }) {
   );
   const youtubeId = parsedVideo?.platform === 'youtube' ? parsedVideo.videoId : null;
   const vimeoId = parsedVideo?.platform === 'vimeo' ? parsedVideo.videoId : null;
+  const instagramUrl = parsedVideo?.platform === 'instagram' ? resolvedUrl : null;
   const inlineVideoHtml = useMemo(() => {
     if (!resolvedUrl || !isDirectVideoUrl(resolvedUrl)) return null;
     return buildVideoHtml(resolvedUrl);
@@ -95,6 +96,24 @@ export default function SmartVideoPlayer({ url }: { url?: string }) {
           style={styles.webView}
         />
       </View>
+    );
+  }
+
+  if (instagramUrl) {
+    return (
+      <Pressable
+        onPress={() => Linking.openURL(instagramUrl)}
+        style={styles.externalLinkCard}
+        testID="smart-video-player.external-link"
+      >
+        <View style={styles.externalLinkBadge}>
+          <Text style={styles.externalLinkBadgeText}>Instagram</Text>
+        </View>
+        <Text style={styles.externalLinkTitle}>Aabn Instagram-video</Text>
+        <Text style={styles.externalLinkSubtitle} numberOfLines={1}>
+          {instagramUrl}
+        </Text>
+      </Pressable>
     );
   }
 
@@ -228,6 +247,36 @@ const styles = StyleSheet.create({
   thumbImage: {
     height: 220,
     width: '100%',
+  },
+  externalLinkCard: {
+    height: 220,
+    borderRadius: 16,
+    backgroundColor: '#111827',
+    paddingHorizontal: 20,
+    paddingVertical: 18,
+    justifyContent: 'center',
+    gap: 10,
+  },
+  externalLinkBadge: {
+    alignSelf: 'flex-start',
+    borderRadius: 999,
+    backgroundColor: '#E1306C',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  externalLinkBadgeText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  externalLinkTitle: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  externalLinkSubtitle: {
+    color: 'rgba(255,255,255,0.72)',
+    fontSize: 13,
   },
   playButtonOverlay: {
     position: 'absolute',

--- a/integrations/supabase/types.ts
+++ b/integrations/supabase/types.ts
@@ -33,6 +33,7 @@ export type Database = {
           location: string | null
           manually_set_category: boolean | null
           player_id: string | null
+          source_activity_id: string | null
           series_id: string | null
           series_instance_date: string | null
           team_id: string | null
@@ -58,6 +59,7 @@ export type Database = {
           location?: string | null
           manually_set_category?: boolean | null
           player_id?: string | null
+          source_activity_id?: string | null
           series_id?: string | null
           series_instance_date?: string | null
           team_id?: string | null
@@ -83,6 +85,7 @@ export type Database = {
           location?: string | null
           manually_set_category?: boolean | null
           player_id?: string | null
+          source_activity_id?: string | null
           series_id?: string | null
           series_instance_date?: string | null
           team_id?: string | null
@@ -103,6 +106,13 @@ export type Database = {
             columns: ["series_id"]
             isOneToOne: false
             referencedRelation: "activity_series"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "activities_source_activity_id_fkey"
+            columns: ["source_activity_id"]
+            isOneToOne: false
+            referencedRelation: "activities"
             referencedColumns: ["id"]
           },
           {
@@ -609,6 +619,7 @@ export type Database = {
           pinned: boolean | null
           player_id: string | null
           reminders: Json | null
+          source_local_meta_id: string | null
           team_id: string | null
           updated_at: string | null
           user_id: string
@@ -633,6 +644,7 @@ export type Database = {
           pinned?: boolean | null
           player_id?: string | null
           reminders?: Json | null
+          source_local_meta_id?: string | null
           team_id?: string | null
           updated_at?: string | null
           user_id: string
@@ -657,6 +669,7 @@ export type Database = {
           pinned?: boolean | null
           player_id?: string | null
           reminders?: Json | null
+          source_local_meta_id?: string | null
           team_id?: string | null
           updated_at?: string | null
           user_id?: string
@@ -674,6 +687,13 @@ export type Database = {
             columns: ["external_event_id"]
             isOneToOne: false
             referencedRelation: "events_external"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "events_local_meta_source_local_meta_id_fkey"
+            columns: ["source_local_meta_id"]
+            isOneToOne: false
+            referencedRelation: "events_local_meta"
             referencedColumns: ["id"]
           },
           {

--- a/services/taskService.ts
+++ b/services/taskService.ts
@@ -783,15 +783,21 @@ export const taskService = {
       throw new Error('User not authenticated');
     }
 
-    const table = isExternal ? 'external_event_tasks' : 'activity_tasks';
-    const activityColumn = isExternal ? 'local_meta_id' : 'activity_id';
+    const result = isExternal
+      ? await supabase
+          .from('external_event_tasks')
+          .delete({ count: 'exact' })
+          .eq('id', taskId)
+          .eq('local_meta_id', activityId)
+          .abortSignal(signal)
+      : await supabase
+          .from('activity_tasks')
+          .delete({ count: 'exact' })
+          .eq('id', taskId)
+          .eq('activity_id', activityId)
+          .abortSignal(signal);
 
-    const { error, count } = await supabase
-      .from(table)
-      .delete({ count: 'exact' })
-      .eq('id', taskId)
-      .eq(activityColumn, activityId)
-      .abortSignal(signal);
+    const { error, count } = result;
 
     if (error) {
       throw error;

--- a/utils/videoUrlParser.ts
+++ b/utils/videoUrlParser.ts
@@ -1,7 +1,7 @@
 
 /**
  * Video URL Parser Utility
- * Provides functions to parse and validate YouTube and Vimeo URLs
+ * Provides functions to parse and validate YouTube, Vimeo, and Instagram URLs
  * 
  * IMPORTANT: Only embed URLs should be loaded in WebView
  * - YouTube: https://www.youtube.com/embed/{videoId}
@@ -10,7 +10,7 @@
  */
 
 export interface VideoInfo {
-  platform: 'youtube' | 'vimeo' | 'unsupported';
+  platform: 'youtube' | 'vimeo' | 'instagram' | 'unsupported';
   videoId: string | null;
   embedUrl: string | null;
   thumbnailUrl: string | null;
@@ -98,9 +98,37 @@ function parseVimeoVideoId(url: string): string | null {
   return null;
 }
 
+function parseInstagramVideoId(url: string): string | null {
+  const parsed = safeParseUrl(url);
+  if (parsed) {
+    const host = normalizeHost(parsed.hostname);
+    if (host === 'instagram.com') {
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      if (!segments.length) return null;
+
+      if (segments[0] === 'reel' || segments[0] === 'p' || segments[0] === 'tv') {
+        return sanitizeVideoId(segments[1] ?? null);
+      }
+    }
+  }
+
+  const regexFallbacks = [
+    /(?:instagram\.com\/reel\/)([^&\n?#/]+)/i,
+    /(?:instagram\.com\/p\/)([^&\n?#/]+)/i,
+    /(?:instagram\.com\/tv\/)([^&\n?#/]+)/i,
+  ];
+
+  for (const pattern of regexFallbacks) {
+    const match = url.match(pattern);
+    if (match?.[1]) return sanitizeVideoId(match[1]);
+  }
+
+  return null;
+}
+
 /**
  * Parse video URL and extract platform information
- * Converts any valid YouTube or Vimeo URL to proper embed format
+ * Converts supported URLs to platform metadata
  */
 export function parseVideoUrl(url: string): VideoInfo {
   if (!url || !url.trim()) {
@@ -130,6 +158,16 @@ export function parseVideoUrl(url: string): VideoInfo {
       platform: 'vimeo',
       videoId: vimeoId,
       embedUrl: `https://player.vimeo.com/video/${vimeoId}`,
+      thumbnailUrl: null,
+    };
+  }
+
+  const instagramId = parseInstagramVideoId(trimmedUrl);
+  if (instagramId) {
+    return {
+      platform: 'instagram',
+      videoId: instagramId,
+      embedUrl: null,
       thumbnailUrl: null,
     };
   }
@@ -175,18 +213,17 @@ export function getVideoThumbnail(url: string): string | null {
 }
 
 /**
- * Check if URL is a valid video URL (YouTube or Vimeo)
- * Returns true only if the URL can be converted to a valid embed URL
+ * Check if URL is a supported video URL (YouTube, Vimeo, or Instagram)
  */
 export function isValidVideoUrl(url: string): boolean {
   const videoInfo = parseVideoUrl(url);
-  return videoInfo.platform !== 'unsupported' && videoInfo.videoId !== null && videoInfo.embedUrl !== null;
+  return videoInfo.platform !== 'unsupported' && videoInfo.videoId !== null;
 }
 
 /**
  * Get platform name from URL
  */
-export function getVideoPlatform(url: string): 'youtube' | 'vimeo' | 'unsupported' {
+export function getVideoPlatform(url: string): 'youtube' | 'vimeo' | 'instagram' | 'unsupported' {
   const videoInfo = parseVideoUrl(url);
   return videoInfo.platform;
 }


### PR DESCRIPTION
## Summary
Denne PR tilføjer Instagram-støtte i opgaveskabelonens videofelt og retter en fejl, hvor gemte Instagram-links kunne forsvinde, når man åbnede opgaven igen.

## Changes
- Tillader Instagram-links i samme felt som YouTube- og Vimeo-links på opgaveskabeloner
- Udvider video-parseren til også at genkende Instagram `reel`, `p` og `tv` links
- Opdaterer video-preview, så Instagram-links vises som et eksternt linkkort i stedet for embed
- Gør `tasks`-skærmen robust ved genåbning af opgaver, så både `videoUrl` og `video_url` læses korrekt
- Opdaterer hjælpetekster og valideringsbeskeder i UI til også at nævne Instagram

## Why
Brugeren skal kunne indsætte Instagram-links i opgaveskabeloner på samme måde som YouTube og Vimeo.
Derudover blev Instagram-linket ikke altid vist igen ved genåbning, fordi skærmen kun læste én variant af videofeltet.

## Testing
- `npm test -- --runInBand __tests__/videoUrlParser.test.ts`
- `npm test -- --runInBand __tests__/smartVideoPlayer.component.test.tsx`
- `npm test -- --runInBand __tests__/tasks.screen.no-subtasks.test.tsx`
- `npm run typecheck`

## Notes
- Instagram-links åbnes eksternt via link i appen, ikke som inline embed
- Eksisterende testmiljø-warnings fra Expo/VirtualizedList er uændrede
