### PR TITLE
fix: make activity delete instant

### DIFF
--- a/__tests__/activityEvents.test.ts
+++ b/__tests__/activityEvents.test.ts
@@ -1,0 +1,30 @@
+import {
+  emitActivityDeleted,
+  emitActivityDeleteRestored,
+  isActivityOptimisticallyDeleted,
+  subscribeToActivityDeleted,
+} from '@/utils/activityEvents';
+
+describe('activity delete events', () => {
+  it('tracks optimistic deleted activities and restores them on failure', () => {
+    const activityId = 'activity-optimistic-delete-test';
+    const seriesId = 'series-optimistic-delete-test';
+    const actions: string[] = [];
+    const unsubscribe = subscribeToActivityDeleted(event => {
+      actions.push(event.action);
+    });
+
+    emitActivityDeleted({ activityIds: [activityId], seriesId, reason: 'test_delete' });
+
+    expect(isActivityOptimisticallyDeleted({ id: activityId })).toBe(true);
+    expect(isActivityOptimisticallyDeleted({ id: 'other-activity', series_id: seriesId })).toBe(true);
+
+    emitActivityDeleteRestored({ activityIds: [activityId], seriesId, reason: 'test_restore' });
+
+    expect(isActivityOptimisticallyDeleted({ id: activityId })).toBe(false);
+    expect(isActivityOptimisticallyDeleted({ id: 'other-activity', series_id: seriesId })).toBe(false);
+    expect(actions).toEqual(['deleted', 'restored']);
+
+    unsubscribe();
+  });
+});

--- a/__tests__/celebration.provider.test.tsx
+++ b/__tests__/celebration.provider.test.tsx
@@ -84,9 +84,33 @@ describe('CelebrationProvider overlay', () => {
     expect(queryAllByTestId('celebration-fountain')).toHaveLength(0);
 
     act(() => {
-      jest.advanceTimersByTime(4100);
+      jest.advanceTimersByTime(2799);
     });
 
+    expect(getByTestId('celebration-overlay')).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(queryByTestId('celebration-overlay')).toBeNull();
+  });
+
+  it('dismisses on the next app tap without requiring the overlay to own the press', async () => {
+    const { getByTestId, queryByTestId } = render(
+      <CelebrationProvider>
+        <TriggerScreen />
+      </CelebrationProvider>
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.press(getByTestId('trigger.task'));
+    expect(getByTestId('celebration-overlay')).toBeTruthy();
+
+    fireEvent(getByTestId('celebration-root'), 'startShouldSetResponderCapture', { nativeEvent: {} });
     expect(queryByTestId('celebration-overlay')).toBeNull();
   });
 
@@ -115,7 +139,7 @@ describe('CelebrationProvider overlay', () => {
     expect(queryAllByTestId('celebration-rocket')).toHaveLength(0);
     expect(queryAllByTestId('celebration-fountain')).toHaveLength(0);
 
-    fireEvent.press(getByTestId('celebration-dismiss'));
+    fireEvent(getByTestId('celebration-root'), 'startShouldSetResponderCapture', { nativeEvent: {} });
     expect(queryByTestId('celebration-overlay')).toBeNull();
   });
 
@@ -151,7 +175,7 @@ describe('CelebrationProvider overlay', () => {
     });
 
     fireEvent.press(getByTestId('trigger.day'));
-    fireEvent.press(getByTestId('celebration-dismiss'));
+    fireEvent(getByTestId('celebration-root'), 'startShouldSetResponderCapture', { nativeEvent: {} });
 
     act(() => {
       jest.advanceTimersByTime(300);

--- a/__tests__/useFootballData.performance.test.ts
+++ b/__tests__/useFootballData.performance.test.ts
@@ -87,9 +87,13 @@ jest.mock('@/utils/taskEvents', () => ({
 
 jest.mock('@/utils/activityEvents', () => ({
   emitActivityPatch: jest.fn(),
+  emitActivityDeleted: jest.fn(),
+  emitActivityDeleteRestored: jest.fn(),
   emitActivitiesRefreshRequested: jest.fn(),
   subscribeToActivityPatch: jest.fn(() => () => {}),
+  subscribeToActivityDeleted: jest.fn(() => () => {}),
   subscribeToActivitiesRefreshRequested: jest.fn(() => () => {}),
+  isActivityOptimisticallyDeleted: jest.fn(() => false),
   getActivitiesRefreshRequestedVersion: jest.fn(() => 0),
   getLastActivitiesRefreshRequestedEvent: jest.fn(() => null),
 }));

--- a/app/activity-details.tsx
+++ b/app/activity-details.tsx
@@ -56,6 +56,10 @@ import {
   shouldHydrateTaskForModal,
 } from '@/utils/taskModalContent';
 import { deserializeActivitySnapshotFromRoute } from '@/utils/activityRouteSnapshot';
+import {
+  emitActivityDeleted,
+  emitActivityDeleteRestored,
+} from '@/utils/activityEvents';
 
 const FALLBACK_COLORS = {
   primary: '#3B82F6',
@@ -1793,7 +1797,6 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
   const [assignActivityModalVisible, setAssignActivityModalVisible] = useState(false);
   const [isTemplateTaskSaving, setIsTemplateTaskSaving] = useState(false);
   const [templateTaskSearch, setTemplateTaskSearch] = useState('');
-  const [isDeleting, setIsDeleting] = useState(false);
   const [isDuplicating, setIsDuplicating] = useState(false);
   const [tasksState, setTasksState] = useState<FeedbackTask[]>((activity.tasks as FeedbackTask[]) || []);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
@@ -4427,68 +4430,77 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
             break;
           }
           case 'delete-external': {
-            if (!cancelled) setIsDeleting(true);
-            try {
-              const result = await deleteSingleExternalActivity(currentActivity.id);
-              if (!result.success) {
-                throw new Error(result.error || 'Kunne ikke slette aktiviteten');
-              }
-              if (!cancelled) {
+            const optimisticEvent = {
+              activityIds: [
+                currentActivity.id,
+                currentActivity.externalEventId,
+                currentActivity.externalEventRowId,
+              ].filter((id): id is string => typeof id === 'string' && id.trim().length > 0),
+              reason: 'activity_external_deleted',
+            };
+
+            emitActivityDeleted(optimisticEvent);
+
+            if (!cancelled) {
+              safeDismiss();
+              setTimeout(() => {
+                Alert.alert('Slettet', 'Den eksterne aktivitet er fjernet fra din app. Sletningen fortsætter i baggrunden.');
+              }, 120);
+            }
+
+            void (async () => {
+              try {
+                const result = await deleteSingleExternalActivity(currentActivity.id);
+                if (!result.success) {
+                  throw new Error(result.error || 'Kunne ikke slette aktiviteten');
+                }
                 Promise.resolve(refreshData()).catch(() => {});
-                safeDismiss();
+              } catch (error: any) {
+                console.error('Error deleting external activity:', error);
+                emitActivityDeleteRestored({ ...optimisticEvent, reason: 'activity_external_delete_failed' });
+                Promise.resolve(refreshData()).catch(() => {});
                 setTimeout(() => {
-                  Alert.alert('Slettet', 'Den eksterne aktivitet er blevet slettet fra din app');
+                  Alert.alert('Fejl', `Kunne ikke slette aktiviteten: ${error?.message || 'Ukendt fejl'}`);
                 }, 300);
               }
-            } catch (error: any) {
-              console.error('Error deleting external activity:', error);
-              if (!cancelled) {
-                Alert.alert('Fejl', `Kunne ikke slette aktiviteten: ${error?.message || 'Ukendt fejl'}`);
-              }
-            } finally {
-              if (!cancelled) setIsDeleting(false);
-            }
+            })();
             break;
           }
           case 'delete-single': {
-            if (!cancelled) setIsDeleting(true);
-            try {
-              await deleteActivitySingle(currentActivity.id);
-              if (!cancelled) {
-                safeDismiss();
-                setTimeout(() => {
-                  Alert.alert('Slettet', 'Aktiviteten er blevet slettet');
-                }, 300);
-              }
-            } catch (error: any) {
-              console.error('Error deleting activity:', error);
-              if (!cancelled) {
-                Alert.alert('Fejl', `Kunne ikke slette aktiviteten: ${error?.message || 'Ukendt fejl'}`);
-              }
-            } finally {
-              if (!cancelled) setIsDeleting(false);
+            const deletionPromise = Promise.resolve(deleteActivitySingle(currentActivity.id));
+
+            if (!cancelled) {
+              safeDismiss();
+              setTimeout(() => {
+                Alert.alert('Slettet', 'Aktiviteten er fjernet. Sletningen fortsætter i baggrunden.');
+              }, 120);
             }
+
+            void deletionPromise.catch((error: any) => {
+              console.error('Error deleting activity:', error);
+              setTimeout(() => {
+                Alert.alert('Fejl', `Kunne ikke slette aktiviteten: ${error?.message || 'Ukendt fejl'}`);
+              }, 300);
+            });
             break;
           }
           case 'delete-series': {
             if (!currentActivity.seriesId) break;
-            if (!cancelled) setIsDeleting(true);
-            try {
-              await deleteActivitySeries(currentActivity.seriesId);
-              if (!cancelled) {
-                safeDismiss();
-                setTimeout(() => {
-                  Alert.alert('Slettet', 'Hele serien er blevet slettet');
-                }, 300);
-              }
-            } catch (error: any) {
-              console.error('Error deleting series:', error);
-              if (!cancelled) {
-                Alert.alert('Fejl', `Kunne ikke slette serien: ${error?.message || 'Ukendt fejl'}`);
-              }
-            } finally {
-              if (!cancelled) setIsDeleting(false);
+            const deletionPromise = Promise.resolve(deleteActivitySeries(currentActivity.seriesId));
+
+            if (!cancelled) {
+              safeDismiss();
+              setTimeout(() => {
+                Alert.alert('Slettet', 'Hele serien er fjernet. Sletningen fortsætter i baggrunden.');
+              }, 120);
             }
+
+            void deletionPromise.catch((error: any) => {
+              console.error('Error deleting series:', error);
+              setTimeout(() => {
+                Alert.alert('Fejl', `Kunne ikke slette serien: ${error?.message || 'Ukendt fejl'}`);
+              }, 300);
+            });
             break;
           }
           default:
@@ -4510,7 +4522,6 @@ export function ActivityDetailsContent(props: ActivityDetailsContentProps) {
     duplicateActivity,
     pendingAction,
     refreshData,
-    router,
     safeDismiss,
     tasksState,
   ]);

--- a/contexts/CelebrationContext.tsx
+++ b/contexts/CelebrationContext.tsx
@@ -3,7 +3,6 @@ import {
   AccessibilityInfo,
   Animated,
   Easing,
-  Modal,
   NativeModules,
   Platform,
   Pressable,
@@ -11,6 +10,7 @@ import {
   Text,
   Vibration,
   View,
+  type GestureResponderEvent,
 } from 'react-native';
 import { NativeModulesProxy } from 'expo-modules-core';
 import * as Haptics from 'expo-haptics';
@@ -107,8 +107,9 @@ type FountainSpark = {
   size: number;
 };
 
-const TASK_DURATION_MS = 4000;
-const DAY_COMPLETE_DURATION_MS = 5100;
+const CELEBRATION_DURATION_MULTIPLIER = 0.7;
+const TASK_DURATION_MS = Math.round(4000 * CELEBRATION_DURATION_MULTIPLIER);
+const DAY_COMPLETE_DURATION_MS = Math.round(5100 * CELEBRATION_DURATION_MULTIPLIER);
 const COOLDOWN_MS = 1200;
 const CONFETTI_COLORS = ['#33b1ff', '#4cd97b', '#f6c445', '#ff7f50', '#9b6dff', '#20b2aa'];
 const CELEBRATION_INTENSITY_MULTIPLIER = 4;
@@ -463,7 +464,7 @@ function CelebrationOverlay({
   const renderLegacyFireworks = !shouldAttemptNativeDayComplete && !renderNativeConfetti;
 
   return (
-    <View style={styles.overlayWrap} pointerEvents="box-none" testID="celebration-overlay">
+    <View style={styles.overlayWrap} pointerEvents="none" testID="celebration-overlay">
       <Text style={styles.srOnly} testID="celebration-overlay.type">
         {celebration.type}
       </Text>
@@ -806,6 +807,15 @@ export function CelebrationProvider({ children }: { children: React.ReactNode })
     setActiveCelebration(null);
   }, [clearDismissTimer, clearHapticsTimers]);
 
+  const handleRootTouchCapture = useCallback((_event: GestureResponderEvent) => {
+    if (!activeCelebrationRef.current) {
+      return false;
+    }
+
+    dismissCelebration();
+    return false;
+  }, [dismissCelebration]);
+
   useEffect(() => {
     let mounted = true;
 
@@ -1010,36 +1020,20 @@ export function CelebrationProvider({ children }: { children: React.ReactNode })
 
   return (
     <CelebrationContext.Provider value={value}>
-      <View style={styles.root}>
+      <View
+        style={styles.root}
+        onStartShouldSetResponderCapture={handleRootTouchCapture}
+        testID="celebration-root"
+      >
         {children}
-        {activeCelebration
-          ? Platform.OS === 'web'
-            ? (
-                <CelebrationOverlay
-                  celebration={activeCelebration}
-                  reduceMotionEnabled={reduceMotionEnabled}
-                  onStart={startCelebration}
-                  onDismiss={dismissCelebration}
-                />
-              )
-            : (
-                <Modal
-                  visible
-                  transparent
-                  animationType="none"
-                  statusBarTranslucent
-                  presentationStyle="overFullScreen"
-                  onRequestClose={dismissCelebration}
-                >
-                  <CelebrationOverlay
-                    celebration={activeCelebration}
-                    reduceMotionEnabled={reduceMotionEnabled}
-                    onStart={startCelebration}
-                    onDismiss={dismissCelebration}
-                  />
-                </Modal>
-              )
-          : null}
+        {activeCelebration ? (
+          <CelebrationOverlay
+            celebration={activeCelebration}
+            reduceMotionEnabled={reduceMotionEnabled}
+            onStart={startCelebration}
+            onDismiss={dismissCelebration}
+          />
+        ) : null}
       </View>
     </CelebrationContext.Provider>
   );

--- a/hooks/useFootballData.ts
+++ b/hooks/useFootballData.ts
@@ -22,7 +22,14 @@ import { useAdmin } from '@/contexts/AdminContext';
 import { useAuthSession } from '@/contexts/AuthSessionContext';
 import { useCelebration } from '@/contexts/CelebrationContext';
 import { subscribeToTaskCompletion, emitTaskCompletionEvent } from '@/utils/taskEvents';
-import { emitActivityPatch, emitActivitiesRefreshRequested } from '@/utils/activityEvents';
+import {
+  emitActivityPatch,
+  emitActivityDeleted,
+  emitActivityDeleteRestored,
+  emitActivitiesRefreshRequested,
+  isActivityOptimisticallyDeleted,
+  subscribeToActivityDeleted,
+} from '@/utils/activityEvents';
 import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
 import { isTaskVisibleForActivity } from '@/utils/taskTemplateVisibility';
 import { resolveCelebrationAfterCompletionFromDatabase } from '@/utils/celebrationRuntime';
@@ -640,8 +647,28 @@ export const useFootballData = ({
       .order('activity_time', { ascending: true });
 
     if (error) throw error;
-    setActivities((data || []) as unknown as Activity[]);
+    const visibleActivities = ((data || []) as unknown as Activity[]).filter(
+      activity => !isActivityOptimisticallyDeleted(activity),
+    );
+    setActivities(visibleActivities);
   }, []);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToActivityDeleted(event => {
+      if (event.action === 'deleted') {
+        setActivities(prevActivities =>
+          prevActivities.filter(activity => !isActivityOptimisticallyDeleted(activity))
+        );
+        return;
+      }
+
+      Promise.resolve(fetchActivities()).catch(() => {});
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [fetchActivities]);
 
   /**
    * IMPORTANT:
@@ -1656,29 +1683,35 @@ export const useFootballData = ({
   }, [adminMode, adminTargetId, adminTargetType, fetchActivities, fetchActivitySeries]);
 
   const deleteActivitySingle = useCallback(async (activityId: string) => {
-    const userId = await getCurrentUserId();
+    const optimisticEvent = { activityIds: [activityId], reason: 'activity_single_deleted' };
+    emitActivityDeleted(optimisticEvent);
 
     try {
+      const userId = await getCurrentUserId();
       await activityService.deleteActivitySingle(activityId, userId);
       await Promise.all([fetchActivities(), fetchCurrentWeekStats()]);
       await forceRefreshNotificationQueue();
       emitActivitiesRefreshRequested({ reason: 'activity_single_deleted' });
     } catch (error) {
       console.error('[deleteActivitySingle] failed:', error);
+      emitActivityDeleteRestored({ ...optimisticEvent, reason: 'activity_single_delete_failed' });
       throw error;
     }
   }, [getCurrentUserId, fetchActivities, fetchCurrentWeekStats]);
 
   const deleteActivitySeries = useCallback(async (seriesId: string) => {
-    const userId = await getCurrentUserId();
+    const optimisticEvent = { seriesId, reason: 'activity_series_deleted' };
+    emitActivityDeleted(optimisticEvent);
 
     try {
+      const userId = await getCurrentUserId();
       await activityService.deleteActivitySeries(seriesId, userId);
       await Promise.all([fetchActivities(), fetchActivitySeries(), fetchCurrentWeekStats()]);
       await forceRefreshNotificationQueue();
       emitActivitiesRefreshRequested({ reason: 'activity_series_deleted' });
     } catch (error) {
       console.error('[deleteActivitySeries] failed:', error);
+      emitActivityDeleteRestored({ ...optimisticEvent, reason: 'activity_series_delete_failed' });
       throw error;
     }
   }, [getCurrentUserId, fetchActivities, fetchActivitySeries, fetchCurrentWeekStats]);
@@ -2136,6 +2169,7 @@ export const useFootballData = ({
   ]);
 
   const deleteActivity = useCallback((id: string) => {
+    emitActivityDeleted({ activityIds: [id], reason: 'activity_deleted_locally' });
     setActivities(prev => prev.filter(activity => activity.id !== id));
   }, []);
 

--- a/hooks/useHomeActivities.ts
+++ b/hooks/useHomeActivities.ts
@@ -12,9 +12,11 @@ import { parseTemplateIdFromMarker } from '@/utils/afterTrainingMarkers';
 import { filterVisibleTasksForActivity } from '@/utils/taskTemplateVisibility';
 import {
   subscribeToActivityPatch,
+  subscribeToActivityDeleted,
   subscribeToActivitiesRefreshRequested,
   getActivitiesRefreshRequestedVersion,
   getLastActivitiesRefreshRequestedEvent,
+  isActivityOptimisticallyDeleted,
 } from '@/utils/activityEvents';
 import { setHomeLoadProgress } from '@/utils/startupLoader';
 import { useAdmin, type AdminMode } from '@/contexts/AdminContext';
@@ -62,6 +64,9 @@ interface ActivityWithCategory {
   is_external: boolean;
   external_calendar_id?: string | null;
   external_event_id?: string | null;
+  series_id?: string | null;
+  seriesId?: string | null;
+  series_instance_date?: string | null;
   created_at: string;
   updated_at: string;
   tasks?: ActivityTask[];
@@ -793,6 +798,8 @@ export function useHomeActivities(): UseHomeActivitiesResult {
             activity_date,
             activity_time,
             activity_end_time,
+            series_id,
+            series_instance_date,
             location,
             category_id,
             intensity,
@@ -823,6 +830,8 @@ export function useHomeActivities(): UseHomeActivitiesResult {
             activity_date,
             activity_time,
             activity_end_time,
+            series_id,
+            series_instance_date,
             location,
             category_id,
             intensity,
@@ -1233,7 +1242,9 @@ export function useHomeActivities(): UseHomeActivitiesResult {
       devLog('[useHomeActivities] External activities:', externalActivities.length);
 
       // 4. Merge internal and external activities
-      const preHydratedActivities = [...internalActivities, ...externalActivities];
+      const preHydratedActivities = [...internalActivities, ...externalActivities].filter(
+        activity => !isActivityOptimisticallyDeleted(activity),
+      );
       devLog('[useHomeActivities] Total merged activities:', preHydratedActivities.length);
       devLog('[useHomeActivities] Activities with resolved category:', preHydratedActivities.filter(a => a.category).length);
       devLog('[useHomeActivities] Activities WITHOUT resolved category:', preHydratedActivities.filter(a => !a.category).length);
@@ -1626,7 +1637,7 @@ export function useHomeActivities(): UseHomeActivitiesResult {
           tasks,
           minReminderMinutes: computeMinReminder(tasks),
         };
-      });
+      }).filter(activity => !isActivityOptimisticallyDeleted(activity));
 
       if (__DEV__) {
         const sampleInternal = finalActivities.find(a => !a.is_external && Array.isArray(a.tasks) && a.tasks.length);
@@ -1802,10 +1813,13 @@ export function useHomeActivities(): UseHomeActivitiesResult {
       if (!hasLoadedOnceRef.current) {
         const cachedSnapshot = await loadCachedSnapshot();
         if (mounted && cachedSnapshot?.activities?.length) {
+          const cachedActivities = cachedSnapshot.activities.filter(
+            activity => !isActivityOptimisticallyDeleted(activity),
+          );
           hydratedFromCache = true;
           hasLoadedOnceRef.current = true;
           lastSuccessfulLoadAtRef.current = new Date(cachedSnapshot.savedAt).getTime() || Date.now();
-          setActivities(cachedSnapshot.activities);
+          setActivities(cachedActivities);
           setInitialLoadSucceeded(true);
           setHasLoadedFullWindow(cachedSnapshot.scope === 'full');
           setLoading(false);
@@ -1873,11 +1887,21 @@ export function useHomeActivities(): UseHomeActivitiesResult {
       patchActivityFields(activityId, updates);
     });
 
+    const unsubscribeDelete = subscribeToActivityDeleted(event => {
+      if (event.action === 'deleted') {
+        setActivities(prev => prev.filter(activity => !isActivityOptimisticallyDeleted(activity)));
+        return;
+      }
+
+      void triggerRefetch(event.reason || 'activity_delete_restored');
+    });
+
     return () => {
       unsubscribeTask();
       unsubscribePatch();
+      unsubscribeDelete();
     };
-  }, [patchActivityFields, patchActivityTasks]);
+  }, [patchActivityFields, patchActivityTasks, triggerRefetch]);
 
   useEffect(() => {
     const unsubscribe = subscribeToActivitiesRefreshRequested(event => {

--- a/utils/activityEvents.ts
+++ b/utils/activityEvents.ts
@@ -5,6 +5,16 @@ export interface ActivityPatchEvent {
 
 type ActivityPatchListener = (event: ActivityPatchEvent) => void;
 
+export interface ActivityDeleteEvent {
+  activityIds?: string[];
+  activityId?: string;
+  seriesId?: string | null;
+  reason?: string;
+  action?: 'deleted' | 'restored';
+}
+
+type ActivityDeleteListener = (event: Required<Pick<ActivityDeleteEvent, 'action'>> & ActivityDeleteEvent) => void;
+
 export interface ActivitiesRefreshRequestedEvent {
   reason?: string;
 }
@@ -13,6 +23,31 @@ type ActivitiesRefreshListener = (event: ActivitiesRefreshRequestedEvent) => voi
 
 let activitiesRefreshVersion = 0;
 let lastActivitiesRefreshRequestedEvent: ActivitiesRefreshRequestedEvent = {};
+const optimisticallyDeletedActivityIds = new Set<string>();
+const optimisticallyDeletedSeriesIds = new Set<string>();
+
+function normalizeId(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  const normalized = String(value).trim();
+  return normalized.length ? normalized : null;
+}
+
+function normalizeDeleteEvent(event: ActivityDeleteEvent): ActivityDeleteEvent {
+  const ids = new Set<string>();
+  const directId = normalizeId(event.activityId);
+  if (directId) ids.add(directId);
+  (event.activityIds ?? []).forEach(id => {
+    const normalized = normalizeId(id);
+    if (normalized) ids.add(normalized);
+  });
+
+  return {
+    ...event,
+    activityId: directId ?? undefined,
+    activityIds: Array.from(ids),
+    seriesId: normalizeId(event.seriesId),
+  };
+}
 
 class ActivityEventBus {
   private listeners = new Set<ActivityPatchListener>();
@@ -36,6 +71,26 @@ class ActivityEventBus {
 }
 
 const activityEventBus = new ActivityEventBus();
+const activityDeleteEventBus = new (class {
+  private listeners = new Set<ActivityDeleteListener>();
+
+  emit(event: Required<Pick<ActivityDeleteEvent, 'action'>> & ActivityDeleteEvent) {
+    this.listeners.forEach(listener => {
+      try {
+        listener(event);
+      } catch (error) {
+        console.error('[activityEvents] delete listener failed:', error);
+      }
+    });
+  }
+
+  subscribe(listener: ActivityDeleteListener) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+})();
 const activitiesRefreshEventBus = new (class {
   private listeners = new Set<ActivitiesRefreshListener>();
 
@@ -63,6 +118,42 @@ export function emitActivityPatch(event: ActivityPatchEvent) {
 
 export function subscribeToActivityPatch(listener: ActivityPatchListener) {
   return activityEventBus.subscribe(listener);
+}
+
+export function emitActivityDeleted(event: ActivityDeleteEvent) {
+  const payload = normalizeDeleteEvent(event);
+  (payload.activityIds ?? []).forEach(id => optimisticallyDeletedActivityIds.add(id));
+  if (payload.seriesId) {
+    optimisticallyDeletedSeriesIds.add(payload.seriesId);
+  }
+  activityDeleteEventBus.emit({ ...payload, action: 'deleted' });
+}
+
+export function emitActivityDeleteRestored(event: ActivityDeleteEvent) {
+  const payload = normalizeDeleteEvent(event);
+  (payload.activityIds ?? []).forEach(id => optimisticallyDeletedActivityIds.delete(id));
+  if (payload.seriesId) {
+    optimisticallyDeletedSeriesIds.delete(payload.seriesId);
+  }
+  activityDeleteEventBus.emit({ ...payload, action: 'restored' });
+}
+
+export function subscribeToActivityDeleted(listener: ActivityDeleteListener) {
+  return activityDeleteEventBus.subscribe(listener);
+}
+
+export function isActivityOptimisticallyDeleted(activity: {
+  id?: unknown;
+  series_id?: unknown;
+  seriesId?: unknown;
+} | null | undefined) {
+  const activityId = normalizeId(activity?.id);
+  if (activityId && optimisticallyDeletedActivityIds.has(activityId)) {
+    return true;
+  }
+
+  const seriesId = normalizeId(activity?.series_id ?? activity?.seriesId);
+  return !!seriesId && optimisticallyDeletedSeriesIds.has(seriesId);
 }
 
 export function emitActivitiesRefreshRequested(event: ActivitiesRefreshRequestedEvent = {}) {

--- a/utils/activityRouteSnapshot.ts
+++ b/utils/activityRouteSnapshot.ts
@@ -27,6 +27,8 @@ type RouteSnapshotActivity = {
   externalCalendarId?: string | null;
   externalEventId?: string | null;
   externalEventRowId?: string | null;
+  seriesId?: string | null;
+  seriesInstanceDate?: string | null;
 };
 
 function normalizeString(value: unknown): string {
@@ -164,6 +166,14 @@ export function serializeActivitySnapshotForRoute(activity: any, resolvedDate: D
     externalEventRowId:
       normalizeNullableString(activity?.externalEventRowId) ??
       normalizeNullableString(activity?.external_event_row_id),
+    seriesId:
+      normalizeNullableString(activity?.seriesId) ??
+      normalizeNullableString(activity?.series_id),
+    seriesInstanceDate:
+      activity?.seriesInstanceDate instanceof Date
+        ? activity.seriesInstanceDate.toISOString()
+        : normalizeNullableString(activity?.seriesInstanceDate) ??
+          normalizeNullableString(activity?.series_instance_date),
   };
 
   try {
@@ -219,6 +229,10 @@ export function deserializeActivitySnapshotFromRoute(value: unknown): Activity |
       externalCalendarId: normalizeNullableString(parsed?.externalCalendarId) ?? undefined,
       externalEventId: normalizeNullableString(parsed?.externalEventId) ?? undefined,
       externalEventRowId: normalizeNullableString(parsed?.externalEventRowId) ?? undefined,
+      seriesId: normalizeNullableString(parsed?.seriesId) ?? undefined,
+      seriesInstanceDate: parsed?.seriesInstanceDate
+        ? new Date(parsed.seriesInstanceDate)
+        : undefined,
     };
   } catch {
     return null;


### PR DESCRIPTION
## Summary

- Makes activity deletion feel instant by removing deleted activities from the UI immediately.
- Runs the actual delete operation in the background and restores/refetches if deletion fails.
- Supports delete behavior even when activity details are opened from a partially loaded route snapshot.
- Shortens task/day-complete celebrations by 30%.
- Lets users keep navigating while celebration is visible; the next app tap dismisses it immediately.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand`
