### PR TITLE
Speed up activity details loading and add Instagram thumbnails

### DIFF
--- a/__tests__/activityRouteSnapshot.test.ts
+++ b/__tests__/activityRouteSnapshot.test.ts
@@ -1,0 +1,60 @@
+import { deserializeActivitySnapshotFromRoute, serializeActivitySnapshotForRoute } from '@/utils/activityRouteSnapshot';
+
+describe('activityRouteSnapshot', () => {
+  it('round-trips an activity snapshot with task video metadata', () => {
+    const serialized = serializeActivitySnapshotForRoute(
+      {
+        id: 'activity-1',
+        title: 'Afslutningstræning',
+        activity_time: '18:30:00',
+        activity_end_time: '20:00:00',
+        location: 'Bane 2',
+        category: {
+          id: 'cat-1',
+          name: 'Afslutninger',
+          color: '#22c55e',
+          emoji: '⚽',
+        },
+        tasks: [
+          {
+            id: 'task-1',
+            title: 'Se reel',
+            description: 'Videoanalyse',
+            completed: false,
+            reminder_minutes: 45,
+            video_url: 'https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=',
+            task_template_id: 'template-1',
+          },
+        ],
+        intensity: 4,
+        intensity_enabled: true,
+        intensity_note: 'Høj kvalitet',
+        is_external: true,
+        external_calendar_id: 'calendar-1',
+        external_event_id: 'event-1',
+        external_event_row_id: 'row-1',
+      },
+      new Date('2026-04-13T18:30:00.000Z'),
+    );
+
+    expect(serialized).toBeTruthy();
+
+    const deserialized = deserializeActivitySnapshotFromRoute(serialized);
+    expect(deserialized).not.toBeNull();
+    expect(deserialized?.id).toBe('activity-1');
+    expect(deserialized?.title).toBe('Afslutningstræning');
+    expect(deserialized?.date.toISOString()).toBe('2026-04-13T18:30:00.000Z');
+    expect(deserialized?.tasks).toHaveLength(1);
+    expect((deserialized?.tasks?.[0] as any)?.video_url).toBe(
+      'https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=',
+    );
+    expect((deserialized?.tasks?.[0] as any)?.task_template_id).toBe('template-1');
+    expect(deserialized?.isExternal).toBe(true);
+    expect(deserialized?.externalEventRowId).toBe('row-1');
+  });
+
+  it('returns null for invalid snapshot payloads', () => {
+    expect(deserializeActivitySnapshotFromRoute('')).toBeNull();
+    expect(deserializeActivitySnapshotFromRoute('not-json')).toBeNull();
+  });
+});

--- a/__tests__/smartVideoPlayer.component.test.tsx
+++ b/__tests__/smartVideoPlayer.component.test.tsx
@@ -48,12 +48,12 @@ describe('SmartVideoPlayer', () => {
     expect(mockOpenUrl).toHaveBeenCalledWith('https://www.youtube.com/watch?si=share-token&v=dQw4w9WgXcQ');
   });
 
-  it('shows an external-link card for Instagram reels', () => {
+  it('shows an Instagram thumbnail and opens the original link when pressed', () => {
     const instagramUrl = 'https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=';
     const { getByTestId } = render(<SmartVideoPlayer url={instagramUrl} />);
 
-    expect(getByTestId('smart-video-player.external-link')).toBeTruthy();
-    fireEvent.press(getByTestId('smart-video-player.external-link'));
+    expect(getByTestId('smart-video-player.thumbnail')).toBeTruthy();
+    fireEvent.press(getByTestId('smart-video-player.thumbnail'));
 
     expect(mockOpenUrl).toHaveBeenCalledWith(instagramUrl);
   });

--- a/__tests__/useHomeActivities.priority.test.ts
+++ b/__tests__/useHomeActivities.priority.test.ts
@@ -1,0 +1,28 @@
+import { getHomeActivityPriorityBucket, partitionActivitiesByHomePriority } from '@/hooks/useHomeActivities';
+
+describe('useHomeActivities priority staging', () => {
+  const now = new Date('2026-04-15T10:00:00.000Z');
+
+  it('classifies activities into today, current week, upcoming, and historical buckets', () => {
+    expect(getHomeActivityPriorityBucket({ activity_date: '2026-04-15' }, now)).toBe('today');
+    expect(getHomeActivityPriorityBucket({ activity_date: '2026-04-13' }, now)).toBe('currentWeek');
+    expect(getHomeActivityPriorityBucket({ activity_date: '2026-04-20' }, now)).toBe('upcoming');
+    expect(getHomeActivityPriorityBucket({ activity_date: '2026-04-01' }, now)).toBe('historical');
+  });
+
+  it('partitions activities in the requested load order', () => {
+    const activities = [
+      { id: 'historical', activity_date: '2026-04-01' },
+      { id: 'upcoming', activity_date: '2026-04-20' },
+      { id: 'today', activity_date: '2026-04-15' },
+      { id: 'week', activity_date: '2026-04-17' },
+    ];
+
+    const partitioned = partitionActivitiesByHomePriority(activities, now);
+
+    expect(partitioned.today.map((activity) => activity.id)).toEqual(['today']);
+    expect(partitioned.currentWeek.map((activity) => activity.id)).toEqual(['week']);
+    expect(partitioned.upcoming.map((activity) => activity.id)).toEqual(['upcoming']);
+    expect(partitioned.historical.map((activity) => activity.id)).toEqual(['historical']);
+  });
+});

--- a/__tests__/videoUrlParser.test.ts
+++ b/__tests__/videoUrlParser.test.ts
@@ -25,6 +25,7 @@ describe('videoUrlParser', () => {
 
     expect(parsed.platform).toBe('instagram');
     expect(parsed.videoId).toBe('C7N2KQ2uV9x');
+    expect(parsed.thumbnailUrl).toBe('https://www.instagram.com/reel/C7N2KQ2uV9x/media/?size=l');
     expect(isPlayableVideoUrl('https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=')).toBe(true);
     expect(
       extractFirstPlayableVideoUrl('Se denne video https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=')

--- a/app/activity-details.tsx
+++ b/app/activity-details.tsx
@@ -55,6 +55,7 @@ import {
   hydrateTaskForModal,
   shouldHydrateTaskForModal,
 } from '@/utils/taskModalContent';
+import { deserializeActivitySnapshotFromRoute } from '@/utils/activityRouteSnapshot';
 
 const FALLBACK_COLORS = {
   primary: '#3B82F6',
@@ -4866,6 +4867,7 @@ export default function ActivityDetailsScreen() {
     id?: string | string[];
     activityId?: string | string[];
     activity_id?: string | string[];
+    activitySnapshot?: string | string[];
     categoryId?: string | string[];
     categoryName?: string | string[];
     categoryColor?: string | string[];
@@ -4897,6 +4899,10 @@ export default function ActivityDetailsScreen() {
   }, []);
 
   const activityId = normalizeParam(params.id ?? params.activityId ?? params.activity_id);
+  const prefetchedActivity = useMemo(
+    () => deserializeActivitySnapshotFromRoute(params.activitySnapshot),
+    [params.activitySnapshot],
+  );
   const fallbackCategoryId = normalizeParam(params.categoryId);
   const fallbackCategoryName = normalizeParam(params.categoryName);
   const fallbackCategoryColor = normalizeParam(params.categoryColor);
@@ -4906,8 +4912,8 @@ export default function ActivityDetailsScreen() {
   const openIntensityParam = normalizeParam(params.openIntensity);
   const initialOpenIntensity = openIntensityParam === '1' || openIntensityParam === 'true';
 
-  const [activity, setActivity] = useState<Activity | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [activity, setActivity] = useState<Activity | null>(prefetchedActivity);
+  const [isLoading, setIsLoading] = useState(!prefetchedActivity);
   const [fetchError, setFetchError] = useState<string | null>(null);
 
   const loadActivity = useCallback(async () => {
@@ -4918,12 +4924,20 @@ export default function ActivityDetailsScreen() {
       return;
     }
 
-    setIsLoading(true);
+    if (!prefetchedActivity) {
+      setIsLoading(true);
+    } else {
+      setActivity(current => current ?? prefetchedActivity);
+      setFetchError(null);
+    }
+
     try {
       const result = await fetchActivityFromDatabase(activityId);
       if (!result) {
-        setActivity(null);
-        setFetchError('not-found');
+        if (!prefetchedActivity) {
+          setActivity(null);
+          setFetchError('not-found');
+        }
       } else {
         if (result.isExternal) {
           const currentCategoryName = String(result.category?.name ?? '').trim().toLowerCase();
@@ -4953,11 +4967,26 @@ export default function ActivityDetailsScreen() {
       }
     } catch (error) {
       console.error('[ActivityDetails] Failed to load activity:', error);
-      setFetchError('fetch-failed');
+      if (!prefetchedActivity) {
+        setFetchError('fetch-failed');
+      }
     } finally {
       setIsLoading(false);
     }
-  }, [activityId, fallbackCategoryColor, fallbackCategoryEmoji, fallbackCategoryId, fallbackCategoryName]);
+  }, [
+    activityId,
+    fallbackCategoryColor,
+    fallbackCategoryEmoji,
+    fallbackCategoryId,
+    fallbackCategoryName,
+    prefetchedActivity,
+  ]);
+
+  useEffect(() => {
+    setActivity(prefetchedActivity);
+    setIsLoading(!prefetchedActivity);
+    setFetchError(null);
+  }, [activityId, prefetchedActivity]);
 
   useEffect(() => {
     (async () => {

--- a/components/ActivityCard.tsx
+++ b/components/ActivityCard.tsx
@@ -17,6 +17,7 @@ import {
   hydrateTaskForModal,
   shouldHydrateTaskForModal,
 } from '@/utils/taskModalContent';
+import { serializeActivitySnapshotForRoute } from '@/utils/activityRouteSnapshot';
 
 interface ActivityCardProps {
   activity: any;
@@ -472,6 +473,7 @@ export default function ActivityCard({
       console.warn('[ActivityCard] Missing activity id for navigation');
       return;
     }
+    const activitySnapshot = serializeActivitySnapshotForRoute(activity, resolvedDate);
     router.push({
       pathname: '/activity-details',
       params: {
@@ -481,15 +483,14 @@ export default function ActivityCard({
         categoryName: activity?.category?.name ? String(activity.category.name) : undefined,
         categoryColor: activity?.category?.color ? String(activity.category.color) : undefined,
         categoryEmoji: activity?.category?.emoji ? String(activity.category.emoji) : undefined,
+        activitySnapshot: activitySnapshot ?? undefined,
       },
     });
   }, [
-    activity?.category?.color,
-    activity?.category?.emoji,
-    activity?.category?.id,
-    activity?.category?.name,
+    activity,
     activityId,
     routeActivityId,
+    resolvedDate,
     router,
   ]);
 

--- a/components/SmartVideoPlayer.tsx
+++ b/components/SmartVideoPlayer.tsx
@@ -26,7 +26,9 @@ export default function SmartVideoPlayer({ url }: { url?: string }) {
     return buildVideoHtml(resolvedUrl, playVimeo);
   }, [playVimeo, resolvedUrl, vimeoId]);
   const thumbnailUrl = useMemo(() => {
-    if (parsedVideo?.platform === 'youtube') return parsedVideo.thumbnailUrl;
+    if (parsedVideo?.platform === 'youtube' || parsedVideo?.platform === 'instagram') {
+      return parsedVideo.thumbnailUrl;
+    }
     if (parsedVideo?.platform === 'vimeo' && vimeoId) return `https://vumbnail.com/${vimeoId}.jpg`;
     return null;
   }, [parsedVideo, vimeoId]);
@@ -100,6 +102,16 @@ export default function SmartVideoPlayer({ url }: { url?: string }) {
   }
 
   if (instagramUrl) {
+    if (thumbnailUrl) {
+      return (
+        <Thumb
+          img={thumbnailUrl}
+          onPress={() => Linking.openURL(instagramUrl)}
+          testID="smart-video-player.thumbnail"
+        />
+      );
+    }
+
     return (
       <Pressable
         onPress={() => Linking.openURL(instagramUrl)}

--- a/hooks/useHomeActivities.ts
+++ b/hooks/useHomeActivities.ts
@@ -367,6 +367,99 @@ export const getInitialHomeActivityWindow = (now: Date = new Date()): HomeActivi
   };
 };
 
+export type HomeActivityPriorityBucket = 'today' | 'currentWeek' | 'upcoming' | 'historical';
+
+type HomeActivityPriorityCandidate = {
+  activity_date?: string | null;
+};
+
+const getActivityDateKey = (activity: HomeActivityPriorityCandidate): string | null => {
+  const dateKey = typeof activity?.activity_date === 'string' ? activity.activity_date.trim() : '';
+  return dateKey.length ? dateKey.slice(0, 10) : null;
+};
+
+export const getHomeActivityPriorityBucket = (
+  activity: HomeActivityPriorityCandidate,
+  now: Date = new Date()
+): HomeActivityPriorityBucket => {
+  const activityDateKey = getActivityDateKey(activity);
+  if (!activityDateKey) {
+    return 'upcoming';
+  }
+
+  const todayKey = format(now, 'yyyy-MM-dd');
+  if (activityDateKey === todayKey) {
+    return 'today';
+  }
+
+  const weekStartKey = format(startOfWeek(now, { weekStartsOn: 1 }), 'yyyy-MM-dd');
+  const weekEndKey = format(endOfWeek(now, { weekStartsOn: 1 }), 'yyyy-MM-dd');
+  if (activityDateKey >= weekStartKey && activityDateKey <= weekEndKey) {
+    return 'currentWeek';
+  }
+
+  if (activityDateKey > weekEndKey) {
+    return 'upcoming';
+  }
+
+  return 'historical';
+};
+
+export const partitionActivitiesByHomePriority = <T extends HomeActivityPriorityCandidate>(
+  activities: T[],
+  now: Date = new Date()
+) => {
+  const today: T[] = [];
+  const currentWeek: T[] = [];
+  const upcoming: T[] = [];
+  const historical: T[] = [];
+
+  activities.forEach((activity) => {
+    const bucket = getHomeActivityPriorityBucket(activity, now);
+    if (bucket === 'today') {
+      today.push(activity);
+      return;
+    }
+    if (bucket === 'currentWeek') {
+      currentWeek.push(activity);
+      return;
+    }
+    if (bucket === 'upcoming') {
+      upcoming.push(activity);
+      return;
+    }
+    historical.push(activity);
+  });
+
+  return {
+    today,
+    currentWeek,
+    upcoming,
+    historical,
+  };
+};
+
+const mergeActivityPriorityStage = <T extends { id?: string | null }>(previous: T[], incoming: T[]): T[] => {
+  if (!incoming.length) return previous;
+
+  const incomingIds = new Set(
+    incoming
+      .map((activity) => normalizeId(activity?.id))
+      .filter((id): id is string => Boolean(id)),
+  );
+  const trailing = previous.filter((activity) => {
+    const id = normalizeId(activity?.id);
+    return !id || !incomingIds.has(id);
+  });
+  return [...incoming, ...trailing];
+};
+
+const yieldPriorityStage = async () => {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+};
+
 const fetchAllQueryPages = async <T,>(
   runPage: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: any | null }>
 ): Promise<{ data: T[] | null; error: any | null }> => {
@@ -1144,6 +1237,32 @@ export function useHomeActivities(): UseHomeActivitiesResult {
       devLog('[useHomeActivities] Total merged activities:', preHydratedActivities.length);
       devLog('[useHomeActivities] Activities with resolved category:', preHydratedActivities.filter(a => a.category).length);
       devLog('[useHomeActivities] Activities WITHOUT resolved category:', preHydratedActivities.filter(a => !a.category).length);
+
+      if (scope === 'full' && preHydratedActivities.length) {
+        const staged = partitionActivitiesByHomePriority(preHydratedActivities);
+        const fullWeekStage = [...staged.today, ...staged.currentWeek];
+        const upcomingStage = [...fullWeekStage, ...staged.upcoming];
+        const fullStage = [...upcomingStage, ...staged.historical];
+
+        if (staged.today.length) {
+          setActivities((prev) => mergeActivityPriorityStage(prev, staged.today));
+          await yieldPriorityStage();
+        }
+
+        if (fullWeekStage.length) {
+          setActivities((prev) => mergeActivityPriorityStage(prev, fullWeekStage));
+          await yieldPriorityStage();
+        }
+
+        if (upcomingStage.length) {
+          setActivities((prev) => mergeActivityPriorityStage(prev, upcomingStage));
+          await yieldPriorityStage();
+        }
+
+        if (fullStage.length) {
+          setActivities((prev) => mergeActivityPriorityStage(prev, fullStage));
+        }
+      }
 
       // 🔍 DEBUG: Log activities with tasks
       const activitiesWithTasks = preHydratedActivities.filter(a => a.tasks && a.tasks.length > 0);

--- a/utils/activityRouteSnapshot.ts
+++ b/utils/activityRouteSnapshot.ts
@@ -1,0 +1,226 @@
+import type { Activity, ActivityCategory, Task } from '@/types';
+
+type RouteSnapshotTask = Task & {
+  reminder_minutes?: number | null;
+  after_training_enabled?: boolean | null;
+  after_training_delay_minutes?: number | null;
+  task_duration_enabled?: boolean | null;
+  task_duration_minutes?: number | null;
+  video_url?: string | null;
+  task_template_id?: string | null;
+  feedback_template_id?: string | null;
+};
+
+type RouteSnapshotActivity = {
+  id: string;
+  title: string;
+  date: string;
+  time: string;
+  endTime?: string | null;
+  location: string;
+  category: ActivityCategory;
+  tasks: RouteSnapshotTask[];
+  intensity?: number | null;
+  intensityEnabled?: boolean;
+  intensityNote?: string | null;
+  isExternal?: boolean;
+  externalCalendarId?: string | null;
+  externalEventId?: string | null;
+  externalEventRowId?: string | null;
+};
+
+function normalizeString(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  return String(value).trim();
+}
+
+function normalizeNullableString(value: unknown): string | null {
+  const normalized = normalizeString(value);
+  return normalized.length ? normalized : null;
+}
+
+function normalizeBoolean(value: unknown, fallback = false): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function normalizeNumberOrNull(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function normalizeCategory(activity: any): ActivityCategory {
+  return {
+    id: normalizeString(activity?.category?.id ?? activity?.category_id),
+    name: normalizeString(activity?.category?.name) || 'Ukendt kategori',
+    color: normalizeString(activity?.category?.color) || '#999999',
+    emoji: normalizeString(activity?.category?.emoji) || '⚽️',
+  };
+}
+
+function normalizeTask(task: any): RouteSnapshotTask {
+  const videoUrl =
+    normalizeNullableString(task?.videoUrl) ??
+    normalizeNullableString(task?.video_url);
+  const taskTemplateId =
+    normalizeNullableString(task?.taskTemplateId) ??
+    normalizeNullableString(task?.task_template_id);
+  const feedbackTemplateId =
+    normalizeNullableString(task?.feedbackTemplateId) ??
+    normalizeNullableString(task?.feedback_template_id);
+  const reminderMinutes =
+    normalizeNumberOrNull(task?.reminder_minutes) ??
+    normalizeNumberOrNull(task?.reminder);
+  const afterTrainingDelayMinutes =
+    normalizeNumberOrNull(task?.afterTrainingDelayMinutes) ??
+    normalizeNumberOrNull(task?.after_training_delay_minutes);
+  const taskDurationMinutes =
+    normalizeNumberOrNull(task?.taskDurationMinutes) ??
+    normalizeNumberOrNull(task?.task_duration_minutes);
+  const taskDurationEnabled =
+    normalizeBoolean(task?.taskDurationEnabled) ||
+    normalizeBoolean(task?.task_duration_enabled);
+
+  return {
+    id: normalizeString(task?.id ?? task?.task_id),
+    title: normalizeString(task?.title),
+    description: normalizeString(task?.description),
+    completed: normalizeBoolean(task?.completed),
+    isTemplate: false,
+    categoryIds: Array.isArray(task?.categoryIds) ? task.categoryIds : [],
+    reminder: reminderMinutes ?? undefined,
+    reminder_minutes: reminderMinutes,
+    subtasks: Array.isArray(task?.subtasks) ? task.subtasks : [],
+    videoUrl: videoUrl ?? undefined,
+    video_url: videoUrl,
+    afterTrainingEnabled:
+      normalizeBoolean(task?.afterTrainingEnabled) ||
+      normalizeBoolean(task?.after_training_enabled),
+    after_training_enabled:
+      normalizeBoolean(task?.after_training_enabled) ||
+      normalizeBoolean(task?.afterTrainingEnabled),
+    afterTrainingDelayMinutes: afterTrainingDelayMinutes,
+    after_training_delay_minutes: afterTrainingDelayMinutes,
+    taskDurationEnabled: taskDurationEnabled,
+    task_duration_enabled: taskDurationEnabled,
+    taskDurationMinutes: taskDurationMinutes,
+    task_duration_minutes: taskDurationMinutes,
+    taskTemplateId: taskTemplateId,
+    task_template_id: taskTemplateId,
+    feedbackTemplateId: feedbackTemplateId,
+    feedback_template_id: feedbackTemplateId,
+    isFeedbackTask:
+      normalizeBoolean(task?.isFeedbackTask) ||
+      normalizeBoolean(task?.is_feedback_task),
+  };
+}
+
+export function serializeActivitySnapshotForRoute(activity: any, resolvedDate: Date): string | null {
+  if (!activity || !(resolvedDate instanceof Date) || Number.isNaN(resolvedDate.getTime())) {
+    return null;
+  }
+
+  const id = normalizeString(activity?.id ?? activity?.activity_id ?? activity?.activityId);
+  const title = normalizeString(activity?.title ?? activity?.name);
+  const time =
+    normalizeString(activity?.activity_time ?? activity?.start_time ?? activity?.time) ||
+    normalizeString(resolvedDate.toISOString().slice(11, 19));
+
+  if (!id || !title || !time) {
+    return null;
+  }
+
+  const snapshot: RouteSnapshotActivity = {
+    id,
+    title,
+    date: resolvedDate.toISOString(),
+    time,
+    endTime:
+      normalizeNullableString(activity?.activity_end_time) ??
+      normalizeNullableString(activity?.end_time) ??
+      normalizeNullableString(activity?.endTime),
+    location: normalizeString(activity?.location),
+    category: normalizeCategory(activity),
+    tasks: Array.isArray(activity?.tasks) ? activity.tasks.map(normalizeTask) : [],
+    intensity: normalizeNumberOrNull(activity?.intensity),
+    intensityEnabled:
+      normalizeBoolean(activity?.intensityEnabled) ||
+      normalizeBoolean(activity?.intensity_enabled),
+    intensityNote:
+      normalizeNullableString(activity?.intensityNote) ??
+      normalizeNullableString(activity?.intensity_note),
+    isExternal:
+      normalizeBoolean(activity?.isExternal) ||
+      normalizeBoolean(activity?.is_external),
+    externalCalendarId:
+      normalizeNullableString(activity?.externalCalendarId) ??
+      normalizeNullableString(activity?.external_calendar_id),
+    externalEventId:
+      normalizeNullableString(activity?.externalEventId) ??
+      normalizeNullableString(activity?.external_event_id),
+    externalEventRowId:
+      normalizeNullableString(activity?.externalEventRowId) ??
+      normalizeNullableString(activity?.external_event_row_id),
+  };
+
+  try {
+    return JSON.stringify(snapshot);
+  } catch {
+    return null;
+  }
+}
+
+export function deserializeActivitySnapshotFromRoute(value: unknown): Activity | null {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (typeof raw !== 'string' || !raw.trim().length) {
+    return null;
+  }
+
+  try {
+    let decoded = raw;
+    try {
+      decoded = decodeURIComponent(raw);
+    } catch {
+      decoded = raw;
+    }
+
+    const parsed = JSON.parse(decoded) as Partial<RouteSnapshotActivity> | null;
+    const id = normalizeString(parsed?.id);
+    const title = normalizeString(parsed?.title);
+    const dateIso = normalizeString(parsed?.date);
+    const time = normalizeString(parsed?.time);
+    const date = new Date(dateIso);
+
+    if (!id || !title || !time || Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return {
+      id,
+      title,
+      date,
+      time,
+      endTime: normalizeNullableString(parsed?.endTime),
+      location: normalizeString(parsed?.location),
+      category: {
+        id: normalizeString(parsed?.category?.id),
+        name: normalizeString(parsed?.category?.name) || 'Ukendt kategori',
+        color: normalizeString(parsed?.category?.color) || '#999999',
+        emoji: normalizeString(parsed?.category?.emoji) || '⚽️',
+      },
+      tasks: Array.isArray(parsed?.tasks) ? parsed.tasks.map(normalizeTask) : [],
+      intensity: normalizeNumberOrNull(parsed?.intensity),
+      intensityEnabled: normalizeBoolean(parsed?.intensityEnabled),
+      intensityNote: normalizeNullableString(parsed?.intensityNote),
+      isExternal: normalizeBoolean(parsed?.isExternal),
+      externalCalendarId: normalizeNullableString(parsed?.externalCalendarId) ?? undefined,
+      externalEventId: normalizeNullableString(parsed?.externalEventId) ?? undefined,
+      externalEventRowId: normalizeNullableString(parsed?.externalEventRowId) ?? undefined,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/utils/videoUrlParser.ts
+++ b/utils/videoUrlParser.ts
@@ -126,6 +126,28 @@ function parseInstagramVideoId(url: string): string | null {
   return null;
 }
 
+function buildInstagramThumbnailUrl(url: string, videoId: string): string | null {
+  const parsed = safeParseUrl(url);
+  if (parsed) {
+    const host = normalizeHost(parsed.hostname);
+    if (host === 'instagram.com') {
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      const contentType = segments[0];
+      if (contentType === 'reel' || contentType === 'p' || contentType === 'tv') {
+        return `https://www.instagram.com/${contentType}/${videoId}/media/?size=l`;
+      }
+    }
+  }
+
+  if (/instagram\.com\/reel\//i.test(url)) {
+    return `https://www.instagram.com/reel/${videoId}/media/?size=l`;
+  }
+  if (/instagram\.com\/tv\//i.test(url)) {
+    return `https://www.instagram.com/tv/${videoId}/media/?size=l`;
+  }
+  return `https://www.instagram.com/p/${videoId}/media/?size=l`;
+}
+
 /**
  * Parse video URL and extract platform information
  * Converts supported URLs to platform metadata
@@ -168,7 +190,7 @@ export function parseVideoUrl(url: string): VideoInfo {
       platform: 'instagram',
       videoId: instagramId,
       embedUrl: null,
-      thumbnailUrl: null,
+      thumbnailUrl: buildInstagramThumbnailUrl(trimmedUrl, instagramId),
     };
   }
 


### PR DESCRIPTION
## Hvad er lavet

Denne PR forbedrer oplevelsen, når man åbner en aktivitet fra home-skærmen, og retter thumbnail-preview for Instagram-videoer i opgaver.

## Ændringer

- `activity-details` åbner nu med det samme ud fra et route-snapshot af den valgte aktivitet i stedet for altid at vente på et nyt database-load
- aktivitetens data revalideres stadig i baggrunden, så vi bevarer korrekthed uden at blokere UI
- `useHomeActivities` prioriterer nu indlæsning i denne rækkefølge:
  - dagens aktiviteter
  - resten af denne uge
  - kommende uger
  - historiske aktiviteter
- Instagram-links i opgaver får nu thumbnail-preview og opfører sig visuelt mere som YouTube-links
- der er tilføjet tests for:
  - activity route snapshot
  - prioriteringsrækkefølge i home activity loading
  - Instagram thumbnail parsing/rendering

## Hvorfor

Appen landede hurtigt efter startup, men åbning af en aktivitet føltes stadig tung, fordi detaljeskærmen ventede på et fuldt fetch, selv når vi allerede havde data i memory. Samtidig viste Instagram-opgaver ikke preview, hvilket gav en dårligere oplevelse end YouTube-links.

## Resultat

- hurtigere oplevet åbning af aktivitetsdetaljer
- bedre prioritering af de aktiviteter brugeren mest sandsynligt trykker på først
- thumbnails virker nu også for Instagram-videoer i opgaver

## Verificering

- `npm run lint`
- `npm run typecheck`
- `npm test`
