### PR TITLE
Fix template task video sync and category cleanup

### DIFF
--- a/__tests__/activity-details.add-task.screen.test.tsx
+++ b/__tests__/activity-details.add-task.screen.test.tsx
@@ -8,6 +8,7 @@ import type { TaskTemplateSelfFeedback } from '@/types';
 
 const mockRefreshData = jest.fn().mockResolvedValue(undefined);
 const mockSupabaseFrom = jest.fn();
+let mockTaskTemplates: any[] = [];
 const mockUpdateActivitySingle = jest.fn().mockResolvedValue(undefined);
 const mockUpdateIntensityByCategory = jest.fn().mockResolvedValue(undefined);
 const mockUpdateActivitySeries = jest.fn().mockResolvedValue(undefined);
@@ -94,6 +95,7 @@ jest.mock('@/contexts/FootballContext', () => ({
     refreshData: mockRefreshData,
     createActivity: jest.fn(),
     duplicateActivity: jest.fn(),
+    tasks: mockTaskTemplates,
   }),
 }));
 
@@ -183,6 +185,7 @@ jest.mock('react-native-safe-area-context', () => ({
 describe('ActivityDetails add-task flow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockTaskTemplates = [];
     mockFetchSelfFeedbackForActivities.mockResolvedValue([]);
     mockFetchSelfFeedbackForTemplates.mockResolvedValue([]);
     mockFetchLatestCategoryFeedback.mockResolvedValue([]);
@@ -1330,6 +1333,172 @@ describe('ActivityDetails add-task flow', () => {
 
     expect(await findByText('Vælg opgaveskabelon')).toBeTruthy();
     expect(queryByTestId('mock.createActivityTaskModal')).toBeNull();
+
+    alertSpy.mockRestore();
+  });
+
+  it('preserves the template video url when creating a task directly from a template', async () => {
+    const instagramUrl = 'https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=';
+    mockTaskTemplates = [
+      {
+        id: 'template-source-1',
+        title: 'Instagram Reel',
+        description: 'Se videoen',
+        completed: false,
+        isTemplate: true,
+        categoryIds: [],
+        subtasks: [],
+        videoUrl: instagramUrl,
+      },
+    ];
+
+    const insertedTaskTemplates: Record<string, any>[] = [];
+    const insertedActivityTasks: Record<string, any>[] = [];
+    const defaultSupabaseFrom = mockSupabaseFrom.getMockImplementation();
+
+    mockSupabaseFrom.mockImplementation((table: string) => {
+      if (table === 'task_templates') {
+        const builder: any = {
+          insert: (payload: Record<string, any>) => {
+            insertedTaskTemplates.push(payload);
+            return builder;
+          },
+          select: () => builder,
+          eq: () => builder,
+          in: async (_column: string, ids: string[]) => ({
+            data: ids.map((id) => ({ id, archived_at: null })),
+            error: null,
+          }),
+          maybeSingle: async () => ({ data: null, error: null }),
+          single: async () => ({
+            data: { id: 'local-template-1' },
+            error: null,
+          }),
+        };
+        return builder;
+      }
+
+      if (table === 'activity_tasks') {
+        const builder: any = {
+          insert: (payload: Record<string, any>) => {
+            insertedActivityTasks.push(payload);
+            return builder;
+          },
+          select: () => builder,
+          eq: async () => ({
+            data: insertedActivityTasks.map((row, index) => ({
+              id: `created-task-${index + 1}`,
+              title: row.title,
+              description: row.description,
+              completed: row.completed ?? false,
+              reminder_minutes: row.reminder_minutes ?? null,
+              task_template_id: row.task_template_id ?? null,
+              feedback_template_id: row.feedback_template_id ?? null,
+              video_url: row.video_url ?? null,
+            })),
+            error: null,
+          }),
+          single: async () => ({
+            data: insertedActivityTasks.at(-1) ?? null,
+            error: null,
+          }),
+        };
+        return builder;
+      }
+
+      if (table === 'activities') {
+        const builder: any = {
+          select: () => builder,
+          eq: () => builder,
+          single: async () => ({
+            data: {
+              id: 'activity-template-video-1',
+              title: 'Session',
+              activity_date: '2026-02-10',
+              activity_time: '10:00',
+              activity_end_time: null,
+              location: 'Pitch',
+              category_id: 'cat-1',
+              intensity: null,
+              intensity_enabled: false,
+              intensity_note: null,
+              is_external: false,
+              external_calendar_id: null,
+              external_event_id: null,
+              series_id: null,
+              series_instance_date: null,
+              activity_categories: {
+                id: 'cat-1',
+                name: 'Training',
+                color: '#123456',
+                emoji: '⚽️',
+              },
+              activity_tasks: insertedActivityTasks.map((row, index) => ({
+                id: `created-task-${index + 1}`,
+                title: row.title,
+                description: row.description,
+                completed: row.completed ?? false,
+                reminder_minutes: row.reminder_minutes ?? null,
+                task_template_id: row.task_template_id ?? null,
+                feedback_template_id: row.feedback_template_id ?? null,
+                video_url: row.video_url ?? null,
+              })),
+            },
+            error: null,
+          }),
+        };
+        return builder;
+      }
+
+      return defaultSupabaseFrom?.(table);
+    });
+
+    const activity = {
+      id: 'activity-template-video-1',
+      title: 'Session',
+      date: new Date('2026-02-10T10:00:00.000Z'),
+      time: '10:00',
+      location: 'Pitch',
+      category: { id: 'cat-1', name: 'Training', color: '#123456', emoji: '⚽️' },
+      tasks: [],
+      isExternal: false,
+      intensityEnabled: false,
+      intensity: null,
+      user_id: 'user-1',
+      player_id: null,
+      team_id: null,
+    };
+
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_title, _message, buttons) => {
+      const templateButton = Array.isArray(buttons)
+        ? (buttons as any[]).find((button) => button?.text === 'Opret fra skabelon')
+        : null;
+      templateButton?.onPress?.();
+    });
+
+    const { getByTestId, findByText, getByText } = render(
+      <ActivityDetailsModule.ActivityDetailsContent
+        activity={activity as any}
+        categories={[activity.category as any]}
+        isAdmin
+        isDark={false}
+        onBack={jest.fn()}
+        onActivityUpdated={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(getByTestId('activity.addTaskButton'));
+    expect(await findByText('Vælg opgaveskabelon')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(getByText('Instagram Reel'));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(insertedTaskTemplates).toHaveLength(1));
+    expect(insertedTaskTemplates[0].video_url).toBe(instagramUrl);
+    expect(insertedActivityTasks).toHaveLength(1);
+    expect(insertedActivityTasks[0].video_url).toBe(instagramUrl);
 
     alertSpy.mockRestore();
   });

--- a/__tests__/taskService.updateTask.category-sync.test.ts
+++ b/__tests__/taskService.updateTask.category-sync.test.ts
@@ -1,0 +1,270 @@
+import { taskService } from '@/services/taskService';
+
+type TaskTemplateCategoryRow = {
+  task_template_id: string;
+  category_id: string;
+};
+
+type ActivityTaskRow = {
+  id: string;
+  activity_id: string;
+  task_template_id: string | null;
+  feedback_template_id: string | null;
+};
+
+type ActivityRow = {
+  id: string;
+  category_id: string | null;
+};
+
+type ExternalEventTaskRow = {
+  id: string;
+  local_meta_id: string;
+  task_template_id: string | null;
+  feedback_template_id: string | null;
+};
+
+type ExternalMetaRow = {
+  id: string;
+  category_id: string | null;
+};
+
+const db = {
+  taskTemplateCategories: [] as TaskTemplateCategoryRow[],
+  activityTasks: [] as ActivityTaskRow[],
+  activities: [] as ActivityRow[],
+  externalEventTasks: [] as ExternalEventTaskRow[],
+  externalMeta: [] as ExternalMetaRow[],
+  rpcCalls: [] as { fn: string; args: Record<string, any> }[],
+};
+
+const applyFilters = <T extends Record<string, any>>(
+  rows: T[],
+  filters: { type: 'eq' | 'in'; column: string; value: any }[],
+): T[] =>
+  rows.filter((row) =>
+    filters.every((filter) => {
+      const currentValue = row[filter.column];
+      if (filter.type === 'eq') {
+        return currentValue === filter.value;
+      }
+      if (filter.type === 'in') {
+        return Array.isArray(filter.value) && filter.value.includes(currentValue);
+      }
+      return true;
+    })
+  );
+
+jest.mock('@/integrations/supabase/client', () => {
+  const from = (table: string) => {
+    const state: {
+      action: 'select' | 'update' | 'insert' | 'delete' | null;
+      filters: { type: 'eq' | 'in'; column: string; value: any }[];
+      payload: any;
+    } = {
+      action: null,
+      filters: [],
+      payload: null,
+    };
+
+    const execute = async () => {
+      if (table === 'task_templates' && state.action === 'update') {
+        return { error: null };
+      }
+
+      if (table === 'task_template_categories' && state.action === 'delete') {
+        db.taskTemplateCategories = db.taskTemplateCategories.filter(
+          (row) => !applyFilters([row], state.filters).length
+        );
+        return { error: null };
+      }
+
+      if (table === 'task_template_categories' && state.action === 'insert') {
+        const rows = Array.isArray(state.payload) ? state.payload : [state.payload];
+        db.taskTemplateCategories.push(...rows);
+        return { error: null };
+      }
+
+      if (table === 'activity_tasks' && state.action === 'select') {
+        return {
+          data: applyFilters(db.activityTasks, state.filters),
+          error: null,
+        };
+      }
+
+      if (table === 'activity_tasks' && state.action === 'delete') {
+        db.activityTasks = db.activityTasks.filter(
+          (row) => !applyFilters([row], state.filters).length
+        );
+        return { error: null };
+      }
+
+      if (table === 'activities' && state.action === 'select') {
+        return {
+          data: applyFilters(db.activities, state.filters),
+          error: null,
+        };
+      }
+
+      if (table === 'external_event_tasks' && state.action === 'select') {
+        return {
+          data: applyFilters(db.externalEventTasks, state.filters),
+          error: null,
+        };
+      }
+
+      if (table === 'external_event_tasks' && state.action === 'delete') {
+        db.externalEventTasks = db.externalEventTasks.filter(
+          (row) => !applyFilters([row], state.filters).length
+        );
+        return { error: null };
+      }
+
+      if (table === 'events_local_meta' && state.action === 'select') {
+        return {
+          data: applyFilters(db.externalMeta, state.filters),
+          error: null,
+        };
+      }
+
+      return { data: [], error: null };
+    };
+
+    const builder: any = {
+      select: () => {
+        state.action = 'select';
+        return builder;
+      },
+      update: (payload: any) => {
+        state.action = 'update';
+        state.payload = payload;
+        return builder;
+      },
+      insert: (payload: any) => {
+        state.action = 'insert';
+        state.payload = payload;
+        return builder;
+      },
+      delete: () => {
+        state.action = 'delete';
+        return builder;
+      },
+      eq: (column: string, value: any) => {
+        state.filters.push({ type: 'eq', column, value });
+        return builder;
+      },
+      in: (column: string, value: any[]) => {
+        state.filters.push({ type: 'in', column, value });
+        return builder;
+      },
+      abortSignal: () => execute(),
+    };
+
+    return builder;
+  };
+
+  return {
+    supabase: {
+      from,
+      rpc: async (fn: string, args: Record<string, any>) => {
+        db.rpcCalls.push({ fn, args });
+        return { data: null, error: null };
+      },
+    },
+  };
+});
+
+describe('taskService.updateTask category sync cleanup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    db.taskTemplateCategories = [
+      { task_template_id: 'template-1', category_id: 'cat-keep' },
+      { task_template_id: 'template-1', category_id: 'cat-remove' },
+    ];
+    db.activityTasks = [
+      {
+        id: 'activity-task-keep',
+        activity_id: 'activity-keep',
+        task_template_id: 'template-1',
+        feedback_template_id: null,
+      },
+      {
+        id: 'activity-task-remove',
+        activity_id: 'activity-remove',
+        task_template_id: 'template-1',
+        feedback_template_id: null,
+      },
+      {
+        id: 'activity-feedback-remove',
+        activity_id: 'activity-remove',
+        task_template_id: null,
+        feedback_template_id: 'template-1',
+      },
+    ];
+    db.activities = [
+      { id: 'activity-keep', category_id: 'cat-keep' },
+      { id: 'activity-remove', category_id: 'cat-remove' },
+    ];
+    db.externalEventTasks = [
+      {
+        id: 'external-task-keep',
+        local_meta_id: 'meta-keep',
+        task_template_id: 'template-1',
+        feedback_template_id: null,
+      },
+      {
+        id: 'external-task-remove',
+        local_meta_id: 'meta-remove',
+        task_template_id: 'template-1',
+        feedback_template_id: null,
+      },
+      {
+        id: 'external-feedback-remove',
+        local_meta_id: 'meta-remove',
+        task_template_id: null,
+        feedback_template_id: 'template-1',
+      },
+    ];
+    db.externalMeta = [
+      { id: 'meta-keep', category_id: 'cat-keep' },
+      { id: 'meta-remove', category_id: 'cat-remove' },
+    ];
+    db.rpcCalls = [];
+  });
+
+  it('removes stale activity and external tasks when a template category is removed', async () => {
+    await taskService.updateTask('template-1', 'user-1', {
+      categoryIds: ['cat-keep'],
+    });
+
+    expect(db.taskTemplateCategories).toEqual([
+      { task_template_id: 'template-1', category_id: 'cat-keep' },
+    ]);
+
+    expect(db.activityTasks).toEqual([
+      {
+        id: 'activity-task-keep',
+        activity_id: 'activity-keep',
+        task_template_id: 'template-1',
+        feedback_template_id: null,
+      },
+    ]);
+
+    expect(db.externalEventTasks).toEqual([
+      {
+        id: 'external-task-keep',
+        local_meta_id: 'meta-keep',
+        task_template_id: 'template-1',
+        feedback_template_id: null,
+      },
+    ]);
+
+    expect(db.rpcCalls).toContainEqual({
+      fn: 'update_all_tasks_from_template',
+      args: {
+        p_template_id: 'template-1',
+        p_dry_run: false,
+      },
+    });
+  });
+});

--- a/app/activity-details.tsx
+++ b/app/activity-details.tsx
@@ -3210,6 +3210,12 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
           typeof template.reminder === 'number' && Number.isFinite(template.reminder)
             ? clampMinutes(template.reminder)
             : null;
+        const resolvedVideoUrl = (() => {
+          const directValue = (template as any)?.videoUrl ?? (template as any)?.video_url;
+          if (typeof directValue !== 'string') return null;
+          const trimmed = directValue.trim();
+          return trimmed.length ? trimmed : null;
+        })();
         const afterTrainingEnabled = template.afterTrainingEnabled === true;
         const taskDurationEnabled =
           template.taskDurationEnabled === true || template.task_duration_enabled === true;
@@ -3221,6 +3227,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
             title: String(template.title ?? '').trim() || 'Opgave',
             description: String(template.description ?? ''),
             reminder_minutes: reminderValue,
+            video_url: resolvedVideoUrl,
             after_training_enabled: afterTrainingEnabled,
             after_training_delay_minutes: afterTrainingEnabled
               ? clampMinutes(template.afterTrainingDelayMinutes ?? 0)
@@ -3250,6 +3257,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
           description: String(template.description ?? ''),
           completed: false,
           reminder_minutes: reminderValue,
+          video_url: resolvedVideoUrl,
           task_template_id: String(localTemplateData.id),
           after_training_enabled: afterTrainingEnabled,
           after_training_delay_minutes:
@@ -3263,6 +3271,7 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
               : null,
         };
         const fallbackBasePayload = { ...basePayload } as Record<string, any>;
+        delete fallbackBasePayload.video_url;
         delete fallbackBasePayload.after_training_enabled;
         delete fallbackBasePayload.after_training_delay_minutes;
         delete fallbackBasePayload.task_duration_enabled;
@@ -3276,7 +3285,8 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
         let { error } = await supabase.from(table).insert(payload as any);
         if (
           error &&
-          (isMissingColumn(error, 'after_training_enabled') ||
+          (isMissingColumn(error, 'video_url') ||
+            isMissingColumn(error, 'after_training_enabled') ||
             isMissingColumn(error, 'after_training_delay_minutes') ||
             isMissingColumn(error, 'task_duration_enabled') ||
             isMissingColumn(error, 'task_duration_minutes'))

--- a/services/taskService.ts
+++ b/services/taskService.ts
@@ -75,6 +75,160 @@ const normalizeTaskDurationMinutes = (value: unknown): number | null => {
   return Math.min(rounded, MAX_TASK_DURATION_MINUTES);
 };
 
+const normalizeStringId = (value: unknown): string | null => {
+  if (value === null || value === undefined) return null;
+  const trimmed = String(value).trim();
+  return trimmed.length ? trimmed : null;
+};
+
+const uniqueStringIds = (values: unknown[]): string[] => {
+  const ids = values
+    .map((value) => normalizeStringId(value))
+    .filter((value): value is string => Boolean(value));
+  return Array.from(new Set(ids));
+};
+
+const removeStaleActivityTemplateTasks = async (
+  taskId: string,
+  nextCategoryIds: string[],
+  signal: AbortSignal,
+): Promise<void> => {
+  const allowedCategoryIds = new Set(nextCategoryIds);
+
+  const collectStaleIds = async (
+    column: 'task_template_id' | 'feedback_template_id',
+  ): Promise<string[]> => {
+    const { data: taskRows, error: taskRowsError } = await supabase
+      .from('activity_tasks')
+      .select('id, activity_id')
+      .eq(column, taskId)
+      .abortSignal(signal);
+
+    if (taskRowsError) throw taskRowsError;
+    if (!Array.isArray(taskRows) || taskRows.length === 0) return [];
+
+    const activityIds = uniqueStringIds(taskRows.map((row: any) => row?.activity_id));
+    if (activityIds.length === 0) {
+      return uniqueStringIds(taskRows.map((row: any) => row?.id));
+    }
+
+    const { data: activities, error: activitiesError } = await supabase
+      .from('activities')
+      .select('id, category_id')
+      .in('id', activityIds)
+      .abortSignal(signal);
+
+    if (activitiesError) throw activitiesError;
+
+    const categoryByActivityId = new Map<string, string | null>();
+    (activities ?? []).forEach((row: any) => {
+      const activityId = normalizeStringId(row?.id);
+      if (!activityId) return;
+      categoryByActivityId.set(activityId, normalizeStringId(row?.category_id));
+    });
+
+    return uniqueStringIds(
+      taskRows
+        .filter((row: any) => {
+          const activityId = normalizeStringId(row?.activity_id);
+          const categoryId = activityId ? categoryByActivityId.get(activityId) ?? null : null;
+          return !categoryId || !allowedCategoryIds.has(categoryId);
+        })
+        .map((row: any) => row?.id)
+    );
+  };
+
+  const staleIds = uniqueStringIds([
+    ...(await collectStaleIds('task_template_id')),
+    ...(await collectStaleIds('feedback_template_id')),
+  ]);
+
+  if (!staleIds.length) return;
+
+  const { error: deleteError } = await supabase
+    .from('activity_tasks')
+    .delete()
+    .in('id', staleIds)
+    .abortSignal(signal);
+
+  if (deleteError) throw deleteError;
+};
+
+const removeStaleExternalTemplateTasks = async (
+  taskId: string,
+  nextCategoryIds: string[],
+  signal: AbortSignal,
+): Promise<void> => {
+  const allowedCategoryIds = new Set(nextCategoryIds);
+
+  const collectStaleIds = async (
+    column: 'task_template_id' | 'feedback_template_id',
+  ): Promise<string[]> => {
+    const { data: taskRows, error: taskRowsError } = await supabase
+      .from('external_event_tasks')
+      .select('id, local_meta_id')
+      .eq(column, taskId)
+      .abortSignal(signal);
+
+    if (taskRowsError) throw taskRowsError;
+    if (!Array.isArray(taskRows) || taskRows.length === 0) return [];
+
+    const localMetaIds = uniqueStringIds(taskRows.map((row: any) => row?.local_meta_id));
+    if (localMetaIds.length === 0) {
+      return uniqueStringIds(taskRows.map((row: any) => row?.id));
+    }
+
+    const { data: metaRows, error: metaRowsError } = await supabase
+      .from('events_local_meta')
+      .select('id, category_id')
+      .in('id', localMetaIds)
+      .abortSignal(signal);
+
+    if (metaRowsError) throw metaRowsError;
+
+    const categoryByLocalMetaId = new Map<string, string | null>();
+    (metaRows ?? []).forEach((row: any) => {
+      const localMetaId = normalizeStringId(row?.id);
+      if (!localMetaId) return;
+      categoryByLocalMetaId.set(localMetaId, normalizeStringId(row?.category_id));
+    });
+
+    return uniqueStringIds(
+      taskRows
+        .filter((row: any) => {
+          const localMetaId = normalizeStringId(row?.local_meta_id);
+          const categoryId = localMetaId ? categoryByLocalMetaId.get(localMetaId) ?? null : null;
+          return !categoryId || !allowedCategoryIds.has(categoryId);
+        })
+        .map((row: any) => row?.id)
+    );
+  };
+
+  const staleIds = uniqueStringIds([
+    ...(await collectStaleIds('task_template_id')),
+    ...(await collectStaleIds('feedback_template_id')),
+  ]);
+
+  if (!staleIds.length) return;
+
+  const { error: deleteError } = await supabase
+    .from('external_event_tasks')
+    .delete()
+    .in('id', staleIds)
+    .abortSignal(signal);
+
+  if (deleteError) throw deleteError;
+};
+
+const removeStaleTemplateCategoryAssignments = async (
+  taskId: string,
+  categoryIds: string[],
+  signal: AbortSignal,
+): Promise<void> => {
+  await removeStaleActivityTemplateTasks(taskId, categoryIds, signal);
+  await removeStaleExternalTemplateTasks(taskId, categoryIds, signal);
+};
+
 export const taskService = {
   /* ======================================================
      CREATE (P8 – autoriseret entry point)
@@ -436,6 +590,15 @@ export const taskService = {
         console.error(
           '[TEMPLATE_CATEGORY_SYNC] Unexpected update_all_tasks_from_template failure',
           categorySyncUnexpectedError
+        );
+      }
+
+      try {
+        await removeStaleTemplateCategoryAssignments(taskId, updates.categoryIds, signal);
+      } catch (categoryCleanupUnexpectedError) {
+        console.error(
+          '[TEMPLATE_CATEGORY_SYNC] Unexpected cleanup failure after template category update',
+          categoryCleanupUnexpectedError
         );
       }
     }


### PR DESCRIPTION
## Hvad er lavet

Denne PR retter to fejl i opgave-skabelon flowet på aktiviteter:

1. Instagram-links blev ikke vist på opgaver, når en opgave blev tilføjet direkte til en aktivitet fra skabeloner.
2. Opgaver blev liggende på aktiviteter, når en kategori blev fjernet fra opgaveskabelonen.

## Ændringer

- Bevarer nu `video_url`, når en opgave oprettes direkte fra en skabelon i aktivitetsskærmen.
- Sikrer at lokale aktivitetstasks oprettet fra skabeloner stadig får Instagram-preview ligesom andre videoopgaver.
- Rydder nu op i eksisterende `activity_tasks` og `external_event_tasks`, hvis en skabelon ikke længere matcher aktivitetens kategori efter en skabelonopdatering.
- Dækker både normale template-opgaver og feedback-relaterede template-opgaver.

## Hvorfor

Vi havde en inkonsistens mellem:
- opgaver tilføjet direkte fra skabeloner
- opgaver oprettet via aktivitetskategorier

Det betød, at Instagram-videoer ikke blev vist i det ene flow. Samtidig blev kategoriændringer på skabeloner ikke korrekt afspejlet på allerede oprettede aktiviteter, så forældede opgaver blev liggende.

## Test

- Tilføjet regressionstest for direkte template-import med bevaret `video_url`
- Tilføjet regressionstest for cleanup af stale aktivitet-/event-opgaver ved kategoriændringer

## Verificering

- `npm run lint`
- `npm run typecheck`
- `npm test`
