### PR TITLE
speed up app startup and resume

### DIFF
--- a/__tests__/OnboardingGate.test.tsx
+++ b/__tests__/OnboardingGate.test.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { Text } from 'react-native';
-import { act, render, screen } from '@testing-library/react-native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import { OnboardingGate } from '@/components/OnboardingGate';
 import { TimeoutError } from '@/utils/withTimeout';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const mockReplace = jest.fn();
 const mockPathname = jest.fn(() => '/(tabs)');
-const mockGetSession = jest.fn();
-const mockOnAuthStateChange = jest.fn();
-const mockUnsubscribe = jest.fn();
+const mockRefreshAuthSession = jest.fn();
 const mockRefreshSubscription = jest.fn();
 const mockCreateSubscription = jest.fn();
 const mockRefreshSubscriptionStatus = jest.fn();
@@ -23,8 +21,27 @@ const mockEq = jest.fn();
 const mockSelect = jest.fn();
 const mockUpsert = jest.fn();
 const mockFrom = jest.fn();
+let mockAuthSessionValue: any;
 let consoleWarnSpy: jest.SpyInstance;
-let authStateHandler: ((event: string, session: { user: any } | null) => void) | null = null;
+
+const setMockAuthSession = ({
+  authReady = true,
+  user = null,
+  refreshSession,
+}: {
+  authReady?: boolean;
+  user?: { id: string } | null;
+  refreshSession?: jest.Mock<any, any>;
+} = {}) => {
+  const session = user ? { user } : null;
+  mockAuthSessionValue = {
+    authReady,
+    isAuthenticated: Boolean(user),
+    session,
+    user,
+    refreshSession: refreshSession ?? mockRefreshAuthSession,
+  };
+};
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
@@ -60,12 +77,12 @@ jest.mock('@/contexts/AppleIAPContext', () => ({
   }),
 }));
 
+jest.mock('@/contexts/AuthSessionContext', () => ({
+  useAuthSession: () => mockAuthSessionValue,
+}));
+
 jest.mock('@/integrations/supabase/client', () => ({
   supabase: {
-    auth: {
-      getSession: (...args: unknown[]) => mockGetSession(...args),
-      onAuthStateChange: (...args: unknown[]) => mockOnAuthStateChange(...args),
-    },
     from: (...args: unknown[]) => mockFrom(...args),
   },
 }));
@@ -76,9 +93,7 @@ describe('OnboardingGate startup hydration', () => {
 
     mockReplace.mockReset();
     mockPathname.mockReset();
-    mockGetSession.mockReset();
-    mockOnAuthStateChange.mockReset();
-    mockUnsubscribe.mockReset();
+    mockRefreshAuthSession.mockReset();
     mockRefreshSubscription.mockReset();
     mockCreateSubscription.mockReset();
     mockRefreshSubscriptionStatus.mockReset();
@@ -92,7 +107,8 @@ describe('OnboardingGate startup hydration', () => {
     (AsyncStorage.removeItem as jest.Mock).mockReset();
 
     mockPathname.mockReturnValue('/(tabs)');
-    mockGetSession.mockResolvedValue({ data: { session: null } });
+    mockRefreshAuthSession.mockResolvedValue(null);
+    setMockAuthSession({ authReady: true, user: null });
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
     (AsyncStorage.setItem as jest.Mock).mockResolvedValue(null);
     (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(null);
@@ -109,14 +125,6 @@ describe('OnboardingGate startup hydration', () => {
       select: mockSelect,
       upsert: mockUpsert,
     });
-
-    authStateHandler = null;
-    mockOnAuthStateChange.mockImplementation((handler: (event: string, session: { user: any } | null) => void) => {
-      authStateHandler = handler;
-      return {
-        data: { subscription: { unsubscribe: mockUnsubscribe } },
-      };
-    });
   });
 
   afterEach(() => {
@@ -126,7 +134,8 @@ describe('OnboardingGate startup hydration', () => {
   });
 
   it('falls back to non-blocking state when startup session lookup times out', async () => {
-    mockGetSession.mockImplementation(() => new Promise(() => {}));
+    setMockAuthSession({ authReady: true, user: { id: 'user-1' } });
+    mockMaybeSingle.mockImplementation(() => new Promise(() => {}));
 
     render(
       <OnboardingGate>
@@ -149,10 +158,11 @@ describe('OnboardingGate startup hydration', () => {
   });
 
   it('uses cached approved access when startup session lookup times out', async () => {
-    mockGetSession.mockImplementation(() => new Promise(() => {}));
+    setMockAuthSession({ authReady: true, user: { id: 'user-1' } });
+    mockMaybeSingle.mockImplementation(() => new Promise(() => {}));
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
       JSON.stringify({
-        userId: 'cached-user-1',
+        userId: 'user-1',
         role: 'player',
         hasApprovedAccess: true,
         updatedAt: '2026-03-01T00:00:00.000Z',
@@ -172,13 +182,13 @@ describe('OnboardingGate startup hydration', () => {
 
     expect(screen.getByText('App indhold')).toBeTruthy();
     expect(screen.queryByText('Kunne ikke klargøre konto. Prøv igen.')).toBeNull();
-    expect(AsyncStorage.getItem).toHaveBeenCalled();
   });
 
   it('does not overwrite newer hydrated state when bootstrap times out later', async () => {
-    mockGetSession.mockImplementation(() => new Promise(() => {}));
+    setMockAuthSession({ authReady: true, user: { id: 'user-1' } });
+    mockMaybeSingle.mockImplementation(() => new Promise(() => {}));
 
-    render(
+    const { rerender } = render(
       <OnboardingGate>
         <Text>App indhold</Text>
       </OnboardingGate>
@@ -188,12 +198,12 @@ describe('OnboardingGate startup hydration', () => {
     expect(screen.queryByText('Klargører konto')).toBeNull();
 
     await act(async () => {
-      await Promise.resolve();
-    });
-    expect(authStateHandler).toBeTruthy();
-
-    await act(async () => {
-      authStateHandler?.('INITIAL_SESSION', { user: null });
+      setMockAuthSession({ authReady: true, user: null });
+      rerender(
+        <OnboardingGate>
+          <Text>App indhold</Text>
+        </OnboardingGate>
+      );
       await Promise.resolve();
     });
 
@@ -210,24 +220,34 @@ describe('OnboardingGate startup hydration', () => {
   });
 
   it('does not overwrite newer hydrated state when retry times out later', async () => {
-    mockGetSession.mockImplementation(() => new Promise(() => {}));
+    setMockAuthSession({ authReady: true, user: { id: 'user-1' } });
+    mockMaybeSingle.mockRejectedValue(new Error('initial startup failed'));
+    mockRefreshAuthSession.mockImplementation(() => new Promise(() => {}));
 
-    render(
+    const { rerender } = render(
       <OnboardingGate>
         <Text>App indhold</Text>
       </OnboardingGate>
     );
 
     await act(async () => {
-      jest.advanceTimersByTime(12000);
       await Promise.resolve();
     });
 
-    expect(screen.queryByTestId('onboarding.error.retryButton')).toBeNull();
-    expect(screen.queryByText('Klargører konto')).toBeNull();
+    expect(screen.getByTestId('onboarding.error.retryButton')).toBeTruthy();
 
     await act(async () => {
-      authStateHandler?.('INITIAL_SESSION', { user: null });
+      fireEvent.press(screen.getByTestId('onboarding.error.retryButton'));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      setMockAuthSession({ authReady: true, user: null });
+      rerender(
+        <OnboardingGate>
+          <Text>App indhold</Text>
+        </OnboardingGate>
+      );
       await Promise.resolve();
     });
 
@@ -244,7 +264,7 @@ describe('OnboardingGate startup hydration', () => {
   });
 
   it('falls back to non-blocking state when role lookup times out', async () => {
-    mockGetSession.mockResolvedValue({ data: { session: { user: { id: 'user-1' } } } });
+    setMockAuthSession({ authReady: true, user: { id: 'user-1' } });
     mockMaybeSingle.mockRejectedValue(new TimeoutError('Onboarding role query timed out'));
 
     render(

--- a/__tests__/home.performance-card-hours.test.tsx
+++ b/__tests__/home.performance-card-hours.test.tsx
@@ -10,6 +10,7 @@ const mockUseFootball = jest.fn();
 const mockUseUserRole = jest.fn();
 const mockUseAdmin = jest.fn();
 const mockUseTeamPlayer = jest.fn();
+const mockUseAuthSession = jest.fn();
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({ push: mockPush }),
@@ -41,6 +42,10 @@ jest.mock('@/contexts/AdminContext', () => ({
 
 jest.mock('@/contexts/TeamPlayerContext', () => ({
   useTeamPlayer: () => mockUseTeamPlayer(),
+}));
+
+jest.mock('@/contexts/AuthSessionContext', () => ({
+  useAuthSession: () => mockUseAuthSession(),
 }));
 
 jest.mock('@/services/feedbackService', () => ({
@@ -120,6 +125,13 @@ jest.mock('@/integrations/supabase/client', () => ({
 describe('Home performance card hour sums', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseAuthSession.mockReturnValue({
+      authReady: true,
+      isAuthenticated: true,
+      user: { id: 'user-1' },
+      session: { user: { id: 'user-1' } },
+      refreshSession: jest.fn().mockResolvedValue({ user: { id: 'user-1' } }),
+    });
 
     const now = new Date();
     const today = new Date(now);
@@ -200,6 +212,8 @@ describe('Home performance card hour sums', () => {
       categories: [],
       createActivity: jest.fn(),
       refreshData: jest.fn(),
+      ensureTemplateDataLoaded: jest.fn().mockResolvedValue(undefined),
+      ensureCurrentWeekStatsLoaded: jest.fn().mockResolvedValue(undefined),
       currentWeekStats: {
         percentage: 60,
         completedTasks: 3,

--- a/__tests__/library.screen.test.tsx
+++ b/__tests__/library.screen.test.tsx
@@ -9,6 +9,7 @@ const mockUseUserRole = jest.fn();
 const mockUseSubscriptionFeatures = jest.fn();
 const mockUseTeamPlayer = jest.fn();
 const mockUseFootball = jest.fn();
+const mockUseAuthSession = jest.fn();
 
 const mockAuthGetUser = jest.fn();
 const mockResolveQuery = jest.fn();
@@ -35,6 +36,10 @@ jest.mock('@/contexts/TeamPlayerContext', () => ({
 
 jest.mock('@/contexts/FootballContext', () => ({
   useFootball: () => mockUseFootball(),
+}));
+
+jest.mock('@/contexts/AuthSessionContext', () => ({
+  useAuthSession: () => mockUseAuthSession(),
 }));
 
 jest.mock('@/components/IconSymbol', () => {
@@ -230,6 +235,13 @@ function setupSupabaseFixture({
 describe('Library screen gating and card state', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseAuthSession.mockReturnValue({
+      authReady: true,
+      isAuthenticated: true,
+      user: { id: 'user-1' },
+      session: { user: { id: 'user-1' } },
+      refreshSession: jest.fn().mockResolvedValue({ user: { id: 'user-1' } }),
+    });
 
     mockUseTeamPlayer.mockReturnValue({
       players: [],

--- a/__tests__/tasks.screen.delete-confirmation.test.tsx
+++ b/__tests__/tasks.screen.delete-confirmation.test.tsx
@@ -5,6 +5,7 @@ import TasksScreen from '../app/(tabs)/tasks';
 
 const mockUseFootball = jest.fn();
 const mockUseAdmin = jest.fn();
+const mockUseAuthSession = jest.fn();
 
 jest.mock('@/contexts/FootballContext', () => ({
   useFootball: () => mockUseFootball(),
@@ -12,6 +13,14 @@ jest.mock('@/contexts/FootballContext', () => ({
 
 jest.mock('@/contexts/AdminContext', () => ({
   useAdmin: () => mockUseAdmin(),
+}));
+
+jest.mock('@/contexts/AuthSessionContext', () => ({
+  useAuthSession: () => mockUseAuthSession(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: () => {},
 }));
 
 jest.mock('@/components/IconSymbol', () => {
@@ -64,6 +73,13 @@ jest.mock('@/integrations/supabase/client', () => ({
 describe('Tasks delete confirmation modal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseAuthSession.mockReturnValue({
+      authReady: true,
+      isAuthenticated: true,
+      user: { id: 'user-1' },
+      session: { user: { id: 'user-1' } },
+      refreshSession: jest.fn().mockResolvedValue({ user: { id: 'user-1' } }),
+    });
 
     mockUseAdmin.mockReturnValue({
       adminMode: 'self',

--- a/__tests__/tasks.screen.no-subtasks.test.tsx
+++ b/__tests__/tasks.screen.no-subtasks.test.tsx
@@ -6,6 +6,7 @@ import TasksScreen from '../app/(tabs)/tasks';
 const mockUseFootball = jest.fn();
 const mockUseAdmin = jest.fn();
 const mockCreateTask = jest.fn();
+const mockUseAuthSession = jest.fn();
 
 jest.mock('@/contexts/FootballContext', () => ({
   useFootball: () => mockUseFootball(),
@@ -13,6 +14,14 @@ jest.mock('@/contexts/FootballContext', () => ({
 
 jest.mock('@/contexts/AdminContext', () => ({
   useAdmin: () => mockUseAdmin(),
+}));
+
+jest.mock('@/contexts/AuthSessionContext', () => ({
+  useAuthSession: () => mockUseAuthSession(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: () => {},
 }));
 
 jest.mock('@/services/taskService', () => ({
@@ -72,6 +81,13 @@ jest.mock('@/integrations/supabase/client', () => ({
 describe('Tasks template editor without subtasks', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseAuthSession.mockReturnValue({
+      authReady: true,
+      isAuthenticated: true,
+      user: { id: 'user-1' },
+      session: { user: { id: 'user-1' } },
+      refreshSession: jest.fn().mockResolvedValue({ user: { id: 'user-1' } }),
+    });
     mockCreateTask.mockResolvedValue({
       id: 'template-created',
       title: 'Ny skabelon',

--- a/__tests__/useFootballData.performance.test.ts
+++ b/__tests__/useFootballData.performance.test.ts
@@ -19,14 +19,36 @@ const mockAdminState = {
   adminTargetId: null as string | null,
   adminTargetType: null as 'player' | 'team' | null,
 };
-let mockSessionUserId = 'user-1';
-let authStateChangeHandler: ((event: string, session: { user: { id: string } } | null) => void) | null = null;
+let mockAuthSessionValue: any;
 let mockWeeklyPerformanceRows: any[] = [];
 let mockLegacyTrophyRows: any[] = [];
 let mockExternalCalendarsRows: any[] = [];
 
+const setMockAuthSession = ({
+  authReady = true,
+  user = { id: 'user-1' },
+  refreshSession,
+}: {
+  authReady?: boolean;
+  user?: { id: string } | null;
+  refreshSession?: jest.Mock<any, any>;
+} = {}) => {
+  const session = user ? { user } : null;
+  mockAuthSessionValue = {
+    authReady,
+    isAuthenticated: Boolean(user),
+    session,
+    user,
+    refreshSession: refreshSession ?? jest.fn().mockResolvedValue(session),
+  };
+};
+
 jest.mock('@/contexts/AdminContext', () => ({
   useAdmin: () => mockAdminState,
+}));
+
+jest.mock('@/contexts/AuthSessionContext', () => ({
+  useAuthSession: () => mockAuthSessionValue,
 }));
 
 jest.mock('@/contexts/CelebrationContext', () => ({
@@ -125,15 +147,10 @@ jest.mock('@/integrations/supabase/client', () => {
     supabase: {
       auth: {
         getSession: jest.fn(async () => ({
-          data: {
-            session: mockSessionUserId ? { user: { id: mockSessionUserId } } : null,
-          },
+          data: { session: { user: { id: 'user-1' } } },
           error: null,
         })),
-        onAuthStateChange: jest.fn((callback: any) => {
-          authStateChangeHandler = callback;
-          return { data: { subscription: { unsubscribe: jest.fn() } } };
-        }),
+        onAuthStateChange: jest.fn(() => ({ data: { subscription: { unsubscribe: jest.fn() } } })),
       },
       from: jest.fn((tableName: string) => createQueryBuilder(tableName)),
       channel: jest.fn(() => ({
@@ -418,8 +435,7 @@ describe('useFootballData lazy-load reset', () => {
     mockAdminState.adminMode = 'self';
     mockAdminState.adminTargetId = null;
     mockAdminState.adminTargetType = null;
-    mockSessionUserId = 'user-1';
-    authStateChangeHandler = null;
+    setMockAuthSession({ user: { id: 'user-1' } });
     mockWeeklyPerformanceRows = [];
     mockLegacyTrophyRows = [];
     mockExternalCalendarsRows = [];
@@ -483,7 +499,7 @@ describe('useFootballData lazy-load reset', () => {
       },
     ];
 
-    const { result } = renderHook(() => useFootballData());
+    const { result, rerender } = renderHook(() => useFootballData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -498,9 +514,9 @@ describe('useFootballData lazy-load reset', () => {
     expect(result.current.hasPerformanceDataLoaded).toBe(true);
     expect(result.current.trophies).toHaveLength(1);
 
-    mockSessionUserId = 'user-2';
+    setMockAuthSession({ user: { id: 'user-2' } });
     await act(async () => {
-      authStateChangeHandler?.('SIGNED_IN', { user: { id: 'user-2' } });
+      rerender();
     });
 
     await waitFor(() => {

--- a/__tests__/useFootballData.performance.test.ts
+++ b/__tests__/useFootballData.performance.test.ts
@@ -499,7 +499,12 @@ describe('useFootballData lazy-load reset', () => {
       },
     ];
 
-    const { result, rerender } = renderHook(() => useFootballData());
+    const { result, rerender } = renderHook(({ sessionVersion }: { sessionVersion: number }) => {
+      void sessionVersion;
+      return useFootballData();
+    }, {
+      initialProps: { sessionVersion: 0 },
+    });
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -516,7 +521,7 @@ describe('useFootballData lazy-load reset', () => {
 
     setMockAuthSession({ user: { id: 'user-2' } });
     await act(async () => {
-      rerender();
+      rerender({ sessionVersion: 1 });
     });
 
     await waitFor(() => {

--- a/app/(tabs)/(home)/index.ios.tsx
+++ b/app/(tabs)/(home)/index.ios.tsx
@@ -58,7 +58,7 @@
  */
 
 import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react';
-import { BackHandler, FlatList, View, Text, StyleSheet, Pressable, StatusBar, RefreshControl, Platform, useColorScheme, DeviceEventEmitter, Image, ImageBackground } from 'react-native';
+import { BackHandler, FlatList, View, Text, StyleSheet, Pressable, StatusBar, RefreshControl, Platform, useColorScheme, DeviceEventEmitter, Image, ImageBackground, InteractionManager } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Svg, { Defs, Stop, LinearGradient as SvgLinearGradient, Circle, G } from 'react-native-svg';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -66,6 +66,7 @@ import { useRouter } from 'expo-router';
 import { useFocusEffect } from '@react-navigation/native';
 import { useHomeActivities } from '@/hooks/useHomeActivities';
 import { useFootball } from '@/contexts/FootballContext';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { useAdmin } from '@/contexts/AdminContext';
 import { useTeamPlayer } from '@/contexts/TeamPlayerContext';
 import ActivityCard from '@/components/ActivityCard';
@@ -228,6 +229,8 @@ const THIS_WEEK_PREMIUM_BG = require('../../../assets/images/home_this_week_prem
 const THIS_WEEK_CARD_RADIUS = 28;
 const THIS_WEEK_BG_CROP_RADIUS = THIS_WEEK_CARD_RADIUS;
 const HOME_REFRESH_TIMEOUT_MS = 10000;
+const HOME_STATS_REFRESH_STALE_MS = 2 * 60 * 1000;
+const HOME_STATS_REFRESH_MIN_INTERVAL_MS = 30 * 1000;
 
 const ThisWeekPremiumCard = React.memo(function ThisWeekPremiumCard({
   weekLabel,
@@ -1053,6 +1056,7 @@ function getActivityTasks(activity: any): any[] {
 export default function HomeScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const { user } = useAuthSession();
   const {
     activities,
     loading,
@@ -1065,6 +1069,8 @@ export default function HomeScreen() {
     isLoading: footballLoading,
     currentWeekStats,
     hasCurrentWeekStatsLoaded,
+    ensureTemplateDataLoaded,
+    ensureCurrentWeekStatsLoaded,
     updateIntensityByCategory,
   } = useFootball();
   const { adminMode, adminTargetType } = useAdmin();
@@ -1085,6 +1091,8 @@ export default function HomeScreen() {
   const isDark = colorScheme === 'dark';
   const emittedHomeReadyRef = useRef(false);
   const didSkipInitialFocusRefreshRef = useRef(false);
+  const lastStatsRefreshStartedAtRef = useRef(0);
+  const lastStatsRefreshCompletedAtRef = useRef(0);
 
   useEffect(() => {
     if (loading || emittedHomeReadyRef.current) return;
@@ -1184,26 +1192,34 @@ export default function HomeScreen() {
     return m;
   }, [categories]);
 
-  // Fetch current trainer ID (the logged-in user who is administering)
   useEffect(() => {
-    async function fetchCurrentTrainerId() {
-      try {
-        const {
-          data: { session },
-        } = await supabase.auth.getSession();
-        const user = session?.user;
-        if (user) {
-          setCurrentTrainerId(user.id);
-          setCurrentUserId(user.id);
-        }
-      } catch (error) {
-        console.error('[Home] Error fetching current trainer ID:', error);
-        // STEP H: Safe fallback - no throw
-      }
-    }
+    const nextUserId = user?.id ?? null;
+    setCurrentTrainerId(nextUserId);
+    setCurrentUserId(nextUserId);
+  }, [user?.id]);
 
-    fetchCurrentTrainerId();
-  }, []);
+  useEffect(() => {
+    const interaction = InteractionManager.runAfterInteractions(() => {
+      void ensureTemplateDataLoaded().catch((error) => {
+        console.error('[Home] Deferred template load failed:', error);
+      });
+      void ensureCurrentWeekStatsLoaded()
+        .then(() => {
+          lastStatsRefreshCompletedAtRef.current = Date.now();
+        })
+        .catch((error) => {
+          console.error('[Home] Deferred stats load failed:', error);
+        });
+    });
+    return () => {
+      interaction.cancel();
+    };
+  }, [ensureCurrentWeekStatsLoaded, ensureTemplateDataLoaded]);
+
+  useEffect(() => {
+    if (!hasCurrentWeekStatsLoaded || lastStatsRefreshCompletedAtRef.current) return;
+    lastStatsRefreshCompletedAtRef.current = Date.now();
+  }, [hasCurrentWeekStatsLoaded]);
 
   // Reset previously loaded week count when loading starts (pull-to-refresh or navigation back)
   useEffect(() => {
@@ -1474,10 +1490,36 @@ export default function HomeScreen() {
         return;
       }
       if (loading || footballLoading) return;
-      void refreshHomeScreen('focus').catch((error) => {
-        console.error('[Home] Focus refresh failed:', error);
+      const now = Date.now();
+      if (now - lastStatsRefreshStartedAtRef.current < HOME_STATS_REFRESH_MIN_INTERVAL_MS) {
+        return;
+      }
+      const shouldForceStatsRefresh =
+        hasCurrentWeekStatsLoaded &&
+        now - lastStatsRefreshCompletedAtRef.current >= HOME_STATS_REFRESH_STALE_MS;
+
+      if (!shouldForceStatsRefresh && hasCurrentWeekStatsLoaded) {
+        return;
+      }
+
+      lastStatsRefreshStartedAtRef.current = now;
+      void ensureCurrentWeekStatsLoaded(shouldForceStatsRefresh)
+        .then(() => {
+          lastStatsRefreshCompletedAtRef.current = Date.now();
+        })
+        .catch((error) => {
+          console.error('[Home] Focus stats refresh failed:', error);
+        });
+      void ensureTemplateDataLoaded().catch((error) => {
+        console.error('[Home] Focus template refresh failed:', error);
       });
-    }, [footballLoading, loading, refreshHomeScreen])
+    }, [
+      ensureCurrentWeekStatsLoaded,
+      ensureTemplateDataLoaded,
+      footballLoading,
+      hasCurrentWeekStatsLoaded,
+      loading,
+    ])
   );
 
   useEffect(() => {

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -58,13 +58,14 @@
  */
 
 import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react';
-import { BackHandler, FlatList, View, Text, StyleSheet, Pressable, StatusBar, RefreshControl, Platform, useColorScheme, DeviceEventEmitter, Image, ImageBackground } from 'react-native';
+import { BackHandler, FlatList, View, Text, StyleSheet, Pressable, StatusBar, RefreshControl, Platform, useColorScheme, DeviceEventEmitter, Image, ImageBackground, InteractionManager } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Svg, { Defs, Stop, LinearGradient as SvgLinearGradient, Circle, G } from 'react-native-svg';
 import { useRouter } from 'expo-router';
 import { useFocusEffect } from '@react-navigation/native';
 import { useHomeActivities } from '@/hooks/useHomeActivities';
 import { useFootball } from '@/contexts/FootballContext';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { useUserRole } from '@/hooks/useUserRole';
 import { useAdmin } from '@/contexts/AdminContext';
 import { useTeamPlayer } from '@/contexts/TeamPlayerContext';
@@ -188,6 +189,8 @@ const THIS_WEEK_PREMIUM_BG = require('../../../assets/images/home_this_week_prem
 const THIS_WEEK_CARD_RADIUS = 28;
 const THIS_WEEK_BG_CROP_RADIUS = THIS_WEEK_CARD_RADIUS;
 const HOME_REFRESH_TIMEOUT_MS = 10000;
+const HOME_STATS_REFRESH_STALE_MS = 2 * 60 * 1000;
+const HOME_STATS_REFRESH_MIN_INTERVAL_MS = 30 * 1000;
 const HOME_REFRESH_TELEMETRY_ROUTE = '/';
 
 type HomeRefreshSource = 'focus' | 'pull_to_refresh';
@@ -1062,6 +1065,7 @@ function getActivityTasks(activity: any): any[] {
 
 export default function HomeScreen() {
   const router = useRouter();
+  const { user } = useAuthSession();
   const { userRole } = useUserRole();
   const {
     activities,
@@ -1075,6 +1079,8 @@ export default function HomeScreen() {
     isLoading: footballLoading,
     currentWeekStats,
     hasCurrentWeekStatsLoaded,
+    ensureTemplateDataLoaded,
+    ensureCurrentWeekStatsLoaded,
     toggleTaskCompletion,
     updateActivitySingle,
     updateIntensityByCategory,
@@ -1105,6 +1111,8 @@ export default function HomeScreen() {
   const isDark = colorScheme === 'dark';
   const emittedHomeReadyRef = useRef(false);
   const didSkipInitialFocusRefreshRef = useRef(false);
+  const lastStatsRefreshStartedAtRef = useRef(0);
+  const lastStatsRefreshCompletedAtRef = useRef(0);
 
   useEffect(() => {
     if (loading || emittedHomeReadyRef.current) return;
@@ -1194,26 +1202,34 @@ export default function HomeScreen() {
   const isTeamAdmin = adminMode !== 'self' && adminTargetId === 'team';
   const isAdminMode = isPlayerAdmin || isTeamAdmin;
 
-  // Fetch current trainer ID (the logged-in user who is administering)
   useEffect(() => {
-    async function fetchCurrentTrainerId() {
-      try {
-        const {
-          data: { session },
-        } = await supabase.auth.getSession();
-        const user = session?.user;
-        if (user) {
-          setCurrentTrainerId(user.id);
-          setCurrentUserId(user.id);
-        }
-      } catch (error) {
-        console.error('[Home] Error fetching current trainer ID:', error);
-        // STEP H: Safe fallback - no throw
-      }
-    }
+    const nextUserId = user?.id ?? null;
+    setCurrentTrainerId(nextUserId);
+    setCurrentUserId(nextUserId);
+  }, [user?.id]);
 
-    fetchCurrentTrainerId();
-  }, []);
+  useEffect(() => {
+    const interaction = InteractionManager.runAfterInteractions(() => {
+      void ensureTemplateDataLoaded().catch((error) => {
+        console.error('[Home] Deferred template load failed:', error);
+      });
+      void ensureCurrentWeekStatsLoaded()
+        .then(() => {
+          lastStatsRefreshCompletedAtRef.current = Date.now();
+        })
+        .catch((error) => {
+          console.error('[Home] Deferred stats load failed:', error);
+        });
+    });
+    return () => {
+      interaction.cancel();
+    };
+  }, [ensureCurrentWeekStatsLoaded, ensureTemplateDataLoaded]);
+
+  useEffect(() => {
+    if (!hasCurrentWeekStatsLoaded || lastStatsRefreshCompletedAtRef.current) return;
+    lastStatsRefreshCompletedAtRef.current = Date.now();
+  }, [hasCurrentWeekStatsLoaded]);
 
   // Reset previously loaded week count when loading starts (pull-to-refresh or navigation back)
   useEffect(() => {
@@ -1467,10 +1483,36 @@ export default function HomeScreen() {
         return;
       }
       if (loading || footballLoading) return;
-      void refreshHomeScreen('focus').catch((error) => {
-        console.error('[Home] Focus refresh failed:', error);
+      const now = Date.now();
+      if (now - lastStatsRefreshStartedAtRef.current < HOME_STATS_REFRESH_MIN_INTERVAL_MS) {
+        return;
+      }
+      const shouldForceStatsRefresh =
+        hasCurrentWeekStatsLoaded &&
+        now - lastStatsRefreshCompletedAtRef.current >= HOME_STATS_REFRESH_STALE_MS;
+
+      if (!shouldForceStatsRefresh && hasCurrentWeekStatsLoaded) {
+        return;
+      }
+
+      lastStatsRefreshStartedAtRef.current = now;
+      void ensureCurrentWeekStatsLoaded(shouldForceStatsRefresh)
+        .then(() => {
+          lastStatsRefreshCompletedAtRef.current = Date.now();
+        })
+        .catch((error) => {
+          console.error('[Home] Focus stats refresh failed:', error);
+        });
+      void ensureTemplateDataLoaded().catch((error) => {
+        console.error('[Home] Focus template refresh failed:', error);
       });
-    }, [footballLoading, loading, refreshHomeScreen])
+    }, [
+      ensureCurrentWeekStatsLoaded,
+      ensureTemplateDataLoaded,
+      footballLoading,
+      hasCurrentWeekStatsLoaded,
+      loading,
+    ])
   );
 
   useEffect(() => {

--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -14,6 +14,7 @@ import {
   Alert,
   ActivityIndicator,
   DeviceEventEmitter,
+  InteractionManager,
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { useRouter } from 'expo-router';
@@ -27,6 +28,7 @@ import { useTeamPlayer } from '@/contexts/TeamPlayerContext';
 import { useSubscriptionFeatures } from '@/hooks/useSubscriptionFeatures';
 import { PremiumFeatureGate } from '@/components/PremiumFeatureGate';
 import { useFootball } from '@/contexts/FootballContext';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { Task } from '@/types';
 import { extractVideoKey, resolveVideoUrl } from '@/utils/videoKey';
 import { HOLDTRAINING_POSITIONS } from '@/utils/exercisePositions';
@@ -641,12 +643,17 @@ export default function LibraryScreen() {
   const isTrainerByTier = subscriptionTier?.startsWith('trainer') ?? false;
   const canCreateExercise = isAdmin || isTrainerLike || isTrainerByTier;
   const isCreator = canCreateExercise;
+  const { authReady, user } = useAuthSession();
 
   const { teams } = useTeamPlayer();
   const router = useRouter();
   const colorScheme = useColorScheme();
   const theme = getColors(colorScheme);
-  const { addTask: addTaskToContext, tasks: tasksFromContext } = useFootball();
+  const {
+    addTask: addTaskToContext,
+    tasks: tasksFromContext,
+    ensureTemplateDataLoaded,
+  } = useFootball();
   const isTrainerUser = isAdmin || isTrainerLike || isTrainerByTier;
 
   const [status, setStatus] = useState<'loading' | 'success' | 'empty' | 'error'>('loading');
@@ -991,21 +998,22 @@ export default function LibraryScreen() {
   );
 
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const { data } = await supabase.auth.getUser();
-      if (cancelled) return;
-      setCurrentUserId(data?.user?.id ?? null);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    if (!authReady) return;
+    setCurrentUserId(user?.id ?? null);
+  }, [authReady, user?.id]);
 
   useFocusEffect(
     useCallback(() => {
-      setReloadNonce(n => n + 1);
-    }, [])
+      const interaction = InteractionManager.runAfterInteractions(() => {
+        void ensureTemplateDataLoaded().catch((error: unknown) => {
+          console.error('[Library] Failed to load template data:', error);
+        });
+        setReloadNonce(n => n + 1);
+      });
+      return () => {
+        interaction.cancel();
+      };
+    }, [ensureTemplateDataLoaded])
   );
 
   useEffect(() => {

--- a/app/(tabs)/tasks.tsx
+++ b/app/(tabs)/tasks.tsx
@@ -15,16 +15,18 @@ import {
   Alert,
   ActivityIndicator,
   Switch,
+  InteractionManager,
 } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 
 import { useFootball } from '@/contexts/FootballContext';
 import { useAdmin } from '@/contexts/AdminContext';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { Task } from '@/types';
 import { IconSymbol } from '@/components/IconSymbol';
 import SmartVideoPlayer from '@/components/SmartVideoPlayer';
 import ContextConfirmationDialog from '@/components/ContextConfirmationDialog';
 import { AdminContextWrapper } from '@/components/AdminContextWrapper';
-import { supabase } from '@/integrations/supabase/client';
 import { taskService } from '@/services/taskService';
 import { forceRefreshNotificationQueue } from '@/utils/notificationScheduler';
 import { emitActivitiesRefreshRequested } from '@/utils/activityEvents';
@@ -404,6 +406,7 @@ const FolderItemComponent = React.memo(
 export default function TasksScreen() {
   const footballData = useFootball() as any;
   const adminData = useAdmin() as any;
+  const { user } = useAuthSession();
 
   const contextTasks = footballData?.tasks;
   const tasks = useMemo(() => (contextTasks ?? []) as Task[], [contextTasks]);
@@ -415,6 +418,9 @@ export default function TasksScreen() {
   const deleteTask = footballData?.deleteTask as ((taskId: string) => any) | undefined;
   const refreshAll = footballData?.refreshAll as (() => Promise<any>) | undefined;
   const refreshData = footballData?.refreshData as (() => Promise<any>) | undefined;
+  const ensureTemplateDataLoaded = footballData?.ensureTemplateDataLoaded as
+    | ((force?: boolean) => Promise<void>)
+    | undefined;
   const updateTask = footballData?.updateTask as ((taskId: string, data: any) => Promise<any>) | undefined;
   const isLoading = !!footballData?.isLoading;
 
@@ -494,6 +500,19 @@ export default function TasksScreen() {
     [filteredTasks, templateView],
   );
   const folders = useMemo(() => organizeFolders(templateTasks), [templateTasks]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const interaction = InteractionManager.runAfterInteractions(() => {
+        void ensureTemplateDataLoaded?.().catch((error: unknown) => {
+          console.error('[Tasks] Failed to load template data:', error);
+        });
+      });
+      return () => {
+        interaction.cancel();
+      };
+    }, [ensureTemplateDataLoaded])
+  );
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -628,18 +647,14 @@ export default function TasksScreen() {
       if (!taskId) return;
 
       const isArchived = typeof (task as any)?.archivedAt === 'string' && String((task as any).archivedAt).trim().length > 0;
+      const authenticatedUserId = user?.id ?? null;
 
       try {
-        const {
-          data: { session },
-          error: sessionError,
-        } = await supabase.auth.getSession();
-
-        if (sessionError || !session?.user?.id) {
+        if (!authenticatedUserId) {
           throw new Error('No authenticated user');
         }
 
-        await taskService.setTaskTemplateArchived(taskId, session.user.id, !isArchived);
+        await taskService.setTaskTemplateArchived(taskId, authenticatedUserId, !isArchived);
         await refreshAll?.();
         if (!refreshAll) {
           await forceRefreshNotificationQueue();
@@ -648,7 +663,7 @@ export default function TasksScreen() {
         Alert.alert('Fejl', error?.message || 'Kunne ikke opdatere arkivstatus');
       }
     },
-    [refreshAll],
+    [refreshAll, user?.id],
   );
 
   const handleDeleteTask = useCallback((task: Task) => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { Platform, StyleSheet, View } from 'react-native';
 import 'react-native-reanimated';
+import { AuthSessionProvider, useAuthSession } from '@/contexts/AuthSessionContext';
 import { FootballProvider } from '@/contexts/FootballContext';
 import { SubscriptionProvider, useSubscription } from '@/contexts/SubscriptionContext';
 import { TeamPlayerProvider } from '@/contexts/TeamPlayerContext';
@@ -30,7 +31,6 @@ import {
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
 const PENDING_NOTIFICATION_ROUTE_KEY = '@pending_notification_route_v1';
-const AUTH_BOOTSTRAP_TIMEOUT_MS = 4000;
 const STARTUP_LOADER_STALL_LOG_MS = 5000;
 
 const NO_PLAN_TIER_VALUES = new Set([
@@ -56,9 +56,18 @@ const isUserEmailConfirmed = (user: any) =>
   Boolean(user?.email_confirmed_at || user?.confirmed_at);
 
 export default function RootLayout() {
+  return (
+    <AuthSessionProvider>
+      <RootLayoutContent />
+    </AuthSessionProvider>
+  );
+}
+
+function RootLayoutContent() {
   const router = useRouter();
   const pathname = usePathname();
   const rootNavigationState = useRootNavigationState();
+  const { authReady, isAuthenticated } = useAuthSession();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
@@ -68,8 +77,6 @@ export default function RootLayout() {
   const pendingTaskIdRef = useRef<string | null>(null);
   const handledNotificationIdsRef = useRef<Set<string>>(new Set());
   const startupLoaderHideReasonRef = useRef<string | null>(null);
-  const [authReady, setAuthReady] = useState(false);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [pendingRouteStorageLoaded, setPendingRouteStorageLoaded] = useState(false);
   const [showStartupLoader, setShowStartupLoader] = useState(true);
   const [homeScreenReady, setHomeScreenReady] = useState(false);
@@ -327,72 +334,31 @@ export default function RootLayout() {
     });
   }, [homeScreenReady, pathname, shouldWaitForHomeReady, showStartupLoader, startupPrerequisitesReady]);
 
+  const didTrackAuthBootstrapRef = useRef(false);
+  const lastTrackedAuthReadyRef = useRef(false);
+
   useEffect(() => {
-    let isMounted = true;
-    let authResolved = false;
+    if (didTrackAuthBootstrapRef.current) return;
+    didTrackAuthBootstrapRef.current = true;
     void trackStartupTelemetry(supabase, {
       eventName: 'auth_bootstrap',
       status: 'started',
       route: pathname,
     });
-    const authBootstrapTimer = setTimeout(() => {
-      if (!isMounted || authResolved) return;
-      console.warn('[RootLayout] Auth bootstrap timed out; continuing startup');
-      void trackStartupTelemetry(supabase, {
-        eventName: 'auth_bootstrap',
-        status: 'timeout',
-        route: pathname,
-        metadata: {
-          timeoutMs: AUTH_BOOTSTRAP_TIMEOUT_MS,
-        },
-      });
-      setAuthReady(true);
-    }, AUTH_BOOTSTRAP_TIMEOUT_MS);
-
-    supabase.auth
-      .getSession()
-      .then(({ data }) => {
-        if (!isMounted) return;
-        authResolved = true;
-        clearTimeout(authBootstrapTimer);
-        setIsAuthenticated(Boolean(data.session?.user));
-        setAuthReady(true);
-        void trackStartupTelemetry(supabase, {
-          eventName: 'auth_bootstrap',
-          status: 'resolved',
-          route: pathname,
-          metadata: {
-            hasSession: Boolean(data.session),
-            hasUser: Boolean(data.session?.user),
-          },
-        });
-      })
-      .catch(() => {
-        if (!isMounted) return;
-        authResolved = true;
-        clearTimeout(authBootstrapTimer);
-        setIsAuthenticated(false);
-        setAuthReady(true);
-        void trackStartupTelemetry(supabase, {
-          eventName: 'auth_bootstrap',
-          status: 'error',
-          route: pathname,
-        });
-      });
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      setIsAuthenticated(Boolean(session?.user));
-      setAuthReady(true);
-    });
-
-    return () => {
-      isMounted = false;
-      clearTimeout(authBootstrapTimer);
-      subscription.unsubscribe();
-    };
   }, [pathname]);
+
+  useEffect(() => {
+    if (!authReady || lastTrackedAuthReadyRef.current) return;
+    lastTrackedAuthReadyRef.current = true;
+    void trackStartupTelemetry(supabase, {
+      eventName: 'auth_bootstrap',
+      status: 'resolved',
+      route: pathname,
+      metadata: {
+        hasUser: isAuthenticated,
+      },
+    });
+  }, [authReady, isAuthenticated, pathname]);
 
   useEffect(() => {
     if (showStartupLoader) return;
@@ -428,12 +394,12 @@ export default function RootLayout() {
 
   return (
     <SubscriptionProvider>
-      <AppleIAPProvider>
+      <AppleIAPProvider startupReady={!showStartupLoader}>
         <SubscriptionRedirectObserver />
         <TeamPlayerProvider>
           <AdminProvider>
             <CelebrationProvider>
-              <FootballProvider>
+              <FootballProvider eagerStartupLoad={false}>
                 <View style={styles.container}>
                   <NotificationPermissionPrompt />
                   <Stack initialRouteName="index">
@@ -521,6 +487,7 @@ const styles = StyleSheet.create({
 function SubscriptionRedirectObserver() {
   const router = useRouter();
   const pathname = usePathname();
+  const { authReady, session } = useAuthSession();
   const { subscriptionStatus, loading: subscriptionLoading } = useSubscription();
   const { entitlementSnapshot } = useAppleIAP();
 
@@ -564,75 +531,34 @@ function SubscriptionRedirectObserver() {
   );
 
   useEffect(() => {
-    let isActive = true;
-    const syncSession = async () => {
-      const { data } = await supabase.auth.getSession();
-      if (!isActive) return;
-      const sessionUser = data.session?.user ?? null;
-      if (sessionUser && !isUserEmailConfirmed(sessionUser) && !isRecoveryFlowRoute) {
-        setUnverifiedEmail(sessionUser.email ?? null);
-        setUserId(null);
-        forcingUnverifiedSignOutRef.current = true;
-        await supabase.auth.signOut({ scope: 'local' }).catch(() => {});
-        setAuthChecked(true);
-        return;
+    if (!authReady) return;
+
+    const sessionUser = session?.user ?? null;
+
+    if (!sessionUser) {
+      if (!forcingUnverifiedSignOutRef.current) {
+        setUnverifiedEmail(null);
       }
       forcingUnverifiedSignOutRef.current = false;
-      setUnverifiedEmail(null);
-      const newUserId = sessionUser?.id ?? null;
-      setUserId(newUserId);
-      if (newUserId) {
-        // const entitlements = await getProfileEntitlements(newUserId).catch(error => {
-        //   console.warn('[SubscriptionRedirectObserver] Initial entitlement fetch failed', error);
-        //   return { hasEntitlement: false };
-        // });
-        // if (isActive) setProfileEntitled(Boolean(entitlements?.hasEntitlement));
-      } else {
-        // setProfileEntitled(false);
-      }
+      setUserId(null);
       setAuthChecked(true);
-    };
-    syncSession();
-    const { data: listener } = supabase.auth.onAuthStateChange(async (_event, session) => {
-      if (!isActive) return;
-      const sessionUser = session?.user ?? null;
-      if (!sessionUser) {
-        if (!forcingUnverifiedSignOutRef.current) {
-          setUnverifiedEmail(null);
-        }
-        forcingUnverifiedSignOutRef.current = false;
-        setUserId(null);
-        setAuthChecked(true);
-        return;
-      }
-      if (sessionUser && !isUserEmailConfirmed(sessionUser) && !isRecoveryFlowRoute) {
-        setUnverifiedEmail(sessionUser.email ?? null);
-        setUserId(null);
-        forcingUnverifiedSignOutRef.current = true;
-        await supabase.auth.signOut({ scope: 'local' }).catch(() => {});
-        setAuthChecked(true);
-        return;
-      }
-      forcingUnverifiedSignOutRef.current = false;
-      setUnverifiedEmail(null);
-      const newUserId = session?.user?.id ?? null;
-      setUserId(newUserId);
-      if (newUserId) {
-        // const entitlements = await getProfileEntitlements(newUserId).catch(error => {
-        //   console.warn('[SubscriptionRedirectObserver] Auth entitlement fetch failed', error);
-        //   return { hasEntitlement: false };
-        // });
-        // if (isActive) setProfileEntitled(Boolean(entitlements?.hasEntitlement));
-      } else {
-        // setProfileEntitled(false);
-      }
+      return;
+    }
+
+    if (!isUserEmailConfirmed(sessionUser) && !isRecoveryFlowRoute) {
+      setUnverifiedEmail(sessionUser.email ?? null);
+      setUserId(null);
+      forcingUnverifiedSignOutRef.current = true;
+      void supabase.auth.signOut({ scope: 'local' }).catch(() => {});
       setAuthChecked(true);
-    });
-    return () => {
-      isActive = false;
-      listener.subscription.unsubscribe();
-    };
-  }, [isRecoveryFlowRoute]);
+      return;
+    }
+
+    forcingUnverifiedSignOutRef.current = false;
+    setUnverifiedEmail(null);
+    setUserId(sessionUser.id ?? null);
+    setAuthChecked(true);
+  }, [authReady, isRecoveryFlowRoute, session]);
 
   const isCreatorCandidate = Boolean(tierKey?.startsWith('trainer'));
 

--- a/app/_layout.web.tsx
+++ b/app/_layout.web.tsx
@@ -6,6 +6,7 @@ import { useFonts } from 'expo-font';
 import { StyleSheet, View } from 'react-native';
 import 'react-native-reanimated';
 
+import { AuthSessionProvider, useAuthSession } from '@/contexts/AuthSessionContext';
 import { FootballProvider } from '@/contexts/FootballContext';
 import { SubscriptionProvider, useSubscription } from '@/contexts/SubscriptionContext';
 import { TeamPlayerProvider } from '@/contexts/TeamPlayerContext';
@@ -85,6 +86,14 @@ const isUserEmailConfirmed = (user: any) =>
   Boolean(user?.email_confirmed_at || user?.confirmed_at);
 
 export default function RootLayout() {
+  return (
+    <AuthSessionProvider>
+      <RootLayoutContent />
+    </AuthSessionProvider>
+  );
+}
+
+function RootLayoutContent() {
   const pathname = usePathname();
   const [fontsLoaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
@@ -162,12 +171,12 @@ export default function RootLayout() {
 
   return (
     <SubscriptionProvider>
-      <AppleIAPProvider>
+      <AppleIAPProvider startupReady={!showStartupLoader}>
         <SubscriptionRedirectObserver />
         <TeamPlayerProvider>
           <AdminProvider>
             <CelebrationProvider>
-              <FootballProvider>
+              <FootballProvider eagerStartupLoad={false}>
                 <View style={styles.container}>
                   <Stack screenOptions={{ headerShown: false }}>
                     <Stack.Screen name="index" />
@@ -209,6 +218,7 @@ const styles = StyleSheet.create({
 function SubscriptionRedirectObserver() {
   const router = useRouter();
   const pathname = usePathname();
+  const { authReady, session } = useAuthSession();
   const { subscriptionStatus, loading: subscriptionLoading } = useSubscription();
   const { entitlementSnapshot } = useAppleIAP();
 
@@ -253,59 +263,34 @@ function SubscriptionRedirectObserver() {
   );
 
   useEffect(() => {
-    let isActive = true;
+    if (!authReady) return;
 
-    const syncSession = async () => {
-      const { data } = await supabase.auth.getSession();
-      if (!isActive) return;
-      const sessionUser = data.session?.user ?? null;
-      if (sessionUser && !isUserEmailConfirmed(sessionUser) && !isRecoveryFlowRoute) {
-        setUnverifiedEmail(sessionUser.email ?? null);
-        setUserId(null);
-        forcingUnverifiedSignOutRef.current = true;
-        await supabase.auth.signOut({ scope: 'local' }).catch(() => {});
-        setAuthChecked(true);
-        return;
+    const sessionUser = session?.user ?? null;
+
+    if (!sessionUser) {
+      if (!forcingUnverifiedSignOutRef.current) {
+        setUnverifiedEmail(null);
       }
       forcingUnverifiedSignOutRef.current = false;
-      setUnverifiedEmail(null);
-      setUserId(sessionUser?.id ?? null);
+      setUserId(null);
       setAuthChecked(true);
-    };
+      return;
+    }
 
-    syncSession();
-
-    const { data: listener } = supabase.auth.onAuthStateChange(async (_event, session) => {
-      if (!isActive) return;
-      const sessionUser = session?.user ?? null;
-      if (!sessionUser) {
-        if (!forcingUnverifiedSignOutRef.current) {
-          setUnverifiedEmail(null);
-        }
-        forcingUnverifiedSignOutRef.current = false;
-        setUserId(null);
-        setAuthChecked(true);
-        return;
-      }
-      if (sessionUser && !isUserEmailConfirmed(sessionUser) && !isRecoveryFlowRoute) {
-        setUnverifiedEmail(sessionUser.email ?? null);
-        setUserId(null);
-        forcingUnverifiedSignOutRef.current = true;
-        await supabase.auth.signOut({ scope: 'local' }).catch(() => {});
-        setAuthChecked(true);
-        return;
-      }
-      forcingUnverifiedSignOutRef.current = false;
-      setUnverifiedEmail(null);
-      setUserId(sessionUser?.id ?? null);
+    if (!isUserEmailConfirmed(sessionUser) && !isRecoveryFlowRoute) {
+      setUnverifiedEmail(sessionUser.email ?? null);
+      setUserId(null);
+      forcingUnverifiedSignOutRef.current = true;
+      void supabase.auth.signOut({ scope: 'local' }).catch(() => {});
       setAuthChecked(true);
-    });
+      return;
+    }
 
-    return () => {
-      isActive = false;
-      listener.subscription.unsubscribe();
-    };
-  }, [isRecoveryFlowRoute]);
+    forcingUnverifiedSignOutRef.current = false;
+    setUnverifiedEmail(null);
+    setUserId(sessionUser.id ?? null);
+    setAuthChecked(true);
+  }, [authReady, isRecoveryFlowRoute, session]);
 
   const isCreatorCandidate = Boolean(tierKey?.startsWith('trainer'));
 

--- a/components/CreateActivityTaskModal.tsx
+++ b/components/CreateActivityTaskModal.tsx
@@ -15,6 +15,7 @@ import {
 import * as CommonStyles from '@/styles/commonStyles';
 import { Task } from '@/types';
 import { supabase } from '@/integrations/supabase/client';
+import type { TablesInsert, TablesUpdate } from '@/integrations/supabase/types';
 import { scheduleTaskReminderImmediate } from '@/utils/notificationScheduler';
 import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
 
@@ -70,6 +71,22 @@ const TASK_FEEDBACK_OPTIONAL_COLUMNS = [
   'feedback_template_id',
   'is_feedback_task',
 ] as const;
+
+type ActivityTaskFeedbackUpdatePayload = TablesUpdate<'activity_tasks'> & {
+  is_feedback_task?: boolean;
+};
+
+type ActivityTaskFeedbackInsertPayload = TablesInsert<'activity_tasks'> & {
+  is_feedback_task?: boolean;
+};
+
+type ExternalEventTaskFeedbackUpdatePayload = TablesUpdate<'external_event_tasks'> & {
+  is_feedback_task?: boolean;
+};
+
+type ExternalEventTaskFeedbackInsertPayload = TablesInsert<'external_event_tasks'> & {
+  is_feedback_task?: boolean;
+};
 
 const isMissingColumn = (error: any, columnName: string): boolean => {
   const needle = String(columnName ?? '').trim().toLowerCase();
@@ -427,7 +444,7 @@ export function CreateActivityTaskModal({
 
       if (matchedIds.length) {
         const keepId = matchedIds[0];
-        const updateFeedbackPayload: Record<string, any> = {
+        const updateFeedbackPayload: ActivityTaskFeedbackUpdatePayload = {
           title,
           description,
           reminder_minutes: delayMinutes,
@@ -440,7 +457,7 @@ export function CreateActivityTaskModal({
         }
         const { error: updateFeedbackError } = await supabase
           .from('activity_tasks')
-          .update(updateFeedbackPayload)
+          .update(updateFeedbackPayload as any)
           .eq('id', keepId);
         if (updateFeedbackError) {
           throw new Error(`Kunne ikke opdatere feedback-opgave: ${updateFeedbackError.message}`);
@@ -460,7 +477,7 @@ export function CreateActivityTaskModal({
         return;
       }
 
-      const insertFeedbackPayload: Record<string, any> = {
+      const insertFeedbackPayload: ActivityTaskFeedbackInsertPayload = {
         activity_id: normalizedActivityLinkId,
         title,
         description,
@@ -579,7 +596,7 @@ export function CreateActivityTaskModal({
 
       if (matchedIds.length) {
         const keepId = matchedIds[0];
-        const updateFeedbackPayload: Record<string, any> = {
+        const updateFeedbackPayload: ExternalEventTaskFeedbackUpdatePayload = {
           title,
           description,
           reminder_minutes: delayMinutes,
@@ -592,7 +609,7 @@ export function CreateActivityTaskModal({
         }
         const { error: updateFeedbackError } = await supabase
           .from('external_event_tasks')
-          .update(updateFeedbackPayload)
+          .update(updateFeedbackPayload as any)
           .eq('id', keepId);
         if (updateFeedbackError) {
           throw new Error(`Kunne ikke opdatere feedback-opgave: ${updateFeedbackError.message}`);
@@ -612,7 +629,7 @@ export function CreateActivityTaskModal({
         return;
       }
 
-      const insertFeedbackPayload: Record<string, any> = {
+      const insertFeedbackPayload: ExternalEventTaskFeedbackInsertPayload = {
         local_meta_id: normalizedLocalMetaId,
         title,
         description,

--- a/components/OnboardingGate.tsx
+++ b/components/OnboardingGate.tsx
@@ -13,6 +13,7 @@ import { usePathname, useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { colors } from '@/styles/commonStyles';
 import { supabase } from '@/integrations/supabase/client';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 import AppleSubscriptionManager from '@/components/AppleSubscriptionManager';
 import SubscriptionManager from '@/components/SubscriptionManager';
 import { useSubscription } from '@/contexts/SubscriptionContext';
@@ -57,6 +58,7 @@ type CachedAuthoritativeNoSub = {
 export function OnboardingGate({ children, renderInlinePaywall = false }: OnboardingGateProps) {
   const STARTUP_TIMEOUT_MS = 12000;
   const STARTUP_ERROR_MESSAGE = 'Kunne ikke klargøre konto. Prøv igen.';
+  const { authReady, user, refreshSession } = useAuthSession();
 
   const [state, setState] = useState<GateState>({
     hydrating: true,
@@ -80,7 +82,6 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
   const lastNavRef = useRef<number>(0);
   const lastGateUserIdRef = useRef<string | null>(null);
   const lastNonPaywallPathRef = useRef<string | null>(null);
-  const backgroundRecoveryInFlightRef = useRef(false);
   const isMountedRef = useRef(true);
   const hydrationRunRef = useRef(0);
   const startupMountedAtRef = useRef(Date.now());
@@ -478,73 +479,10 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
     ]
   );
 
-  const recoverSessionInBackground = useCallback(
-    async (source: 'startup' | 'retry') => {
-      if (backgroundRecoveryInFlightRef.current) return;
-      backgroundRecoveryInFlightRef.current = true;
-
-      const recoveryRunId = hydrationRunRef.current;
-      try {
-        const { data } = await supabase.auth.getSession();
-        if (!isMountedRef.current || hydrationRunRef.current !== recoveryRunId) return;
-        await refreshRoleAndSubscription(data.session?.user ?? null);
-      } catch (error) {
-        console.warn(`[OnboardingGate] Background ${source} recovery failed`, error);
-      } finally {
-        backgroundRecoveryInFlightRef.current = false;
-      }
-    },
-    [refreshRoleAndSubscription]
-  );
-
   useEffect(() => {
-    let active = true;
-    const bootstrapRunId = hydrationRunRef.current;
-
-    const bootstrap = async () => {
-      try {
-        const { data } = await withTimeout(
-          supabase.auth.getSession(),
-          STARTUP_TIMEOUT_MS,
-          'Onboarding session lookup timed out'
-        );
-        if (active) {
-          await refreshRoleAndSubscription(data.session?.user ?? null);
-        }
-      } catch (error) {
-        if (!active || !isMountedRef.current || hydrationRunRef.current !== bootstrapRunId) return;
-        if (error instanceof TimeoutError) {
-          const usedCache = await applyCachedApprovedAccess(null, bootstrapRunId);
-          if (usedCache) {
-            void recoverSessionInBackground('startup');
-            return;
-          }
-          setState(prev => ({ ...prev, hydrating: false, initError: null, needsSubscription: false }));
-          void recoverSessionInBackground('startup');
-          return;
-        }
-        console.warn('[OnboardingGate] Startup bootstrap failed', error);
-        setState(prev => ({
-          ...prev,
-          hydrating: false,
-          needsSubscription: false,
-          initError: STARTUP_ERROR_MESSAGE,
-        }));
-      }
-    };
-
-    bootstrap();
-
-    const { data: listener } = supabase.auth.onAuthStateChange((_, session) => {
-      if (!active) return;
-      refreshRoleAndSubscription(session?.user ?? null);
-    });
-
-    return () => {
-      active = false;
-      listener.subscription.unsubscribe();
-    };
-  }, [applyCachedApprovedAccess, recoverSessionInBackground, refreshRoleAndSubscription]);
+    if (!authReady) return;
+    void refreshRoleAndSubscription(user ?? null);
+  }, [authReady, refreshRoleAndSubscription, user]);
 
   const handleRetryStartup = useCallback(async () => {
     if (!isMountedRef.current) return;
@@ -552,23 +490,19 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
     refreshCalledRef.current = false;
     setState(prev => ({ ...prev, hydrating: true, initError: null }));
     try {
-      const { data } = await withTimeout(
-        supabase.auth.getSession(),
+      const refreshedSession = await withTimeout(
+        refreshSession(),
         STARTUP_TIMEOUT_MS,
         'Onboarding retry session lookup timed out'
       );
       if (!isMountedRef.current || hydrationRunRef.current !== retryRunId) return;
-      await refreshRoleAndSubscription(data.session?.user ?? null);
+      await refreshRoleAndSubscription(refreshedSession?.user ?? user ?? null);
     } catch (error) {
       if (!isMountedRef.current || hydrationRunRef.current !== retryRunId) return;
       if (error instanceof TimeoutError) {
-        const usedCache = await applyCachedApprovedAccess(state.user ?? null, retryRunId);
-        if (usedCache) {
-          void recoverSessionInBackground('retry');
-          return;
-        }
+        const usedCache = await applyCachedApprovedAccess(user ?? null, retryRunId);
+        if (usedCache) return;
         setState(prev => ({ ...prev, hydrating: false, initError: null, needsSubscription: false }));
-        void recoverSessionInBackground('retry');
         return;
       }
       console.warn('[OnboardingGate] Startup retry failed', error);
@@ -579,7 +513,14 @@ export function OnboardingGate({ children, renderInlinePaywall = false }: Onboar
         initError: STARTUP_ERROR_MESSAGE,
       }));
     }
-  }, [STARTUP_ERROR_MESSAGE, STARTUP_TIMEOUT_MS, applyCachedApprovedAccess, recoverSessionInBackground, refreshRoleAndSubscription, state.user]);
+  }, [
+    STARTUP_ERROR_MESSAGE,
+    STARTUP_TIMEOUT_MS,
+    applyCachedApprovedAccess,
+    refreshRoleAndSubscription,
+    refreshSession,
+    user,
+  ]);
 
   const handleCreateSubscription = useCallback(async (planId: string) => {
     if (!state.user) return;

--- a/components/SubscriptionManager.tsx
+++ b/components/SubscriptionManager.tsx
@@ -146,17 +146,18 @@ export default function SubscriptionManager({
     subscriptionStatus,
     subscriptionPlans,
     loading,
+    ensureSubscriptionPlansLoaded,
     createSubscription,
     changeSubscriptionPlan,
     refreshSubscription,
   } = useSubscription();
   const [creatingPlanId, setCreatingPlanId] = useState<string | null>(null);
   const [showPlans, setShowPlans] = useState(isSignupFlow || forceShowPlans); // Collapsed by default unless in signup flow
-    useEffect(() => {
-      if (forceShowPlans) {
-        setShowPlans(true);
-      }
-    }, [forceShowPlans]);
+  useEffect(() => {
+    if (forceShowPlans) {
+      setShowPlans(true);
+    }
+  }, [forceShowPlans]);
 
   const [retryCount, setRetryCount] = useState(0);
   const colorScheme = useColorScheme();
@@ -173,14 +174,13 @@ export default function SubscriptionManager({
     [subscriptionStatus?.isLifetime, subscriptionStatus?.status],
   );
 
-  // LINT FIX: Include refreshSubscription in dependency array
-  // Refresh subscription status when component mounts - ONLY ONCE
   useEffect(() => {
+    void ensureSubscriptionPlansLoaded();
     if (!isSignupFlow) {
       console.log('[SubscriptionManager] Component mounted, refreshing subscription');
-      refreshSubscription();
+      void refreshSubscription();
     }
-  }, [isSignupFlow, refreshSubscription]);
+  }, [ensureSubscriptionPlansLoaded, isSignupFlow, refreshSubscription]);
 
   // Log subscription status changes for debugging
   useEffect(() => {

--- a/components/SubscriptionManager.web.tsx
+++ b/components/SubscriptionManager.web.tsx
@@ -24,7 +24,14 @@ export default function SubscriptionManager({
   isSignupFlow = false,
   selectedRole = null 
 }: SubscriptionManagerProps) {
-  const { subscriptionStatus, subscriptionPlans, loading, createSubscription, refreshSubscription } = useSubscription();
+  const {
+    subscriptionStatus,
+    subscriptionPlans,
+    loading,
+    ensureSubscriptionPlansLoaded,
+    createSubscription,
+    refreshSubscription,
+  } = useSubscription();
   const [creatingPlanId, setCreatingPlanId] = useState<string | null>(null);
   const [showPlans, setShowPlans] = useState(isSignupFlow); // Collapsed by default unless in signup flow
   const [retryCount, setRetryCount] = useState(0);
@@ -40,11 +47,12 @@ export default function SubscriptionManager({
 
   // Refresh subscription status when component mounts
   useEffect(() => {
+    void ensureSubscriptionPlansLoaded();
     if (!isSignupFlow) {
       console.log('[SubscriptionManager.web] Component mounted, refreshing subscription');
-      refreshSubscription();
+      void refreshSubscription();
     }
-  }, [isSignupFlow, refreshSubscription]);
+  }, [ensureSubscriptionPlansLoaded, isSignupFlow, refreshSubscription]);
 
   // Log subscription status changes for debugging
   useEffect(() => {

--- a/contexts/AppleIAPContext.tsx
+++ b/contexts/AppleIAPContext.tsx
@@ -3,6 +3,7 @@ import { Platform, Alert } from 'react-native';
 import Constants from 'expo-constants';
 import * as Application from 'expo-application';
 import { supabase } from '@/integrations/supabase/client';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { bumpEntitlementsVersion } from '@/services/entitlementsEvents';
 import { syncEntitlementsSnapshot, SubscriptionTier } from '@/services/entitlementsSync';
 import { useSubscription } from '@/contexts/SubscriptionContext';
@@ -535,10 +536,17 @@ const finishPurchaseWithLogging = async (purchase: any, sku: string | null, labe
   }
 };
 
-export function AppleIAPProvider({ children }: { children: ReactNode }) {
+export function AppleIAPProvider({
+  children,
+  startupReady = true,
+}: {
+  children: ReactNode;
+  startupReady?: boolean;
+}) {
+  const { authReady, session, user } = useAuthSession();
   const [products, setProducts] = useState<SubscriptionProduct[]>([]);
   const [subscriptionStatus, setSubscriptionStatus] = useState<SubscriptionStatus | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [purchasing, setPurchasing] = useState(false);
   const [iapReady, setIapReady] = useState<boolean>(iapReadyFlag);
   const [iapDiagnostics, setIapDiagnostics] = useState<IapDiagnostics>(defaultDiagnostics);
@@ -572,6 +580,8 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
   const entitlementsUnsupportedRef = useRef(false);
   const entitlementsWarnedRef = useRef(false);
   const autoRestoreAttemptedRef = useRef(false);
+  const backgroundWarmupStartedRef = useRef(false);
+  const lastResolvedUserIdRef = useRef<string | null>(null);
   const { ingestAppleEntitlements } = useSubscription();
 
   useEffect(() => {
@@ -624,11 +634,8 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
       return;
     }
     try {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      const user = session?.user ?? null;
-      if (!user) {
+      const activeUser = user ?? session?.user ?? null;
+      if (!activeUser) {
         setEntitlements([]);
         return;
       }
@@ -661,11 +668,16 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
       }
       console.warn('[AppleIAP] Unexpected entitlement fetch error', error);
     }
-  }, []);
+  }, [session, user]);
 
   useEffect(() => {
+    if (!authReady) return;
+    if (!user?.id) {
+      setEntitlements([]);
+      return;
+    }
     void fetchEntitlements();
-  }, [fetchEntitlements]);
+  }, [authReady, fetchEntitlements, user?.id]);
 
   useEffect(() => {
     const signature = JSON.stringify(entitlements);
@@ -949,41 +961,46 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const emptyStatus: SubscriptionStatus = { isActive: false, productId: null, expiryDate: null, isInTrialPeriod: false };
-    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (session?.user) {
+    if (!authReady) return;
+
+    const nextUserId = user?.id ?? null;
+    if (nextUserId) {
+      if (lastResolvedUserIdRef.current !== nextUserId) {
         autoRestoreAttemptedRef.current = false;
+        backgroundWarmupStartedRef.current = false;
         setVerifiedActiveProductId(null);
         setEntitlementCheckState('idle');
+        setEntitlementLastCheckedAtMs(null);
         setEntitlementLastCheckError(null);
-        void refreshSubscriptionStatus({ force: true, reason: 'auth_login' });
-        return;
       }
-      setSubscriptionStatus(emptyStatus);
-      subscriptionStatusRef.current = emptyStatus;
-      setEntitlements([]);
-      setVerifiedActiveProductId(null);
-      setPendingPlan(null);
-      pendingPlanRef.current = null;
-      lastRequestedSkuRef.current = null;
-      lastRequestedAtRef.current = null;
-      activePurchaseFlowRef.current = null;
-      refreshAfterPurchasePromiseRef.current = null;
-      refreshInFlightRef.current = false;
-      refreshPromiseRef.current = null;
-      setPurchasing(false);
-      handledPurchaseEventsRef.current = new Map();
-      alertInFlightRef.current = false;
-      lastAlertKeyRef.current = null;
-      lastAlertAtRef.current = 0;
-      setIapUnavailableReason(null);
-      setEntitlementCheckState('idle');
-      setEntitlementLastCheckedAtMs(null);
-      setEntitlementLastCheckError(null);
-    });
-    return () => {
-      data.subscription.unsubscribe();
-    };
-  }, [refreshSubscriptionStatus]);
+      lastResolvedUserIdRef.current = nextUserId;
+      return;
+    }
+
+    lastResolvedUserIdRef.current = null;
+    backgroundWarmupStartedRef.current = false;
+    setSubscriptionStatus(emptyStatus);
+    subscriptionStatusRef.current = emptyStatus;
+    setEntitlements([]);
+    setVerifiedActiveProductId(null);
+    setPendingPlan(null);
+    pendingPlanRef.current = null;
+    lastRequestedSkuRef.current = null;
+    lastRequestedAtRef.current = null;
+    activePurchaseFlowRef.current = null;
+    refreshAfterPurchasePromiseRef.current = null;
+    refreshInFlightRef.current = false;
+    refreshPromiseRef.current = null;
+    setPurchasing(false);
+    handledPurchaseEventsRef.current = new Map();
+    alertInFlightRef.current = false;
+    lastAlertKeyRef.current = null;
+    lastAlertAtRef.current = 0;
+    setIapUnavailableReason(null);
+    setEntitlementCheckState('idle');
+    setEntitlementLastCheckedAtMs(null);
+    setEntitlementLastCheckError(null);
+  }, [authReady, user?.id]);
 
   const complimentaryFlags = useMemo(() => {
     const hasComplimentaryPlayerPremium = entitlements.some(e => e.entitlement === 'spiller_premium');
@@ -1165,39 +1182,53 @@ export function AppleIAPProvider({ children }: { children: ReactNode }) {
     }
   }, [updateDiagnostics, syncIapReadyState]);
 
-  const initializeIAP = useCallback(async () => {
+  const startBackgroundWarmup = useCallback(async () => {
+    if (Platform.OS !== 'ios' || isExpoGo || !authReady || !user?.id) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const ready = await syncIapReadyState();
+      if (!ready) {
+        return;
+      }
+
+      await refreshSubscriptionStatus({ force: true, reason: 'startup_warmup' });
+    } finally {
+      setLoading(false);
+    }
+  }, [authReady, refreshSubscriptionStatus, syncIapReadyState, user?.id]);
+
+  useEffect(() => {
     if (Platform.OS !== 'ios' || isExpoGo) {
       setLoading(false);
       return;
     }
 
-    const ready = await syncIapReadyState();
-    if (!ready) {
-      setLoading(false);
-      return;
-    }
-
-    await refreshSubscriptionStatus({ force: true, reason: 'startup_init' });
-    setLoading(false);
-  }, [refreshSubscriptionStatus, syncIapReadyState]);
-
-  // Initialize IAP connection
-  useEffect(() => {
-    if (Platform.OS === 'ios' && !isExpoGo) {
-      initializeIAP();
-    } else {
-      setLoading(false);
-    }
-
     return () => {
-      if (Platform.OS === 'ios' && RNIap && !isExpoGo) {
+      if (RNIap && !isExpoGo) {
         RNIap.endConnection?.();
         iapReadyFlag = false;
         iapInitPromise = null;
         setIapReady(false);
       }
     };
-  }, [initializeIAP]);
+  }, []);
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios' || isExpoGo) return;
+    if (!startupReady || !authReady || !user?.id) return;
+    if (backgroundWarmupStartedRef.current) return;
+
+    backgroundWarmupStartedRef.current = true;
+    const timer = setTimeout(() => {
+      void startBackgroundWarmup();
+    }, 1200);
+
+    return () => clearTimeout(timer);
+  }, [authReady, startBackgroundWarmup, startupReady, user?.id]);
 
   const purchaseErrorListenerCleanupRef = useRef<(() => void) | null>(null);
   const purchaseUpdateListenerCleanupRef = useRef<(() => void) | null>(null);

--- a/contexts/AppleIAPContext.web.tsx
+++ b/contexts/AppleIAPContext.web.tsx
@@ -99,7 +99,12 @@ const defaultDiagnostics: IapDiagnostics = {
 const AppleIAPContext = createContext<AppleIAPContextType | undefined>(undefined);
 
 // Stub provider for web - Apple IAP is not available on web
-export function AppleIAPProvider({ children }: { children: ReactNode }) {
+export function AppleIAPProvider({
+  children,
+}: {
+  children: ReactNode;
+  startupReady?: boolean;
+}) {
   const { ingestAppleEntitlements } = useSubscription();
   useEffect(() => {
     ingestAppleEntitlements?.({

--- a/contexts/AuthSessionContext.tsx
+++ b/contexts/AuthSessionContext.tsx
@@ -1,0 +1,91 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+import { getLatestSession, supabase } from '@/integrations/supabase/client';
+
+type AuthSessionContextValue = {
+  authReady: boolean;
+  isAuthenticated: boolean;
+  session: Session | null;
+  user: User | null;
+  refreshSession: () => Promise<Session | null>;
+};
+
+const AuthSessionContext = createContext<AuthSessionContextValue | undefined>(undefined);
+
+export function AuthSessionProvider({ children }: { children: ReactNode }) {
+  const initialSession = getLatestSession();
+  const [session, setSession] = useState<Session | null>(initialSession);
+  const [authReady, setAuthReady] = useState(Boolean(initialSession));
+
+  const refreshSession = useCallback(async () => {
+    const {
+      data: { session: nextSession },
+    } = await supabase.auth.getSession();
+    setSession(nextSession ?? null);
+    setAuthReady(true);
+    return nextSession ?? null;
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (!mounted) return;
+        setSession(data.session ?? null);
+        setAuthReady(true);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setSession(null);
+        setAuthReady(true);
+      });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      if (!mounted) return;
+      setSession(nextSession ?? null);
+      setAuthReady(true);
+    });
+
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const value = useMemo<AuthSessionContextValue>(() => {
+    const user = session?.user ?? null;
+    return {
+      authReady,
+      isAuthenticated: Boolean(user),
+      session,
+      user,
+      refreshSession,
+    };
+  }, [authReady, refreshSession, session]);
+
+  return (
+    <AuthSessionContext.Provider value={value}>
+      {children}
+    </AuthSessionContext.Provider>
+  );
+}
+
+export function useAuthSession() {
+  const context = useContext(AuthSessionContext);
+  if (!context) {
+    throw new Error('useAuthSession must be used within an AuthSessionProvider');
+  }
+  return context;
+}

--- a/contexts/FootballContext.tsx
+++ b/contexts/FootballContext.tsx
@@ -75,6 +75,8 @@ interface FootballContextType {
   deleteActivityTask: (activityId: string, taskId: string) => Promise<void>;
   refreshData: () => Promise<void>;
   refreshAll: () => Promise<void>;
+  ensureTemplateDataLoaded: (force?: boolean) => Promise<void>;
+  ensureCurrentWeekStatsLoaded: (force?: boolean) => Promise<void>;
   ensureActivitiesLoaded: (force?: boolean) => Promise<void>;
   ensurePerformanceDataLoaded: (force?: boolean) => Promise<void>;
   addExternalCalendar: (calendar: Omit<ExternalCalendar, 'id'>) => void;
@@ -92,7 +94,13 @@ interface FootballContextType {
 
 const FootballContext = createContext<FootballContextType | undefined>(undefined);
 
-export function FootballProvider({ children }: { children: ReactNode }) {
+export function FootballProvider({
+  children,
+  eagerStartupLoad = false,
+}: {
+  children: ReactNode;
+  eagerStartupLoad?: boolean;
+}) {
   const {
     categories,
     tasks,
@@ -125,6 +133,8 @@ export function FootballProvider({ children }: { children: ReactNode }) {
     deleteActivityTask,
     refreshData,
     refreshAll,
+    ensureTemplateDataLoaded,
+    ensureCurrentWeekStatsLoaded,
     ensureActivitiesLoaded,
     ensurePerformanceDataLoaded,
     addExternalCalendar,
@@ -134,7 +144,7 @@ export function FootballProvider({ children }: { children: ReactNode }) {
     importMultipleActivities,
     fetchExternalCalendarEvents,
     refreshCategories,
-  } = useFootballData();
+  } = useFootballData({ eagerStartupLoad });
 
   // ✅ Runtime-safe wrapper: createActivity must always be a function
   // If useFootballData() doesn't provide it, fall back to addActivity + refreshData (fail-soft).
@@ -212,6 +222,8 @@ export function FootballProvider({ children }: { children: ReactNode }) {
       deleteActivityTask,
       refreshData,
       refreshAll,
+      ensureTemplateDataLoaded,
+      ensureCurrentWeekStatsLoaded,
       ensureActivitiesLoaded,
       ensurePerformanceDataLoaded,
       addExternalCalendar,
@@ -254,6 +266,8 @@ export function FootballProvider({ children }: { children: ReactNode }) {
       deleteActivityTask,
       refreshData,
       refreshAll,
+      ensureTemplateDataLoaded,
+      ensureCurrentWeekStatsLoaded,
       ensureActivitiesLoaded,
       ensurePerformanceDataLoaded,
       addExternalCalendar,

--- a/contexts/SubscriptionContext.tsx
+++ b/contexts/SubscriptionContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { PRODUCT_IDS } from '@/contexts/appleProductIds';
 import { bumpEntitlementsVersion, subscribeToEntitlementVersion } from '@/services/entitlementsEvents';
 import type { SubscriptionTier } from '@/services/entitlementsSync';
@@ -77,6 +78,7 @@ interface SubscriptionContextType {
   subscriptionMeta: SubscriptionStatusMeta;
   subscriptionPlans: SubscriptionPlan[];
   loading: boolean;
+  ensureSubscriptionPlansLoaded: () => Promise<void>;
   refreshSubscription: () => Promise<void>;
   createSubscription: (
     planId: string
@@ -177,6 +179,7 @@ const subscriptionTierFromProfile = (tier: string | null): SubscriptionTier | nu
 };
 
 export function SubscriptionProvider({ children }: { children: ReactNode }) {
+  const { authReady, session, user } = useAuthSession();
   const [subscriptionStatus, setSubscriptionStatus] = useState<SubscriptionStatus | null>(null);
   const [subscriptionMeta, setSubscriptionMeta] = useState<SubscriptionStatusMeta>({
     lastUpdateReason: null,
@@ -278,6 +281,24 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       console.warn('[SubscriptionContext] Network error fetching subscription plans');
     }
   }, []);
+
+  const ensureSubscriptionPlansLoaded = useCallback(async () => {
+    if (subscriptionPlans.length > 0) {
+      return;
+    }
+    await fetchSubscriptionPlans();
+  }, [fetchSubscriptionPlans, subscriptionPlans.length]);
+
+  const getActiveSession = useCallback(async () => {
+    if (session) {
+      return session;
+    }
+
+    const {
+      data: { session: fallbackSession },
+    } = await supabase.auth.getSession();
+    return fallbackSession ?? null;
+  }, [session]);
 
   const applyOptimisticSubscription = useCallback(
     (planId: string) => {
@@ -390,14 +411,21 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       console.log('[SubscriptionContext] Fetching subscription status');
       setLoading(true);
 
-      const {
-        data: { session },
-        error: sessionError,
-      } = await supabase.auth.getSession();
+      let activeSession = session ?? null;
+      let sessionError: Error | null = null;
 
-      const user = session?.user ?? null;
+      if (!activeSession && !authReady) {
+        const {
+          data: sessionData,
+          error,
+        } = await supabase.auth.getSession();
+        activeSession = sessionData.session ?? null;
+        sessionError = error ?? null;
+      }
 
-      if (sessionError || !session || !user) {
+      const activeUser = activeSession?.user ?? user ?? null;
+
+      if (sessionError || !activeSession || !activeUser) {
         console.warn('[SubscriptionContext] No valid session');
         currentUserIdRef.current = null;
         lastStableStatusRef.current = null;
@@ -406,11 +434,11 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      if (currentUserIdRef.current && currentUserIdRef.current !== user.id) {
+      if (currentUserIdRef.current && currentUserIdRef.current !== activeUser.id) {
         lastStableStatusRef.current = null;
         lastSignatureRef.current = buildEntitlementSignature(null);
       }
-      currentUserIdRef.current = user.id;
+      currentUserIdRef.current = activeUser.id;
 
       const supabaseUrl = 'https://lhpczofddvwcyrgotzha.supabase.co';
       const functionUrl = `${supabaseUrl}/functions/v1/get-subscription-status`;
@@ -418,7 +446,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       const response = await fetch(functionUrl, {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${session.access_token}`,
+          Authorization: `Bearer ${activeSession.access_token}`,
           'Content-Type': 'application/json',
           apikey:
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxocGN6b2ZkZHZ3Y3lyZ290emhhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQxNTgzMjQsImV4cCI6MjA3OTczNDMyNH0.5oWZ_G5ryy_ae77CG8YMeEDEyAJkSS7Jv4cFZy-G7qA',
@@ -451,7 +479,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         subscriptionTier: (data?.subscriptionTier as SubscriptionTier | null) ?? null,
       };
 
-      const statusWithProfileFallback = await applyProfileEntitlementFallback(user.id, statusData);
+      const statusWithProfileFallback = await applyProfileEntitlementFallback(activeUser.id, statusData);
       const reason = payloadHasError ? 'fetch-fallback' : 'fetch-success';
       applyStatus(coerceWithEntitlements(statusWithProfileFallback, reason), reason);
     } catch {
@@ -467,37 +495,33 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         console.log('[SubscriptionContext] Loading set to false');
       }
     }
-  }, [applyProfileEntitlementFallback, applyStatus, coerceWithEntitlements]);
+  }, [applyProfileEntitlementFallback, applyStatus, authReady, coerceWithEntitlements, session, user]);
 
   useEffect(() => {
-    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
-      const nextUserId = session?.user?.id ?? null;
+    if (!authReady) return;
 
-      if (!nextUserId) {
-        currentUserIdRef.current = null;
-        lastStableStatusRef.current = null;
-        lastSignatureRef.current = buildEntitlementSignature(null);
-        statusRef.current = null;
-        applyStatus(buildEmptyStatus(), 'auth-signout');
-        setLoading(false);
-        return;
-      }
+    const nextUserId = user?.id ?? null;
 
-      if (currentUserIdRef.current && currentUserIdRef.current !== nextUserId) {
-        lastStableStatusRef.current = null;
-        lastSignatureRef.current = buildEntitlementSignature(null);
-        statusRef.current = null;
-        applyStatus(buildEmptyStatus(), 'auth-user-change');
-      }
+    if (!nextUserId) {
+      currentUserIdRef.current = null;
+      lastStableStatusRef.current = null;
+      lastSignatureRef.current = buildEntitlementSignature(null);
+      statusRef.current = null;
+      applyStatus(buildEmptyStatus(), 'auth-signout');
+      setLoading(false);
+      return;
+    }
 
-      currentUserIdRef.current = nextUserId;
-      void fetchSubscriptionStatus();
-    });
+    if (currentUserIdRef.current && currentUserIdRef.current !== nextUserId) {
+      lastStableStatusRef.current = null;
+      lastSignatureRef.current = buildEntitlementSignature(null);
+      statusRef.current = null;
+      applyStatus(buildEmptyStatus(), 'auth-user-change');
+    }
 
-    return () => {
-      data.subscription.unsubscribe();
-    };
-  }, [applyStatus, fetchSubscriptionStatus]);
+    currentUserIdRef.current = nextUserId;
+    void fetchSubscriptionStatus();
+  }, [applyStatus, authReady, fetchSubscriptionStatus, user?.id]);
 
   const refreshSubscription = useCallback(async () => {
     console.log('[SubscriptionContext] Manual refresh requested');
@@ -509,12 +533,9 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       try {
         console.log('[SubscriptionContext] Creating subscription', { planId });
 
-        const {
-          data: { session },
-          error: sessionError,
-        } = await supabase.auth.getSession();
+        const activeSession = await getActiveSession();
 
-        if (sessionError || !session) {
+        if (!activeSession) {
           console.warn('[SubscriptionContext] No valid session for subscription creation');
           return {
             success: false,
@@ -528,7 +549,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         const response = await fetch(functionUrl, {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${session.access_token}`,
+            Authorization: `Bearer ${activeSession.access_token}`,
             'Content-Type': 'application/json',
             apikey:
               'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxocGN6b2ZkZHZ3Y3lyZ290emhhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQxNTgzMjQsImV4cCI6MjA3OTczNDMyNH0.5oWZ_G5ryy_ae77CG8YMeEDEyAJkSS7Jv4cFZy-G7qA',
@@ -582,7 +603,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         return { success: false, error: 'Der opstod en uventet fejl. Prøv igen om et øjeblik.' };
       }
     },
-    [applyOptimisticSubscription, fetchSubscriptionStatus]
+    [applyOptimisticSubscription, fetchSubscriptionStatus, getActiveSession]
   );
 
   const changeSubscriptionPlan = useCallback(
@@ -598,12 +619,9 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       const endpointCandidates = ['change-subscription', 'update-subscription'];
 
       try {
-        const {
-          data: { session },
-          error: sessionError,
-        } = await supabase.auth.getSession();
+        const activeSession = await getActiveSession();
 
-        if (sessionError || !session) {
+        if (!activeSession) {
           return {
             success: false,
             error:
@@ -623,7 +641,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
             response = await fetch(functionUrl, {
               method: 'POST',
               headers: {
-                Authorization: `Bearer ${session.access_token}`,
+                Authorization: `Bearer ${activeSession.access_token}`,
                 'Content-Type': 'application/json',
                 apikey:
                   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxocGN6b2ZkZHZ3Y3lyZ290emhhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQxNTgzMjQsImV4cCI6MjA3OTczNDMyNH0.5oWZ_G5ryy_ae77CG8YMeEDEyAJkSS7Jv4cFZy-G7qA',
@@ -678,14 +696,8 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         };
       }
     },
-    [applyOptimisticSubscription, fetchSubscriptionStatus]
+    [applyOptimisticSubscription, fetchSubscriptionStatus, getActiveSession]
   );
-
-  useEffect(() => {
-    console.log('[SubscriptionContext] Context initialized');
-    fetchSubscriptionPlans();
-    fetchSubscriptionStatus();
-  }, [fetchSubscriptionPlans, fetchSubscriptionStatus]);
 
   useEffect(() => {
     if (__DEV__) {
@@ -716,6 +728,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
         subscriptionMeta,
         subscriptionPlans,
         loading,
+        ensureSubscriptionPlansLoaded,
         refreshSubscription,
         createSubscription,
         changeSubscriptionPlan,

--- a/contexts/TeamPlayerContext.tsx
+++ b/contexts/TeamPlayerContext.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 
 export interface Team {
   id: string;
@@ -50,6 +51,7 @@ const SELECTED_CONTEXT_KEY = '@selected_context';
 const toDateOrNow = (value: string | null | undefined): Date => (value ? new Date(value) : new Date());
 
 export function TeamPlayerProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuthSession();
   const [teams, setTeams] = useState<Team[]>([]);
   const [players, setPlayers] = useState<Player[]>([]);
   const [selectedContext, setSelectedContextState] = useState<SelectedContext>({
@@ -58,40 +60,10 @@ export function TeamPlayerProvider({ children }: { children: ReactNode }) {
     name: null,
   });
   const [loading, setLoading] = useState(true);
-  const [userId, setUserId] = useState<string | null>(null);
   const rosterLoadedRef = React.useRef(false);
   const rosterLoadRequestIdRef = React.useRef(0);
   const rosterLoadPromiseRef = React.useRef<Promise<{ teams: Team[]; players: Player[] }> | null>(null);
-
-  // Keep userId in sync with auth state (initial load + sign in/out)
-  useEffect(() => {
-    let mounted = true;
-
-    const syncCurrentUser = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      const user = session?.user ?? null;
-      if (!mounted) return;
-      console.log('TeamPlayerContext - Current user:', user?.id);
-      setUserId(user?.id || null);
-    };
-
-    syncCurrentUser();
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      const nextUserId = session?.user?.id || null;
-      console.log('TeamPlayerContext - Auth state changed:', _event, nextUserId);
-      setUserId(nextUserId);
-    });
-
-    return () => {
-      mounted = false;
-      subscription.unsubscribe();
-    };
-  }, []);
+  const userId = user?.id ?? null;
 
   const requireUserId = useCallback(async (): Promise<string> => {
     if (userId) return userId;
@@ -99,10 +71,9 @@ export function TeamPlayerProvider({ children }: { children: ReactNode }) {
     const {
       data: { session },
     } = await supabase.auth.getSession();
-    const user = session?.user ?? null;
+    const fallbackUser = session?.user ?? null;
 
-    const resolvedUserId = user?.id || null;
-    setUserId(resolvedUserId);
+    const resolvedUserId = fallbackUser?.id || null;
     if (!resolvedUserId) {
       throw new Error('User not authenticated');
     }

--- a/hooks/useFootballData.ts
+++ b/hooks/useFootballData.ts
@@ -19,12 +19,15 @@ import { taskService } from '@/services/taskService';
 import { activityService } from '@/services/activityService';
 import { calendarService } from '@/services/calendarService';
 import { useAdmin } from '@/contexts/AdminContext';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { useCelebration } from '@/contexts/CelebrationContext';
 import { subscribeToTaskCompletion, emitTaskCompletionEvent } from '@/utils/taskEvents';
 import { emitActivityPatch, emitActivitiesRefreshRequested } from '@/utils/activityEvents';
 import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
 import { isTaskVisibleForActivity } from '@/utils/taskTemplateVisibility';
 import { resolveCelebrationAfterCompletionFromDatabase } from '@/utils/celebrationRuntime';
+
+const NOTIFICATION_SYNC_THROTTLE_MS = 30 * 1000;
 
 type ExternalTaskForPerformance = {
   id?: string | number | null;
@@ -286,8 +289,15 @@ const emptyCurrentWeekStats = {
   weekActivities: [] as Activity[],
 };
 
-export const useFootballData = () => {
+type UseFootballDataOptions = {
+  eagerStartupLoad?: boolean;
+};
+
+export const useFootballData = ({
+  eagerStartupLoad = false,
+}: UseFootballDataOptions = {}) => {
   const { adminMode, adminTargetId, adminTargetType } = useAdmin();
+  const { authReady, user } = useAuthSession();
   const { showCelebration } = useCelebration();
 
   const [activities, setActivities] = useState<Activity[]>([]);
@@ -299,15 +309,19 @@ export const useFootballData = () => {
   const [externalActivities] = useState<Activity[]>([]);
   const [currentWeekStats, setCurrentWeekStats] = useState(emptyCurrentWeekStats);
   const [hasCurrentWeekStatsLoaded, setHasCurrentWeekStatsLoaded] = useState(false);
+  const [hasTemplateDataLoaded, setHasTemplateDataLoaded] = useState(false);
   const [hasActivitiesLoaded, setHasActivitiesLoaded] = useState(false);
   const [hasPerformanceDataLoaded, setHasPerformanceDataLoaded] = useState(false);
-  const [authUserId, setAuthUserId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(Boolean(eagerStartupLoad));
+  const authUserId = user?.id ?? null;
   const refreshDataPromiseRef = useRef<Promise<void> | null>(null);
   const deferredStartupLoadPromiseRef = useRef<Promise<void> | null>(null);
+  const templateDataLoadPromiseRef = useRef<Promise<void> | null>(null);
+  const currentWeekStatsLoadPromiseRef = useRef<Promise<void> | null>(null);
   const activitiesLoadPromiseRef = useRef<Promise<void> | null>(null);
   const performanceDataLoadPromiseRef = useRef<Promise<void> | null>(null);
   const lazyLoadScopeKeyRef = useRef<string | null>(null);
+  const lastNotificationSyncAtRef = useRef(0);
 
   const findTaskCompletionState = useCallback(
     (activityId: string, taskId: string): boolean | null => {
@@ -486,33 +500,6 @@ export const useFootballData = () => {
   }, []);
 
   useEffect(() => {
-    let mounted = true;
-
-    supabase.auth.getSession().then(({ data, error }) => {
-      if (!mounted) return;
-      if (error) {
-        console.error('[useFootballData] initial session lookup failed:', error);
-        setAuthUserId(null);
-        return;
-      }
-
-      setAuthUserId(data.session?.user?.id ?? null);
-    });
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (!mounted) return;
-      setAuthUserId(session?.user?.id ?? null);
-    });
-
-    return () => {
-      mounted = false;
-      subscription.unsubscribe();
-    };
-  }, []);
-
-  useEffect(() => {
     const scopeKey = [
       authUserId ?? 'anonymous',
       adminMode,
@@ -532,18 +519,24 @@ export const useFootballData = () => {
     lazyLoadScopeKeyRef.current = scopeKey;
     refreshDataPromiseRef.current = null;
     deferredStartupLoadPromiseRef.current = null;
+    templateDataLoadPromiseRef.current = null;
+    currentWeekStatsLoadPromiseRef.current = null;
     activitiesLoadPromiseRef.current = null;
     performanceDataLoadPromiseRef.current = null;
 
     setActivities([]);
+    setCategories([]);
+    setTasks([]);
     setTrophies([]);
     setExternalCalendars([]);
     setActivitySeries([]);
     setCurrentWeekStats(emptyCurrentWeekStats);
+    setHasTemplateDataLoaded(false);
     setHasCurrentWeekStatsLoaded(false);
     setHasActivitiesLoaded(false);
     setHasPerformanceDataLoaded(false);
-  }, [adminMode, adminTargetId, adminTargetType, authUserId]);
+    setLoading(Boolean(eagerStartupLoad));
+  }, [adminMode, adminTargetId, adminTargetType, authUserId, eagerStartupLoad]);
 
   const fetchCategories = useCallback(async () => {
     try {
@@ -1170,13 +1163,6 @@ export const useFootballData = () => {
     }
   }, [weekRange]);
 
-  useEffect(() => {
-    setCurrentWeekStats(prev => ({
-      ...prev,
-      weekActivities: activitiesThisWeek as Activity[],
-    }));
-  }, [activitiesThisWeek]);
-
   const runLoadOperations = useCallback(async (
     context: string,
     operations: DataLoadOperation[]
@@ -1190,6 +1176,102 @@ export const useFootballData = () => {
       }
     });
   }, []);
+
+  const ensureTemplateDataLoaded = useCallback(async (force: boolean = false) => {
+    if (!force && hasTemplateDataLoaded) {
+      return;
+    }
+
+    if (!force && templateDataLoadPromiseRef.current) {
+      await templateDataLoadPromiseRef.current;
+      return;
+    }
+
+    if (force && templateDataLoadPromiseRef.current) {
+      await templateDataLoadPromiseRef.current;
+    }
+
+    const pendingLoad = (async () => {
+      setLoading(true);
+      try {
+        await runLoadOperations('ensureTemplateDataLoaded', [
+          { name: 'categories', run: fetchCategories },
+          { name: 'tasks', run: fetchTasks },
+        ]);
+        setHasTemplateDataLoaded(true);
+      } finally {
+        if (!eagerStartupLoad) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    templateDataLoadPromiseRef.current = pendingLoad;
+
+    try {
+      await pendingLoad;
+    } finally {
+      if (templateDataLoadPromiseRef.current === pendingLoad) {
+        templateDataLoadPromiseRef.current = null;
+      }
+    }
+  }, [
+    eagerStartupLoad,
+    fetchCategories,
+    fetchTasks,
+    hasTemplateDataLoaded,
+    runLoadOperations,
+  ]);
+
+  const ensureCurrentWeekStatsLoaded = useCallback(async (force: boolean = false) => {
+    if (!force && hasCurrentWeekStatsLoaded) {
+      return;
+    }
+
+    if (!force && currentWeekStatsLoadPromiseRef.current) {
+      await currentWeekStatsLoadPromiseRef.current;
+      return;
+    }
+
+    if (force && currentWeekStatsLoadPromiseRef.current) {
+      await currentWeekStatsLoadPromiseRef.current;
+    }
+
+    const pendingLoad = (async () => {
+      setLoading(true);
+      try {
+        await runLoadOperations('ensureCurrentWeekStatsLoaded', [
+          { name: 'currentWeekStats', run: fetchCurrentWeekStats },
+        ]);
+      } finally {
+        if (!eagerStartupLoad) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    currentWeekStatsLoadPromiseRef.current = pendingLoad;
+
+    try {
+      await pendingLoad;
+    } finally {
+      if (currentWeekStatsLoadPromiseRef.current === pendingLoad) {
+        currentWeekStatsLoadPromiseRef.current = null;
+      }
+    }
+  }, [
+    eagerStartupLoad,
+    fetchCurrentWeekStats,
+    hasCurrentWeekStatsLoaded,
+    runLoadOperations,
+  ]);
+
+  useEffect(() => {
+    setCurrentWeekStats(prev => ({
+      ...prev,
+      weekActivities: activitiesThisWeek as Activity[],
+    }));
+  }, [activitiesThisWeek]);
 
   const ensureActivitiesLoaded = useCallback(async (force: boolean = false) => {
     if (!force && hasActivitiesLoaded) {
@@ -1278,6 +1360,13 @@ export const useFootballData = () => {
   ]);
 
   useEffect(() => {
+    if (!eagerStartupLoad || !authReady) {
+      if (!eagerStartupLoad) {
+        setLoading(false);
+      }
+      return;
+    }
+
     let cancelled = false;
     let interactionTask: { cancel?: () => void } | null = null;
 
@@ -1332,6 +1421,8 @@ export const useFootballData = () => {
       interactionTask?.cancel?.();
     };
   }, [
+    authReady,
+    eagerStartupLoad,
     fetchCategories,
     fetchCurrentWeekStats,
     fetchTasks,
@@ -1379,11 +1470,22 @@ export const useFootballData = () => {
   }, []);
 
   useEffect(() => {
+    const syncNotificationState = (force = false) => {
+      const now = Date.now();
+      if (!force && now - lastNotificationSyncAtRef.current < NOTIFICATION_SYNC_THROTTLE_MS) {
+        return;
+      }
+
+      lastNotificationSyncAtRef.current = now;
+      refreshNotificationQueue();
+      if (Platform.OS === 'ios') {
+        checkNotificationPermissions();
+      }
+    };
+
     const sub = AppState.addEventListener('change', (state: AppStateStatus) => {
       if (state === 'active') {
-        refreshNotificationQueue();
-        // Keep permission status in sync when user returns from iOS settings
-        checkNotificationPermissions();
+        syncNotificationState();
       }
     });
 
@@ -1392,7 +1494,11 @@ export const useFootballData = () => {
 
   useEffect(() => {
     if (Platform.OS === 'ios') {
-      checkNotificationPermissions();
+      const now = Date.now();
+      if (now - lastNotificationSyncAtRef.current >= NOTIFICATION_SYNC_THROTTLE_MS) {
+        lastNotificationSyncAtRef.current = now;
+        checkNotificationPermissions();
+      }
     }
   }, []);
 
@@ -2137,6 +2243,8 @@ export const useFootballData = () => {
     todayActivities,
     isLoading: loading,
     refreshAll,
+    ensureTemplateDataLoaded,
+    ensureCurrentWeekStatsLoaded,
     ensureActivitiesLoaded,
     ensurePerformanceDataLoaded,
     refreshCategories, // ✅ P14 export

--- a/hooks/useHomeActivities.ts
+++ b/hooks/useHomeActivities.ts
@@ -1,8 +1,10 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as FileSystem from 'expo-file-system';
 import { addDays, addMonths, endOfWeek, format, startOfWeek } from 'date-fns';
 import { supabase } from '@/integrations/supabase/client';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { getCategories, DatabaseActivityCategory } from '@/services/activities';
 import { resolveActivityCategory, type CategoryMappingRecord } from '@/shared/activityCategoryResolver';
 import { subscribeToTaskCompletion } from '@/utils/taskEvents';
@@ -16,6 +18,10 @@ import {
 } from '@/utils/activityEvents';
 import { setHomeLoadProgress } from '@/utils/startupLoader';
 import { useAdmin, type AdminMode } from '@/contexts/AdminContext';
+
+const HOME_ACTIVITY_SNAPSHOT_PREFIX = '@home_activity_snapshot_v1';
+const HOME_FOCUS_REFRESH_STALE_MS = 2 * 60 * 1000;
+const HOME_FOCUS_REFRESH_MIN_INTERVAL_MS = 30 * 1000;
 
 interface ActivityTask {
   id: string;
@@ -440,10 +446,17 @@ interface UseHomeActivitiesResult {
   loadFullWindow: () => Promise<boolean>;
 }
 
+type CachedHomeActivitySnapshot = {
+  scope: HomeActivityLoadScope;
+  savedAt: string;
+  activities: ActivityWithCategory[];
+};
+
 export function useHomeActivities(): UseHomeActivitiesResult {
   const { adminMode, adminTargetId, adminTargetType } = useAdmin();
-  const [userId, setUserId] = useState<string | null>(null);
-  const [sessionChecked, setSessionChecked] = useState(false);
+  const { authReady, user } = useAuthSession();
+  const userId = user?.id ?? null;
+  const sessionChecked = authReady;
   const [activities, setActivities] = useState<ActivityWithCategory[]>([]);
   const [loading, setLoading] = useState(true);
   const [initialLoadSucceeded, setInitialLoadSucceeded] = useState(false);
@@ -454,6 +467,8 @@ export function useHomeActivities(): UseHomeActivitiesResult {
   const lastSeenRefreshVersionRef = useRef<number>(0);
   const hasLoadedOnceRef = useRef(false);
   const hasLoadedFullWindowRef = useRef(false);
+  const lastSuccessfulLoadAtRef = useRef(0);
+  const lastFocusRefreshStartedAtRef = useRef(0);
 
   useEffect(() => {
     hasLoadedFullWindowRef.current = hasLoadedFullWindow;
@@ -472,10 +487,52 @@ export function useHomeActivities(): UseHomeActivitiesResult {
     lastSeenRefreshVersionRef.current = 0;
     hasLoadedOnceRef.current = false;
     hasLoadedFullWindowRef.current = false;
+    lastSuccessfulLoadAtRef.current = 0;
+    lastFocusRefreshStartedAtRef.current = 0;
     setActivities([]);
     setInitialLoadSucceeded(false);
     setHasLoadedFullWindow(false);
   }, [activityScopeKey]);
+
+  const homeSnapshotKey = `${HOME_ACTIVITY_SNAPSHOT_PREFIX}:${activityScopeKey}`;
+
+  const loadCachedSnapshot = useCallback(async (): Promise<CachedHomeActivitySnapshot | null> => {
+    try {
+      const raw = await AsyncStorage.getItem(homeSnapshotKey);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as Partial<CachedHomeActivitySnapshot>;
+      if (!Array.isArray(parsed.activities)) return null;
+      const scope = parsed.scope === 'full' ? 'full' : 'initial';
+      return {
+        scope,
+        savedAt:
+          typeof parsed.savedAt === 'string' && parsed.savedAt.trim().length > 0
+            ? parsed.savedAt
+            : new Date(0).toISOString(),
+        activities: parsed.activities as ActivityWithCategory[],
+      };
+    } catch {
+      return null;
+    }
+  }, [homeSnapshotKey]);
+
+  const persistCachedSnapshot = useCallback(
+    async (scope: HomeActivityLoadScope, nextActivities: ActivityWithCategory[]) => {
+      try {
+        await AsyncStorage.setItem(
+          homeSnapshotKey,
+          JSON.stringify({
+            scope,
+            savedAt: new Date().toISOString(),
+            activities: nextActivities,
+          } satisfies CachedHomeActivitySnapshot),
+        );
+      } catch {
+        // Cache is best-effort only.
+      }
+    },
+    [homeSnapshotKey]
+  );
 
   const patchActivityTasks = useCallback((activityId: string, taskId: string, completed: boolean) => {
     setActivities(prev => {
@@ -614,50 +671,6 @@ export function useHomeActivities(): UseHomeActivitiesResult {
       return mutated ? next : prev;
     });
   }, [enrichCategoryPatch]);
-
-  // Get user ID
-  useEffect(() => {
-    const fetchUser = async () => {
-      setHomeLoadProgress(0.05);
-      try {
-        const {
-          data: { session },
-          error,
-        } = await supabase.auth.getSession();
-
-        if (error) {
-          console.error('Failed to fetch session:', error);
-          setActivities([]);
-          setInitialLoadSucceeded(false);
-          setLoading(false);
-          setSessionChecked(true);
-          return;
-        }
-
-        const userIdFromSession = session?.user?.id;
-        if (!userIdFromSession) {
-          setActivities([]);
-          setInitialLoadSucceeded(true);
-          setLoading(false);
-          setSessionChecked(true);
-          setHomeLoadProgress(1);
-          return;
-        }
-
-        setUserId(userIdFromSession);
-        setSessionChecked(true);
-        setHomeLoadProgress(0.12);
-      } catch (err) {
-        console.error('Failed to fetch session:', err);
-        setActivities([]);
-        setInitialLoadSucceeded(false);
-        setLoading(false);
-        setSessionChecked(true);
-        setHomeLoadProgress(0);
-      }
-    };
-    fetchUser();
-  }, []);
 
   const refetchActivities = useCallback(async (scope: HomeActivityLoadScope = 'full'): Promise<boolean> => {
     const setStartupProgressIfInitial = (progress: number) => {
@@ -1535,6 +1548,8 @@ export function useHomeActivities(): UseHomeActivitiesResult {
 
       setStartupProgressIfInitial(0.95);
       setActivities(finalActivities);
+      lastSuccessfulLoadAtRef.current = Date.now();
+      void persistCachedSnapshot(scope, finalActivities);
 
       if (orphanCleanupResults.length && __DEV__) {
         orphanCleanupResults.forEach(result => {
@@ -1564,7 +1579,9 @@ export function useHomeActivities(): UseHomeActivitiesResult {
       return true;
     } catch (err) {
       console.error('Failed to fetch activities:', err);
-      setActivities([]);
+      if (!hasLoadedOnceRef.current) {
+        setActivities([]);
+      }
       if (scope === 'full') {
         setHasLoadedFullWindow(false);
       }
@@ -1573,7 +1590,7 @@ export function useHomeActivities(): UseHomeActivitiesResult {
       }
       return false;
     }
-  }, [adminMode, adminTargetId, adminTargetType, userId]);
+  }, [adminMode, adminTargetId, adminTargetType, persistCachedSnapshot, userId]);
 
   const triggerRefetch = useCallback(
     async (
@@ -1651,6 +1668,8 @@ export function useHomeActivities(): UseHomeActivitiesResult {
         return;
       }
 
+      setHomeLoadProgress(0.05);
+
       if (!userId) {
         setActivities([]);
         setInitialLoadSucceeded(true);
@@ -1659,7 +1678,23 @@ export function useHomeActivities(): UseHomeActivitiesResult {
         return;
       }
 
-      if (mounted) {
+      let hydratedFromCache = false;
+
+      if (!hasLoadedOnceRef.current) {
+        const cachedSnapshot = await loadCachedSnapshot();
+        if (mounted && cachedSnapshot?.activities?.length) {
+          hydratedFromCache = true;
+          hasLoadedOnceRef.current = true;
+          lastSuccessfulLoadAtRef.current = new Date(cachedSnapshot.savedAt).getTime() || Date.now();
+          setActivities(cachedSnapshot.activities);
+          setInitialLoadSucceeded(true);
+          setHasLoadedFullWindow(cachedSnapshot.scope === 'full');
+          setLoading(false);
+          setHomeLoadProgress(1);
+        }
+      }
+
+      if (mounted && !hydratedFromCache) {
         setLoading(true);
         setInitialLoadSucceeded(false);
         setHomeLoadProgress(0.15);
@@ -1667,13 +1702,16 @@ export function useHomeActivities(): UseHomeActivitiesResult {
 
       let firstLoadSucceeded = false;
       try {
-        firstLoadSucceeded = await triggerRefetch('initial_load_first_week', 'initial');
+        firstLoadSucceeded = await triggerRefetch(
+          hydratedFromCache ? 'initial_load_cache_revalidate' : 'initial_load_first_week',
+          'initial'
+        );
       } catch (err) {
         console.error('Failed to load home activities:', err);
       } finally {
         hasLoadedOnceRef.current = true;
         if (mounted) {
-          setInitialLoadSucceeded(firstLoadSucceeded);
+          setInitialLoadSucceeded(hydratedFromCache || firstLoadSucceeded);
           setLoading(false);
         }
       }
@@ -1688,14 +1726,22 @@ export function useHomeActivities(): UseHomeActivitiesResult {
     return () => {
       mounted = false;
     };
-  }, [activityScopeKey, sessionChecked, userId, triggerRefetch]);
+  }, [activityScopeKey, loadCachedSnapshot, sessionChecked, triggerRefetch, userId]);
 
   useFocusEffect(
     useCallback(() => {
       if (!hasLoadedOnceRef.current) {
         return;
       }
-      triggerRefetch('home_focus');
+      const now = Date.now();
+      if (now - lastFocusRefreshStartedAtRef.current < HOME_FOCUS_REFRESH_MIN_INTERVAL_MS) {
+        return;
+      }
+      if (now - lastSuccessfulLoadAtRef.current < HOME_FOCUS_REFRESH_STALE_MS) {
+        return;
+      }
+      lastFocusRefreshStartedAtRef.current = now;
+      void triggerRefetch('home_focus');
     }, [triggerRefetch])
   );
 

--- a/hooks/useUserRole.ts
+++ b/hooks/useUserRole.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import type { RealtimeChannel } from '@supabase/supabase-js';
+import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { supabase } from '@/integrations/supabase/client';
 
 type UserRole = 'admin' | 'trainer' | 'player';
@@ -25,9 +26,9 @@ interface FetchRoleOptions {
 }
 
 export function useUserRole() {
+  const { authReady, isAuthenticated, user } = useAuthSession();
   const [userRole, setUserRole] = useState<UserRole | null>(null);
   const [loading, setLoading] = useState(true);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   const userIdRef = useRef<string | null>(null);
   const lastKnownRoleRef = useRef<UserRole | null>(null);
@@ -41,27 +42,15 @@ export function useUserRole() {
     }
 
     try {
-      let targetUserId = userId ?? userIdRef.current;
+      let targetUserId = userId ?? userIdRef.current ?? user?.id ?? null;
 
       if (!targetUserId) {
-        const {
-          data: { session },
-          error: sessionError,
-        } = await supabase.auth.getSession();
-
-        const sessionUser = session?.user ?? null;
-
-        if (sessionError || !sessionUser) {
-          if (mountedRef.current) {
-            lastKnownRoleRef.current = null;
-            setUserRole(null);
-            setCurrentUserId(null);
-            setIsAuthenticated(false);
-          }
-          return;
+        if (mountedRef.current) {
+          lastKnownRoleRef.current = null;
+          setUserRole(null);
+          setCurrentUserId(null);
         }
-
-        targetUserId = sessionUser.id;
+        return;
       }
 
       if (userIdRef.current && userIdRef.current !== targetUserId) {
@@ -69,7 +58,6 @@ export function useUserRole() {
       }
 
       userIdRef.current = targetUserId;
-      setIsAuthenticated(true);
       setCurrentUserId(prev => (prev === targetUserId ? prev : targetUserId));
 
       const { data, error } = await supabase
@@ -115,44 +103,39 @@ export function useUserRole() {
         setLoading(false);
       }
     }
-  }, []);
+  }, [user?.id]);
 
   const refreshUserRole = useCallback(async () => {
     await fetchUserRole({ reason: 'manual-refresh' });
   }, [fetchUserRole]);
 
   useEffect(() => {
-    fetchUserRole();
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (!mountedRef.current) {
-        return;
-      }
-
-      if (session?.user) {
-        setIsAuthenticated(true);
-        fetchUserRole({ reason: 'auth-change', userId: session.user.id });
-      } else {
-        userIdRef.current = null;
-        lastKnownRoleRef.current = null;
-        setCurrentUserId(null);
-        setUserRole(null);
-        setIsAuthenticated(false);
-        setLoading(false);
-      }
-    });
-
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
-      subscription.unsubscribe();
       if (realtimeChannelRef.current) {
         supabase.removeChannel(realtimeChannelRef.current);
         realtimeChannelRef.current = null;
       }
     };
-  }, [fetchUserRole]);
+  }, []);
+
+  useEffect(() => {
+    if (!authReady) {
+      return;
+    }
+
+    if (user?.id) {
+      void fetchUserRole({ reason: 'auth-state', userId: user.id });
+      return;
+    }
+
+    userIdRef.current = null;
+    lastKnownRoleRef.current = null;
+    setCurrentUserId(null);
+    setUserRole(null);
+    setLoading(false);
+  }, [authReady, fetchUserRole, user?.id]);
 
   useEffect(() => {
     if (!currentUserId) {
@@ -210,5 +193,5 @@ export function useUserRole() {
   // Export isAdmin as a computed property - includes both admin and trainer roles
   const isAdmin = userRole === 'admin' || userRole === 'trainer';
 
-  return { userRole, loading, isAdmin, refreshUserRole, isAuthenticated };
+  return { userRole, loading: !authReady || loading, isAdmin, refreshUserRole, isAuthenticated };
 }

--- a/integrations/supabase/client.ts
+++ b/integrations/supabase/client.ts
@@ -28,6 +28,9 @@ let latestSession: Session | null = null;
 let inFlightGetSessionStartedAt = 0;
 let inFlightGetUserStartedAt = 0;
 
+export const getLatestSession = () => latestSession;
+export const getLatestUser = () => latestSession?.user ?? null;
+
 class AuthRequestTimeoutError extends Error {
   timeoutMs: number;
 

--- a/services/taskService.ts
+++ b/services/taskService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/integrations/supabase/client';
+import type { TablesUpdate } from '@/integrations/supabase/types';
 import { emitTaskCompletionEvent } from '@/utils/taskEvents';
 import type { TaskCompletionEvent } from '@/utils/taskEvents';
 import { Task } from '@/types';
@@ -314,7 +315,7 @@ export const taskService = {
     updates: UpdateTaskData,
     signal: AbortSignal = new AbortController().signal,
   ): Promise<void> {
-    const updateData: Record<string, any> = {};
+    const updateData: TablesUpdate<'task_templates'> = {};
 
     if (updates.title !== undefined) updateData.title = updates.title;
     if (updates.description !== undefined) updateData.description = updates.description;


### PR DESCRIPTION
## Hvad er ændret

Denne PR gør startup og resume markant lettere, især på iOS.

De vigtigste ændringer er:

- Central auth/session state via en fælles `AuthSessionContext`, så vi ikke længere starter flere parallelle `getSession()` / `onAuthStateChange()` flows ved boot.
- Apple IAP på iOS bliver ikke længere initialiseret som en del af cold start. I stedet bliver det varmet op i baggrunden efter startup, når auth er klar.
- `FootballProvider` loader ikke længere tung template/stat-data eager ved app-start. Data bliver nu loadet lazy fra de skærme, der faktisk bruger det.
- Home hydreres nu fra et cachet snapshot, så brugeren kan se sidste kendte state med det samme, mens frisk data hentes i baggrunden.
- Resume/focus-refresh er gjort lettere med stale/throttle-logik, så vi undgår fuld refresh ved hver wake fra sleep.
- Subscription plans bliver nu også loadet lazy dér, hvor de vises, i stedet for som en del af global bootstrap.

## Hvorfor

Root cause var, at appen gjorde for meget globalt arbejde i startup-pathen:

- auth/session blev slået op flere steder
- iOS IAP blev initialiseret for tidligt
- football/template/stat-data blev hentet globalt
- home ventede på mere data end nødvendigt
- wake fra sleep triggere for mange refreshes

Det gav især langsom cold start og tung resume-adfærd på iOS.

## Effekt for brugeren

Forventet effekt:

- hurtigere oplevet startup
- hurtigere wake fra sleep
- mindre loader/frys ved åbning af appen
- mindre iOS-specifik startup-omkostning
- hurtigere første visning af home via cached snapshot

## Tekniske highlights

- ny `AuthSessionContext`
- deferred IAP warmup efter startup
- lazy football/template/stat loading via `ensureTemplateDataLoaded()` og `ensureCurrentWeekStatsLoaded()`
- throttled focus/resume refresh
- cached home snapshot + background revalidation
- lazy loading af subscription plans i subscription managers

## Validering

Kørt:

- `npm run typecheck`

## Bemærkninger

Tradeoffet her er bevidst: noget data bliver nu loadet efter første paint i stedet for før første paint. Det gør startup hurtigere og flytter tungt arbejde væk fra boot-pathen.
