### PR TITLE
feat: opdater opgaveside og opgavesync

### DIFF
--- a/__tests__/taskService.library-idempotent.test.ts
+++ b/__tests__/taskService.library-idempotent.test.ts
@@ -95,6 +95,10 @@ jest.mock('@/integrations/supabase/client', () => {
         }
         return builder;
       },
+      delete: () => {
+        state.action = 'delete';
+        return builder;
+      },
       select: () => builder,
       eq: (column: string, value: unknown) => {
         state.filters.push({ column, value, op: 'eq' });
@@ -106,7 +110,19 @@ jest.mock('@/integrations/supabase/client', () => {
       },
       order: () => builder,
       limit: () => builder,
-      abortSignal: () => builder,
+      abortSignal: () => {
+        if (state.action === 'delete' && state.table === 'task_template_subtasks') {
+          db.taskTemplateSubtasks = db.taskTemplateSubtasks.filter((row) => {
+            return !state.filters.every((filter: any) => {
+              if (filter.op === 'eq') {
+                return (row as any)[filter.column] === filter.value;
+              }
+              return true;
+            });
+          });
+        }
+        return builder;
+      },
       maybeSingle: async () => {
         if (state.table === 'task_templates') {
           const match = db.taskTemplates.find((row) => {
@@ -207,12 +223,12 @@ describe('taskService.createTask library idempotency', () => {
     expect(db.taskTemplates[0].task_duration_minutes).toBe(600);
   });
 
-  it('ignores subtasks when creating via P8 payload', async () => {
+  it('saves subtasks in order when creating via P8 payload', async () => {
     const payload = {
       task: {
         id: '',
-        title: 'Template without subtasks',
-        description: 'Should not persist subtasks',
+        title: 'Template with subtasks',
+        description: 'Should persist subtasks',
         completed: false,
         isTemplate: true,
         categoryIds: [],
@@ -227,9 +243,13 @@ describe('taskService.createTask library idempotency', () => {
       adminTargetId: null,
     };
 
-    await taskService.createTask(payload as any);
+    const created = await taskService.createTask(payload as any);
 
     expect(db.taskTemplates).toHaveLength(1);
-    expect(db.taskTemplateSubtasks).toHaveLength(0);
+    expect(db.taskTemplateSubtasks).toEqual([
+      { task_template_id: 'template-1', title: 'Delopgave A', sort_order: 0 },
+      { task_template_id: 'template-1', title: 'Delopgave B', sort_order: 1 },
+    ]);
+    expect(created.subtasks.map((subtask) => subtask.title)).toEqual(['Delopgave A', 'Delopgave B']);
   });
 });

--- a/__tests__/taskService.updateTask.category-sync.test.ts
+++ b/__tests__/taskService.updateTask.category-sync.test.ts
@@ -15,6 +15,8 @@ type ActivityTaskRow = {
 type ActivityRow = {
   id: string;
   category_id: string | null;
+  activity_date: string;
+  activity_time: string;
 };
 
 type ExternalEventTaskRow = {
@@ -27,6 +29,11 @@ type ExternalEventTaskRow = {
 type ExternalMetaRow = {
   id: string;
   category_id: string | null;
+  local_start_override?: string | null;
+  events_external?: {
+    start_date: string;
+    start_time: string;
+  } | null;
 };
 
 const db = {
@@ -69,7 +76,7 @@ jest.mock('@/integrations/supabase/client', () => {
 
     const execute = async () => {
       if (table === 'task_templates' && state.action === 'update') {
-        return { error: null };
+        return { data: [{ id: 'template-1' }], error: null };
       }
 
       if (table === 'task_template_categories' && state.action === 'delete') {
@@ -132,7 +139,9 @@ jest.mock('@/integrations/supabase/client', () => {
 
     const builder: any = {
       select: () => {
-        state.action = 'select';
+        if (!state.action) {
+          state.action = 'select';
+        }
         return builder;
       },
       update: (payload: any) => {
@@ -200,10 +209,23 @@ describe('taskService.updateTask category sync cleanup', () => {
         task_template_id: null,
         feedback_template_id: 'template-1',
       },
+      {
+        id: 'activity-task-past-remove',
+        activity_id: 'activity-past-remove',
+        task_template_id: 'template-1',
+        feedback_template_id: null,
+      },
+      {
+        id: 'activity-feedback-past-remove',
+        activity_id: 'activity-past-remove',
+        task_template_id: null,
+        feedback_template_id: 'template-1',
+      },
     ];
     db.activities = [
-      { id: 'activity-keep', category_id: 'cat-keep' },
-      { id: 'activity-remove', category_id: 'cat-remove' },
+      { id: 'activity-keep', category_id: 'cat-keep', activity_date: '2999-01-01', activity_time: '10:00:00' },
+      { id: 'activity-remove', category_id: 'cat-remove', activity_date: '2999-01-01', activity_time: '10:00:00' },
+      { id: 'activity-past-remove', category_id: 'cat-remove', activity_date: '2000-01-01', activity_time: '10:00:00' },
     ];
     db.externalEventTasks = [
       {
@@ -224,15 +246,40 @@ describe('taskService.updateTask category sync cleanup', () => {
         task_template_id: null,
         feedback_template_id: 'template-1',
       },
+      {
+        id: 'external-task-past-remove',
+        local_meta_id: 'meta-past-remove',
+        task_template_id: 'template-1',
+        feedback_template_id: null,
+      },
+      {
+        id: 'external-feedback-past-remove',
+        local_meta_id: 'meta-past-remove',
+        task_template_id: null,
+        feedback_template_id: 'template-1',
+      },
     ];
     db.externalMeta = [
-      { id: 'meta-keep', category_id: 'cat-keep' },
-      { id: 'meta-remove', category_id: 'cat-remove' },
+      {
+        id: 'meta-keep',
+        category_id: 'cat-keep',
+        events_external: { start_date: '2999-01-01', start_time: '10:00:00' },
+      },
+      {
+        id: 'meta-remove',
+        category_id: 'cat-remove',
+        events_external: { start_date: '2999-01-01', start_time: '10:00:00' },
+      },
+      {
+        id: 'meta-past-remove',
+        category_id: 'cat-remove',
+        events_external: { start_date: '2000-01-01', start_time: '10:00:00' },
+      },
     ];
     db.rpcCalls = [];
   });
 
-  it('removes stale activity and external tasks when a template category is removed', async () => {
+  it('removes stale future activity and external tasks when a template category is removed', async () => {
     await taskService.updateTask('template-1', 'user-1', {
       categoryIds: ['cat-keep'],
     });
@@ -248,6 +295,18 @@ describe('taskService.updateTask category sync cleanup', () => {
         task_template_id: 'template-1',
         feedback_template_id: null,
       },
+      {
+        id: 'activity-task-past-remove',
+        activity_id: 'activity-past-remove',
+        task_template_id: 'template-1',
+        feedback_template_id: null,
+      },
+      {
+        id: 'activity-feedback-past-remove',
+        activity_id: 'activity-past-remove',
+        task_template_id: null,
+        feedback_template_id: 'template-1',
+      },
     ]);
 
     expect(db.externalEventTasks).toEqual([
@@ -257,7 +316,31 @@ describe('taskService.updateTask category sync cleanup', () => {
         task_template_id: 'template-1',
         feedback_template_id: null,
       },
+      {
+        id: 'external-task-past-remove',
+        local_meta_id: 'meta-past-remove',
+        task_template_id: 'template-1',
+        feedback_template_id: null,
+      },
+      {
+        id: 'external-feedback-past-remove',
+        local_meta_id: 'meta-past-remove',
+        task_template_id: null,
+        feedback_template_id: 'template-1',
+      },
     ]);
+
+    expect(db.rpcCalls).toContainEqual({
+      fn: 'update_all_tasks_from_template',
+      args: {
+        p_template_id: 'template-1',
+        p_dry_run: false,
+      },
+    });
+  });
+
+  it('syncs future activities when a task template is archived', async () => {
+    await taskService.setTaskTemplateArchived('template-1', 'user-1', true);
 
     expect(db.rpcCalls).toContainEqual({
       fn: 'update_all_tasks_from_template',

--- a/__tests__/tasks.screen.delete-confirmation.test.tsx
+++ b/__tests__/tasks.screen.delete-confirmation.test.tsx
@@ -6,6 +6,7 @@ import TasksScreen from '../app/(tabs)/tasks';
 const mockUseFootball = jest.fn();
 const mockUseAdmin = jest.fn();
 const mockUseAuthSession = jest.fn();
+const mockUseUserRole = jest.fn();
 
 jest.mock('@/contexts/FootballContext', () => ({
   useFootball: () => mockUseFootball(),
@@ -17,6 +18,10 @@ jest.mock('@/contexts/AdminContext', () => ({
 
 jest.mock('@/contexts/AuthSessionContext', () => ({
   useAuthSession: () => mockUseAuthSession(),
+}));
+
+jest.mock('@/hooks/useUserRole', () => ({
+  useUserRole: () => mockUseUserRole(),
 }));
 
 jest.mock('@react-navigation/native', () => ({
@@ -80,6 +85,7 @@ describe('Tasks delete confirmation modal', () => {
       session: { user: { id: 'user-1' } },
       refreshSession: jest.fn().mockResolvedValue({ user: { id: 'user-1' } }),
     });
+    mockUseUserRole.mockReturnValue({ userRole: 'trainer', loading: false, isAdmin: true });
 
     mockUseAdmin.mockReturnValue({
       adminMode: 'self',
@@ -122,8 +128,8 @@ describe('Tasks delete confirmation modal', () => {
   it('requires case-sensitive SLET before delete confirm can be pressed', () => {
     const { getByTestId, getByText } = render(<TasksScreen />);
 
-    fireEvent.press(getByTestId('tasks.folder.toggle.personal'));
-    fireEvent.press(getByTestId('tasks.template.deleteButton.template-1'));
+    fireEvent.press(getByTestId('tasks.folder.personal'));
+    fireEvent.press(getByTestId('tasks.task.delete.template-1'));
 
     expect(
       getByText(

--- a/__tests__/tasks.screen.no-subtasks.test.tsx
+++ b/__tests__/tasks.screen.no-subtasks.test.tsx
@@ -7,6 +7,7 @@ const mockUseFootball = jest.fn();
 const mockUseAdmin = jest.fn();
 const mockCreateTask = jest.fn();
 const mockUseAuthSession = jest.fn();
+const mockUseUserRole = jest.fn();
 
 jest.mock('@/contexts/FootballContext', () => ({
   useFootball: () => mockUseFootball(),
@@ -18,6 +19,10 @@ jest.mock('@/contexts/AdminContext', () => ({
 
 jest.mock('@/contexts/AuthSessionContext', () => ({
   useAuthSession: () => mockUseAuthSession(),
+}));
+
+jest.mock('@/hooks/useUserRole', () => ({
+  useUserRole: () => mockUseUserRole(),
 }));
 
 jest.mock('@react-navigation/native', () => ({
@@ -78,7 +83,32 @@ jest.mock('@/integrations/supabase/client', () => ({
   },
 }));
 
-describe('Tasks template editor without subtasks', () => {
+const baseTask = (overrides: Record<string, any>) => ({
+  id: 'template-1',
+  title: 'Pasningsøvelse',
+  description: 'test',
+  completed: false,
+  isTemplate: true,
+  categoryIds: [],
+  subtasks: [],
+  archivedAt: null,
+  userId: 'user-1',
+  ...overrides,
+});
+
+const baseFootball = (overrides: Record<string, any> = {}) => ({
+  tasks: [],
+  categories: [],
+  duplicateTask: jest.fn(),
+  deleteTask: jest.fn().mockResolvedValue(undefined),
+  refreshAll: jest.fn().mockResolvedValue(undefined),
+  refreshData: jest.fn().mockResolvedValue(undefined),
+  updateTask: jest.fn().mockResolvedValue(undefined),
+  isLoading: false,
+  ...overrides,
+});
+
+describe('Tasks redesigned template screen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseAuthSession.mockReturnValue({
@@ -88,6 +118,7 @@ describe('Tasks template editor without subtasks', () => {
       session: { user: { id: 'user-1' } },
       refreshSession: jest.fn().mockResolvedValue({ user: { id: 'user-1' } }),
     });
+    mockUseUserRole.mockReturnValue({ userRole: 'trainer', loading: false, isAdmin: true });
     mockCreateTask.mockResolvedValue({
       id: 'template-created',
       title: 'Ny skabelon',
@@ -106,114 +137,178 @@ describe('Tasks template editor without subtasks', () => {
       contextName: null,
     });
 
-    mockUseFootball.mockReturnValue({
-      tasks: [],
-      categories: [],
-      duplicateTask: jest.fn(),
-      deleteTask: jest.fn().mockResolvedValue(undefined),
-      refreshAll: jest.fn().mockResolvedValue(undefined),
-      refreshData: jest.fn().mockResolvedValue(undefined),
-      updateTask: jest.fn().mockResolvedValue(undefined),
-      isLoading: false,
-    });
+    mockUseFootball.mockReturnValue(baseFootball());
   });
 
-  it('shows empty state when there are 0 task templates', () => {
-    const { getByText } = render(<TasksScreen />);
+  it('shows the Opgaver header and Ny opgave CTA', () => {
+    const { getByTestId, getByText } = render(<TasksScreen />);
 
-    expect(getByText('Ingen aktive opgaveskabeloner')).toBeTruthy();
+    expect(getByTestId('tasks.header.title')).toHaveTextContent('Opgaver');
+    expect(getByTestId('tasks.header.newTaskButton')).toBeTruthy();
+    expect(getByText('Ny opgave')).toBeTruthy();
   });
 
-  it('hides subtask UI and saves template without subtasks payload', async () => {
-    const { getByTestId, queryByText, queryByTestId } = render(<TasksScreen />);
-
-    fireEvent.press(getByTestId('tasks.newTemplateButton'));
-
-    expect(queryByText('Delopgaver')).toBeNull();
-    expect(queryByTestId('tasks.template.subtaskInput.0')).toBeNull();
-
-    fireEvent.changeText(getByTestId('tasks.template.titleInput'), 'Template uden delopgaver');
-    fireEvent.press(getByTestId('tasks.template.saveButton'));
-
-    await waitFor(() => {
-      expect(mockCreateTask).toHaveBeenCalledTimes(1);
-    });
-
-    const createArg = mockCreateTask.mock.calls[0][0];
-    expect(createArg).toBeDefined();
-    expect(createArg.subtasks).toBeUndefined();
-  });
-
-  it('shows category dropdown and lets user select categories', () => {
-    mockUseFootball.mockReturnValue({
+  it('groups trainer self-mode templates into personal and inspiration folders', () => {
+    mockUseFootball.mockReturnValue(baseFootball({
       tasks: [
-        {
-          id: 'template-1',
-          title: 'Pasningsøvelse',
-          description: 'test',
-          completed: false,
-          isTemplate: true,
-          categoryIds: ['cat-1'],
-          subtasks: [],
-          archivedAt: null,
-        },
+        baseTask({ id: 'personal-1', title: 'Egen opgave' }),
+        baseTask({ id: 'fc-1', title: 'FC opgave', source_folder: 'FootballCoach Inspiration' }),
+      ],
+    }));
+
+    const { getByTestId, getByText } = render(<TasksScreen />);
+
+    expect(getByTestId('tasks.folder.personal')).toBeTruthy();
+    expect(getByTestId('tasks.folder.inspiration')).toBeTruthy();
+    expect(getByText('Personlige opgaver')).toBeTruthy();
+    expect(getByText('FootballCoach Inspiration')).toBeTruthy();
+  });
+
+  it('groups player self-mode templates by trainer name', () => {
+    mockUseUserRole.mockReturnValue({ userRole: 'player', loading: false, isAdmin: false });
+    mockUseFootball.mockReturnValue(baseFootball({
+      tasks: [
+        baseTask({
+          id: 'trainer-task-1',
+          title: 'Fra coach',
+          userId: 'trainer-1',
+          trainerName: 'Coach Mads',
+          source_folder: 'Fra træner: Coach Mads',
+        }),
+      ],
+    }));
+
+    const { getByTestId, getByText } = render(<TasksScreen />);
+
+    expect(getByTestId('tasks.folder.trainer.trainer-1')).toBeTruthy();
+    expect(getByText('Fra træner: Coach Mads')).toBeTruthy();
+  });
+
+  it('shows selected admin context templates under personal tasks', () => {
+    mockUseUserRole.mockReturnValue({ userRole: 'trainer', loading: false, isAdmin: true });
+    mockUseAdmin.mockReturnValue({
+      adminMode: 'player',
+      adminTargetType: 'player',
+      adminTargetId: 'player-1',
+      selectedContext: { type: 'player', name: 'Spiller A' },
+      contextName: 'Spiller A',
+    });
+    mockUseFootball.mockReturnValue(baseFootball({
+      tasks: [baseTask({ id: 'admin-task-1', title: 'Spilleropgave', userId: 'trainer-1' })],
+    }));
+
+    const { getByTestId, queryByTestId } = render(<TasksScreen />);
+
+    expect(getByTestId('tasks.folder.personal')).toBeTruthy();
+    expect(queryByTestId('tasks.folder.trainer.trainer-1')).toBeNull();
+  });
+
+  it('filters tasks with search', () => {
+    mockUseFootball.mockReturnValue(baseFootball({
+      tasks: [
+        baseTask({ id: 'pass-1', title: 'Pasning' }),
+        baseTask({ id: 'sprint-1', title: 'Sprint' }),
+      ],
+    }));
+
+    const { getByTestId, getByText, queryByText } = render(<TasksScreen />);
+
+    fireEvent.changeText(getByTestId('tasks.searchInput'), 'pas');
+    fireEvent.press(getByTestId('tasks.folder.personal'));
+
+    expect(getByText('Pasning')).toBeTruthy();
+    expect(queryByText('Alle aktiviteter')).toBeNull();
+    expect(queryByText('Sprint')).toBeNull();
+  });
+
+  it('filters tasks by selected category', () => {
+    mockUseFootball.mockReturnValue(baseFootball({
+      tasks: [
+        baseTask({ id: 'cat-pass', title: 'Pasning', categoryIds: ['cat-1'] }),
+        baseTask({ id: 'cat-speed', title: 'Sprint', categoryIds: ['cat-2'] }),
       ],
       categories: [
         { id: 'cat-1', name: 'Teknik', color: '#00AAFF', emoji: '⚽️' },
         { id: 'cat-2', name: 'Styrke', color: '#EF4444', emoji: '💪' },
       ],
-      duplicateTask: jest.fn(),
-      deleteTask: jest.fn().mockResolvedValue(undefined),
-      refreshAll: jest.fn().mockResolvedValue(undefined),
-      refreshData: jest.fn().mockResolvedValue(undefined),
-      updateTask: jest.fn().mockResolvedValue(undefined),
-      isLoading: false,
-    });
+    }));
 
-    const { getByTestId, getByText, queryByTestId, queryByText } = render(<TasksScreen />);
+    const { getByTestId, getByText, queryByText } = render(<TasksScreen />);
 
-    fireEvent.press(getByTestId('tasks.folder.toggle.personal'));
-    fireEvent.press(getByTestId('tasks.template.card.template-1'));
+    fireEvent.press(getByTestId('tasks.categoryFilter.button'));
+    fireEvent.press(getByTestId('tasks.categoryFilter.option.cat-1'));
+    fireEvent.press(getByTestId('tasks.folder.personal'));
 
-    expect(getByText('Indsæt link til video')).toBeTruthy();
-    expect(getByText('Teknik')).toBeTruthy();
-    expect(queryByText('Teknik, Styrke')).toBeNull();
-
-    fireEvent.press(getByTestId('tasks.template.categoryDropdownToggle'));
-    fireEvent.press(getByTestId('tasks.template.categoryOption.1'));
-
-    expect(getByText('Teknik, Styrke')).toBeTruthy();
+    expect(getByText('Pasning')).toBeTruthy();
+    expect(getByTestId('tasks.taskCategoryBadge.cat-pass.cat-1')).toBeTruthy();
+    expect(queryByText('Sprint')).toBeNull();
   });
 
-  it('reopens a template with snake_case video_url populated in the editor', () => {
-    mockUseFootball.mockReturnValue({
+  it('validates required title and video URL in the modal', () => {
+    const { getByTestId, getByText } = render(<TasksScreen />);
+
+    fireEvent.press(getByTestId('tasks.header.newTaskButton'));
+    fireEvent.press(getByTestId('tasks.modal.saveButton'));
+    expect(getByText('Titel er påkrævet.')).toBeTruthy();
+
+    fireEvent.changeText(getByTestId('tasks.modal.titleInput'), 'Video opgave');
+    fireEvent.changeText(getByTestId('tasks.modal.videoUrlInput'), 'https://example.com/video');
+    fireEvent.press(getByTestId('tasks.modal.saveButton'));
+
+    expect(getByText('Video URL skal være fra YouTube, youtu.be eller Vimeo.')).toBeTruthy();
+  });
+
+  it('adds, removes and saves subtasks in order', async () => {
+    const { getAllByPlaceholderText, getAllByText, getByTestId } = render(<TasksScreen />);
+
+    fireEvent.press(getByTestId('tasks.header.newTaskButton'));
+    fireEvent.changeText(getByTestId('tasks.modal.titleInput'), 'Template med delopgaver');
+    fireEvent.changeText(getAllByPlaceholderText('Delopgave')[0], 'Første');
+    fireEvent.press(getByTestId('tasks.modal.addSubtaskButton'));
+    fireEvent.changeText(getAllByPlaceholderText('Delopgave')[1], 'Anden');
+    fireEvent.press(getByTestId('tasks.modal.addSubtaskButton'));
+    fireEvent.changeText(getAllByPlaceholderText('Delopgave')[2], 'Tredje');
+    fireEvent.press(getAllByText('minus.circle.fill')[0]);
+    fireEvent.press(getByTestId('tasks.modal.saveButton'));
+
+    await waitFor(() => expect(mockCreateTask).toHaveBeenCalledTimes(1));
+    const createArg = mockCreateTask.mock.calls[0][0];
+    expect(createArg.subtasks.map((subtask: any) => subtask.title)).toEqual(['Anden', 'Tredje']);
+  });
+
+  it('shows delay options for reminder and feedback toggles', () => {
+    const { getByTestId } = render(<TasksScreen />);
+
+    fireEvent.press(getByTestId('tasks.header.newTaskButton'));
+    fireEvent(getByTestId('tasks.modal.reminderToggle'), 'valueChange', true);
+    expect(getByTestId('tasks.modal.reminderOption.15')).toBeTruthy();
+
+    fireEvent(getByTestId('tasks.modal.feedbackToggle'), 'valueChange', true);
+    expect(getByTestId('tasks.modal.feedbackDelayOption.15')).toBeTruthy();
+  });
+
+  it('renders category chips and reopens snake_case video_url in the editor', () => {
+    mockUseFootball.mockReturnValue(baseFootball({
       tasks: [
-        {
-          id: 'template-ig-1',
-          title: 'Instagram template',
-          description: 'test',
-          completed: false,
-          isTemplate: true,
-          categoryIds: [],
-          subtasks: [],
-          video_url: 'https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=',
-          archivedAt: null,
-        },
+        baseTask({
+          id: 'template-video-1',
+          title: 'YouTube template',
+          categoryIds: ['cat-1'],
+          video_url: 'https://youtu.be/abc123',
+        }),
       ],
-      categories: [],
-      duplicateTask: jest.fn(),
-      deleteTask: jest.fn().mockResolvedValue(undefined),
-      refreshAll: jest.fn().mockResolvedValue(undefined),
-      refreshData: jest.fn().mockResolvedValue(undefined),
-      updateTask: jest.fn().mockResolvedValue(undefined),
-      isLoading: false,
-    });
+      categories: [
+        { id: 'cat-1', name: 'Teknik', color: '#00AAFF', emoji: '⚽️' },
+        { id: 'cat-2', name: 'Styrke', color: '#EF4444', emoji: '💪' },
+      ],
+    }));
 
     const { getByDisplayValue, getByTestId } = render(<TasksScreen />);
 
-    fireEvent.press(getByTestId('tasks.folder.toggle.personal'));
-    fireEvent.press(getByTestId('tasks.template.card.template-ig-1'));
-
-    expect(getByDisplayValue('https://www.instagram.com/reel/C7N2KQ2uV9x/?igsh=MWQ=')).toBeTruthy();
+    fireEvent.press(getByTestId('tasks.folder.personal'));
+    fireEvent.press(getByTestId('tasks.taskCard.template-video-1'));
+    expect(getByDisplayValue('https://youtu.be/abc123')).toBeTruthy();
+    fireEvent.press(getByTestId('tasks.modal.categoryOption.1'));
+    expect(getByTestId('tasks.modal.categoryOption.1')).toBeTruthy();
   });
 });

--- a/app/(tabs)/tasks.tsx
+++ b/app/(tabs)/tasks.tsx
@@ -22,6 +22,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import { useFootball } from '@/contexts/FootballContext';
 import { useAdmin } from '@/contexts/AdminContext';
 import { useAuthSession } from '@/contexts/AuthSessionContext';
+import { useUserRole } from '@/hooks/useUserRole';
 import { Task } from '@/types';
 import { IconSymbol } from '@/components/IconSymbol';
 import SmartVideoPlayer from '@/components/SmartVideoPlayer';
@@ -31,6 +32,7 @@ import { taskService } from '@/services/taskService';
 import { forceRefreshNotificationQueue } from '@/utils/notificationScheduler';
 import { emitActivitiesRefreshRequested } from '@/utils/activityEvents';
 import { getTaskModalVideoUrl } from '@/utils/taskModalContent';
+import { LinearGradient } from 'expo-linear-gradient';
 
 // ✅ Robust import: undgå Hermes-crash hvis named export "colors" ikke findes
 import * as CommonStyles from '@/styles/commonStyles';
@@ -73,19 +75,10 @@ function isValidVideoUrl(url?: string | null): boolean {
   const normalizedUrl = url.toLowerCase();
 
   return (
-    normalizedUrl.includes('youtube.com') ||
+    normalizedUrl.includes('youtube') ||
     normalizedUrl.includes('youtu.be') ||
-    normalizedUrl.includes('vimeo.com') ||
-    normalizedUrl.includes('instagram.com')
+    normalizedUrl.includes('vimeo')
   );
-}
-
-function getVideoSourceLabel(url?: string | null): string {
-  const normalizedUrl = String(url ?? '').toLowerCase();
-  if (normalizedUrl.includes('instagram.com')) return 'Instagram';
-  if (normalizedUrl.includes('vimeo.com')) return 'Vimeo';
-  if (normalizedUrl.includes('youtu')) return 'YouTube';
-  return 'Video';
 }
 
 function getYouTubeThumbnail(url: string): string | null {
@@ -112,6 +105,72 @@ function getYouTubeThumbnail(url: string): string | null {
   }
 }
 
+const FOOTBALLCOACH_INSPIRATION = 'FootballCoach Inspiration';
+
+const withAlpha = (color: string, alpha: number): string => {
+  const clamped = Math.max(0, Math.min(1, alpha));
+  const hex = color.trim();
+  if (/^#[0-9a-fA-F]{6}$/.test(hex)) {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    return `rgba(${r},${g},${b},${clamped})`;
+  }
+  return color;
+};
+
+const sanitizeTestIdSegment = (value: unknown): string =>
+  String(value ?? 'unknown')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '_')
+    .replace(/^_+|_+$/g, '') || 'unknown';
+
+const createLocalSubtaskId = () => `local-subtask-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const isFootballCoachSource = (sourceFolder: string) =>
+  sourceFolder.toLowerCase() === FOOTBALLCOACH_INSPIRATION.toLowerCase();
+
+const parseTrainerNameFromSource = (sourceFolder: string): string | null => {
+  const normalized = sourceFolder.trim();
+  if (!normalized.toLowerCase().startsWith('fra træner')) return null;
+  const [, rawName] = normalized.split(':');
+  const trainerName = String(rawName ?? '').trim();
+  return trainerName || null;
+};
+
+const getTaskOwnerId = (task: any): string | null => {
+  const value = task?.userId ?? task?.user_id ?? task?.ownerId ?? null;
+  const normalized = String(value ?? '').trim();
+  return normalized || null;
+};
+
+const getTaskTrainerName = (task: any): string => {
+  const fromTask = String(task?.trainerName ?? task?.trainer_name ?? '').trim();
+  if (fromTask) return fromTask;
+  const fromSource = parseTrainerNameFromSource(getTaskSourceFolder(task));
+  return fromSource || 'Ukendt træner';
+};
+
+const normalizeModalSubtasks = (subtasks: any[] | undefined | null) => {
+  const normalized = (subtasks ?? [])
+    .map((subtask) => ({
+      id: String(subtask?.id ?? '').trim() || createLocalSubtaskId(),
+      title: String(subtask?.title ?? ''),
+      completed: !!subtask?.completed,
+    }));
+  return normalized.length ? normalized : [{ id: createLocalSubtaskId(), title: '', completed: false }];
+};
+
+const normalizeSubtasksForSave = (subtasks: any[] | undefined | null) =>
+  (subtasks ?? [])
+    .map((subtask) => ({
+      id: String(subtask?.id ?? '').trim() || createLocalSubtaskId(),
+      title: String(subtask?.title ?? '').trim(),
+      completed: false,
+    }))
+    .filter((subtask) => subtask.title.length > 0);
+
 type FolderType = 'personal' | 'trainer' | 'footballcoach' | 'source';
 
 interface FolderItem {
@@ -120,6 +179,7 @@ interface FolderItem {
   type: FolderType;
   icon: string;
   androidIcon: string;
+  testID: string;
   tasks: Task[];
 }
 
@@ -141,97 +201,106 @@ function getIconsForFolderName(name: string): { icon: string; androidIcon: strin
   const n = name.toLowerCase();
 
   if (n.startsWith('footballcoach inspiration')) {
-    return { icon: 'star.circle.fill', androidIcon: 'stars' };
+    return { icon: 'star.fill', androidIcon: 'stars' };
   }
   if (n.startsWith('fra træner:')) {
-    return { icon: 'person.2.fill', androidIcon: 'groups' };
+    return { icon: 'folder.fill', androidIcon: 'folder' };
   }
   if (n.includes('personligt') || n.includes('personlige')) {
-    return { icon: 'person.crop.circle.fill', androidIcon: 'account_circle' };
+    return { icon: 'folder.fill', androidIcon: 'folder' };
   }
   return { icon: 'folder.fill', androidIcon: 'folder' };
 }
 
 // Pure function to organize tasks into folders
-function organizeFolders(allTasks: Task[]): FolderItem[] {
+function organizeFolders(
+  allTasks: Task[],
+  options: { adminMode: string; userRole: string | null; currentUserId: string | null },
+): FolderItem[] {
   const personalTasks: Task[] = [];
-  const trainerTasks: Task[] = [];
+  const trainerFolders = new Map<string, FolderItem>();
   const footballCoachTasks: Task[] = [];
-  const otherSourceFolders = new Map<string, FolderItem>();
+  const isAdminContext = options.adminMode !== 'self';
+  const isPlayerSelf = options.adminMode === 'self' && options.userRole === 'player';
 
   allTasks.forEach((task: any) => {
     const sfRaw = getTaskSourceFolder(task);
     const sf = sfRaw.toLowerCase();
+    const ownerId = getTaskOwnerId(task);
 
-    if (!sfRaw) {
-      personalTasks.push(task);
-      return;
-    }
-
-    if (sf === 'trainer' || sf === 'fra træner' || sf.startsWith('fra træner:')) {
-      trainerTasks.push(task);
-      return;
-    }
-
-    if (sf === 'footballcoach inspiration') {
+    if (isFootballCoachSource(sfRaw)) {
       footballCoachTasks.push(task);
       return;
     }
 
-    const sourceId = `source:${sfRaw}`;
-    if (!otherSourceFolders.has(sourceId)) {
-      const icons = getIconsForFolderName(sfRaw);
-      otherSourceFolders.set(sourceId, {
-        id: sourceId,
-        name: sfRaw,
-        type: 'source',
-        icon: icons.icon,
-        androidIcon: icons.androidIcon,
-        tasks: [],
-      });
+    if (isAdminContext) {
+      personalTasks.push(task);
+      return;
     }
-    otherSourceFolders.get(sourceId)!.tasks.push(task);
+
+    if (isPlayerSelf) {
+      const isTrainerTask =
+        sf === 'trainer' ||
+        sf === 'fra træner' ||
+        sf.startsWith('fra træner:') ||
+        (!!ownerId && !!options.currentUserId && ownerId !== options.currentUserId);
+
+      if (isTrainerTask) {
+        const trainerName = getTaskTrainerName(task);
+        const stableId = ownerId || trainerName;
+        const folderId = `trainer.${sanitizeTestIdSegment(stableId)}`;
+        if (!trainerFolders.has(folderId)) {
+          const icons = getIconsForFolderName(`Fra træner: ${trainerName}`);
+          trainerFolders.set(folderId, {
+            id: folderId,
+            name: `Fra træner: ${trainerName}`,
+            type: 'trainer',
+            icon: icons.icon,
+            androidIcon: icons.androidIcon,
+            testID: `tasks.folder.trainer.${sanitizeTestIdSegment(stableId)}`,
+            tasks: [],
+          });
+        }
+        trainerFolders.get(folderId)!.tasks.push(task);
+        return;
+      }
+
+      personalTasks.push(task);
+      return;
+    }
+
+    personalTasks.push(task);
   });
 
   const folders: FolderItem[] = [];
 
   if (personalTasks.length) {
-    const icons = getIconsForFolderName('Personligt');
+    const icons = getIconsForFolderName('Personlige opgaver');
     folders.push({
       id: 'personal',
-      name: 'Personligt oprettet',
+      name: 'Personlige opgaver',
       type: 'personal',
       icon: icons.icon,
       androidIcon: icons.androidIcon,
+      testID: 'tasks.folder.personal',
       tasks: personalTasks,
     });
   }
 
-  if (trainerTasks.length) {
-    const icons = getIconsForFolderName('Fra træner:');
-    folders.push({
-      id: 'trainer_assigned',
-      name: 'Opgaver fra træner',
-      type: 'trainer',
-      icon: icons.icon,
-      androidIcon: icons.androidIcon,
-      tasks: trainerTasks,
-    });
-  }
+  folders.push(...Array.from(trainerFolders.values()).sort((a, b) => a.name.localeCompare(b.name)));
 
   if (footballCoachTasks.length) {
-    const icons = getIconsForFolderName('FootballCoach Inspiration');
+    const icons = getIconsForFolderName(FOOTBALLCOACH_INSPIRATION);
     folders.push({
-      id: 'footballcoach',
-      name: 'FootballCoach Inspiration',
+      id: 'inspiration',
+      name: FOOTBALLCOACH_INSPIRATION,
       type: 'footballcoach',
       icon: icons.icon,
       androidIcon: icons.androidIcon,
+      testID: 'tasks.folder.inspiration',
       tasks: footballCoachTasks,
     });
   }
-
-  folders.push(...Array.from(otherSourceFolders.values()).sort((a, b) => a.name.localeCompare(b.name)));
 
   return folders;
 }
@@ -246,7 +315,7 @@ export const TaskCard = React.memo(
     onArchive = () => {},
     onDelete,
     onVideoPress,
-    getCategoryNames,
+    getCategoryItems,
     isArchived = false,
   }: {
     task: Task;
@@ -256,28 +325,38 @@ export const TaskCard = React.memo(
     onArchive?: () => void;
     onDelete: () => void;
     onVideoPress: (url: string) => void;
-    getCategoryNames: (categoryIds: string[]) => string;
+    getCategoryItems: (categoryIds: string[]) => any[];
     isArchived?: boolean;
   }) => {
     const videoUrl = getTaskModalVideoUrl(task);
     const ytThumb = typeof videoUrl === 'string' && videoUrl.includes('youtu') ? getYouTubeThumbnail(videoUrl) : null;
     const taskId = String((task as any)?.id ?? '');
+    const categoryItems = getCategoryItems((((task as any)?.categoryIds ?? []) as string[]).filter(Boolean));
+    const description = String((task as any)?.description ?? '').trim();
 
     return (
       <TouchableOpacity
-        style={[styles.taskCard, { backgroundColor: isDark ? '#2a2a2a' : colors.card }]}
+        style={[
+          styles.taskCard,
+          styles.taskCardShadow,
+          { backgroundColor: isDark ? '#2a2a2a' : colors.card },
+        ]}
         onPress={onPress}
-        testID={`tasks.template.card.${taskId}`}
+        testID={`tasks.taskCard.${taskId}`}
+        activeOpacity={0.9}
       >
         <View style={styles.taskHeader}>
           <View style={styles.taskHeaderLeft}>
-            <IconSymbol ios_icon_name="doc.text" android_material_icon_name="description" size={20} color={colors.secondary} />
-            <View style={styles.checkbox} />
-            <Text style={[styles.taskTitle, { color: isDark ? '#e3e3e3' : colors.text }]}>{String((task as any)?.title ?? '')}</Text>
+            <View style={styles.taskIconWrap}>
+              <IconSymbol ios_icon_name="checklist" android_material_icon_name="checklist" size={18} color={colors.primary} />
+            </View>
+            <Text style={[styles.taskTitle, { color: isDark ? '#e3e3e3' : colors.text }]} numberOfLines={2}>
+              {String((task as any)?.title ?? '')}
+            </Text>
           </View>
 
           <View style={styles.taskActions}>
-            <TouchableOpacity onPress={onDuplicate} style={styles.actionButton}>
+            <TouchableOpacity onPress={onDuplicate} style={styles.actionButton} testID={`tasks.task.duplicate.${taskId}`}>
               <IconSymbol ios_icon_name="doc.on.doc" android_material_icon_name="content_copy" size={20} color={colors.secondary} />
             </TouchableOpacity>
             <TouchableOpacity onPress={onPress} style={styles.actionButton}>
@@ -295,21 +374,24 @@ export const TaskCard = React.memo(
                 color={colors.primary}
               />
             </TouchableOpacity>
-            <TouchableOpacity onPress={onDelete} style={styles.actionButton} testID={`tasks.template.deleteButton.${taskId}`}>
+            <TouchableOpacity onPress={onDelete} style={styles.actionButton} testID={`tasks.task.delete.${taskId}`}>
               <IconSymbol ios_icon_name="trash" android_material_icon_name="delete" size={20} color={colors.error} />
             </TouchableOpacity>
           </View>
         </View>
 
-        {videoUrl && isValidVideoUrl(videoUrl) && (
+        {description ? (
+          <Text
+            style={[styles.taskDescription, styles.taskDescriptionIndented, { color: isDark ? '#b8b8b8' : colors.textSecondary }]}
+            numberOfLines={2}
+          >
+            {description}
+          </Text>
+        ) : null}
+
+        {videoUrl && isValidVideoUrl(videoUrl) && ytThumb && (
           <TouchableOpacity style={styles.videoThumbnailWrapper} onPress={() => onVideoPress(videoUrl)} activeOpacity={0.85}>
-            {ytThumb ? (
-              <Image source={{ uri: ytThumb }} style={styles.videoThumbnail} resizeMode="cover" />
-            ) : (
-              <View style={styles.videoThumbnailFallback}>
-                <Text style={styles.videoThumbnailFallbackLabel}>{getVideoSourceLabel(videoUrl)}</Text>
-              </View>
-            )}
+            <Image source={{ uri: ytThumb }} style={styles.videoThumbnail} resizeMode="cover" />
             <View style={styles.videoOverlay}>
               <IconSymbol ios_icon_name="play.circle.fill" android_material_icon_name="play_circle" size={56} color="#fff" />
             </View>
@@ -332,12 +414,40 @@ export const TaskCard = React.memo(
           </View>
         )}
 
-        <View style={styles.categoriesRow}>
-          <IconSymbol ios_icon_name="tag.fill" android_material_icon_name="label" size={14} color={isDark ? '#999' : colors.textSecondary} />
-          <Text style={[styles.categoriesText, { color: isDark ? '#999' : colors.textSecondary }]}>
-            Vises automatisk på alle {getCategoryNames((((task as any)?.categoryIds ?? []) as string[]).filter(Boolean))} aktiviteter
-          </Text>
-        </View>
+        {categoryItems.length ? (
+          <View style={styles.categoriesBlock}>
+            <View style={styles.categoriesLabelRow}>
+              <IconSymbol ios_icon_name="tag.fill" android_material_icon_name="label" size={14} color={isDark ? '#999' : colors.textSecondary} />
+              <Text style={[styles.categoriesLabelText, { color: isDark ? '#999' : colors.textSecondary }]}>Kategorier</Text>
+            </View>
+            <View style={styles.taskCategoryBadges}>
+              {categoryItems.map((category: any) => {
+                const catId = String(category.id);
+                const catColor = category.color || colors.primary;
+                return (
+                  <View
+                    key={catId}
+                    style={[
+                      styles.taskCategoryBadge,
+                      {
+                        backgroundColor: withAlpha(catColor, 0.14),
+                        borderColor: catColor,
+                      },
+                    ]}
+                    testID={`tasks.taskCategoryBadge.${sanitizeTestIdSegment(taskId)}.${sanitizeTestIdSegment(catId)}`}
+                  >
+                    {String(category.emoji ?? '').trim() ? (
+                      <Text style={styles.taskCategoryBadgeEmoji}>{String(category.emoji ?? '').trim()}</Text>
+                    ) : null}
+                    <Text style={[styles.taskCategoryBadgeText, { color: catColor }]} numberOfLines={1}>
+                      {String(category.name ?? '')}
+                    </Text>
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+        ) : null}
       </TouchableOpacity>
     );
   },
@@ -363,17 +473,27 @@ const FolderItemComponent = React.memo(
     cardBgColor: string;
   }) => {
     return (
-      <View>
+      <View style={styles.folderWrap}>
         <TouchableOpacity
           style={[styles.folderHeader, { backgroundColor: cardBgColor }]}
           onPress={onToggle}
-          testID={`tasks.folder.toggle.${folder.id}`}
+          testID={folder.testID}
+          activeOpacity={0.85}
+          accessibilityRole="button"
+          accessibilityState={{ selected: isExpanded }}
         >
           <View style={styles.folderHeaderLeft}>
-            <IconSymbol ios_icon_name={folder.icon} android_material_icon_name={folder.androidIcon} size={24} color={colors.primary} />
-            <Text style={[styles.folderName, { color: textColor }]}>{folder.name}</Text>
-            <View style={[styles.countBadge, { backgroundColor: colors.primary }]}>
-              <Text style={styles.countBadgeText}>{folder.tasks.length}</Text>
+            <View style={[styles.folderIconWrap, { backgroundColor: withAlpha(colors.primary, 0.12) }]}>
+              <IconSymbol ios_icon_name={folder.icon} android_material_icon_name={folder.androidIcon} size={18} color={colors.primary} />
+            </View>
+            <View style={styles.folderTextWrap}>
+              <Text style={[styles.folderName, { color: textColor }]} numberOfLines={1}>{folder.name}</Text>
+              <Text style={[styles.folderSubtitle, { color: textSecondaryColor }]} numberOfLines={1}>
+                {folder.tasks.length} opgaver
+              </Text>
+            </View>
+            <View style={[styles.countBadge, { backgroundColor: isExpanded ? colors.primary : withAlpha(colors.primary, 0.12) }]}>
+              <Text style={[styles.countBadgeText, { color: isExpanded ? '#fff' : colors.primary }]}>{folder.tasks.length}</Text>
             </View>
           </View>
           <IconSymbol
@@ -407,6 +527,8 @@ export default function TasksScreen() {
   const footballData = useFootball() as any;
   const adminData = useAdmin() as any;
   const { user } = useAuthSession();
+  const roleInfo = useUserRole() as any;
+  const userRole = typeof roleInfo?.userRole === 'string' ? roleInfo.userRole : null;
 
   const contextTasks = footballData?.tasks;
   const tasks = useMemo(() => (contextTasks ?? []) as Task[], [contextTasks]);
@@ -455,14 +577,16 @@ export default function TasksScreen() {
 
   // ✅ VIGTIGT: alle state hooks før callbacks/memos der bruger dem
   const [refreshing, setRefreshing] = useState(false);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
+  const [categoryFilterOpen, setCategoryFilterOpen] = useState(false);
+  const [selectedCategoryFilterId, setSelectedCategoryFilterId] = useState<string | null>(null);
 
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
+  const [formErrors, setFormErrors] = useState<{ title?: string; videoUrl?: string }>({});
 
   const [videoUrl, setVideoUrl] = useState('');
 
@@ -478,15 +602,30 @@ export default function TasksScreen() {
 
   const safeTasks = useMemo(() => (tasks || []).filter(Boolean) as Task[], [tasks]);
 
+  const uniqueCategories = useMemo(() => {
+    const map = new Map<string, any>();
+    (categories ?? []).forEach((c: any) => {
+      if (c?.id) map.set(String(c.id), c);
+    });
+    return Array.from(map.values());
+  }, [categories]);
+
+  const selectedCategoryFilter = useMemo(() => {
+    if (!selectedCategoryFilterId) return null;
+    return uniqueCategories.find((c: any) => String(c.id) === selectedCategoryFilterId) ?? null;
+  }, [selectedCategoryFilterId, uniqueCategories]);
+
   const filteredTasks = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
-    if (!q) return safeTasks;
     return safeTasks.filter((t: any) => {
       const title = String(t?.title ?? '').toLowerCase();
       const desc = String(t?.description ?? '').toLowerCase();
-      return title.includes(q) || desc.includes(q);
+      const categoryIds = (((t as any)?.categoryIds ?? []) as string[]).map(String);
+      const matchesSearch = !q || title.includes(q) || desc.includes(q);
+      const matchesCategory = !selectedCategoryFilterId || categoryIds.includes(selectedCategoryFilterId);
+      return matchesSearch && matchesCategory;
     });
-  }, [safeTasks, searchQuery]);
+  }, [safeTasks, searchQuery, selectedCategoryFilterId]);
 
   const templateTasks = useMemo(
     () =>
@@ -499,7 +638,10 @@ export default function TasksScreen() {
       }),
     [filteredTasks, templateView],
   );
-  const folders = useMemo(() => organizeFolders(templateTasks), [templateTasks]);
+  const folders = useMemo(
+    () => organizeFolders(templateTasks, { adminMode, userRole, currentUserId: user?.id ?? null }),
+    [templateTasks, adminMode, userRole, user?.id],
+  );
 
   useFocusEffect(
     useCallback(() => {
@@ -526,7 +668,7 @@ export default function TasksScreen() {
   }, [refreshData]);
 
   const toggleFolder = useCallback((folderId: string) => {
-    setExpanded((prev) => {
+    setExpandedFolders((prev) => {
       const next = new Set(prev);
       if (next.has(folderId)) next.delete(folderId);
       else next.add(folderId);
@@ -534,19 +676,30 @@ export default function TasksScreen() {
     });
   }, []);
 
-  const openTaskModal = useCallback(async (task: Task | null, creating: boolean = false) => {
+  const toggleCategoryFilterOpen = useCallback(() => {
+    setCategoryFilterOpen(prev => !prev);
+  }, []);
+
+  const selectCategoryFilter = useCallback((categoryId: string | null) => {
+    setSelectedCategoryFilterId(categoryId);
+    setCategoryFilterOpen(false);
+  }, []);
+
+  const openTaskModal = useCallback((task: Task | null, creating: boolean = false) => {
     const normalizedTask = task
       ? ({
           ...(task as any),
           reminder: normalizeReminderValue((task as any).reminder),
           taskDurationEnabled: !!(task as any).taskDurationEnabled,
           taskDurationMinutes: normalizeTaskDurationValue((task as any).taskDurationMinutes),
+          subtasks: normalizeModalSubtasks((task as any).subtasks),
         } as Task)
       : task;
 
     setSelectedTask(normalizedTask);
     setIsCreating(creating);
     setIsSaving(false);
+    setFormErrors({});
     setVideoUrl(getTaskModalVideoUrl(task) ?? '');
     setIsModalVisible(true);
   }, []);
@@ -555,15 +708,74 @@ export default function TasksScreen() {
     setSelectedTask(null);
     setIsCreating(false);
     setIsModalVisible(false);
-    setIsCategoryDropdownOpen(false);
     setVideoUrl('');
+    setFormErrors({});
     setIsSaving(false);
+  }, []);
+
+  const validateTaskForm = useCallback(() => {
+    const nextErrors: { title?: string; videoUrl?: string } = {};
+    if (!String((selectedTask as any)?.title ?? '').trim()) {
+      nextErrors.title = 'Titel er påkrævet.';
+    }
+    if (videoUrl.trim() && !isValidVideoUrl(videoUrl)) {
+      nextErrors.videoUrl = 'Video URL skal være fra YouTube, youtu.be eller Vimeo.';
+    }
+    setFormErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  }, [selectedTask, videoUrl]);
+
+  const updateTaskTitle = useCallback((text: string) => {
+    setFormErrors(prev => ({ ...prev, title: undefined }));
+    setSelectedTask(prev => (prev ? ({ ...(prev as any), title: text } as Task) : prev));
+  }, []);
+
+  const updateTaskDescription = useCallback((text: string) => {
+    setSelectedTask(prev => (prev ? ({ ...(prev as any), description: text } as Task) : prev));
+  }, []);
+
+  const updateVideoUrl = useCallback((text: string) => {
+    setFormErrors(prev => ({ ...prev, videoUrl: undefined }));
+    setVideoUrl(text);
+  }, []);
+
+  const addSubtask = useCallback(() => {
+    setSelectedTask(prev => {
+      if (!prev) return prev;
+      const subtasks = normalizeModalSubtasks((prev as any).subtasks);
+      return {
+        ...(prev as any),
+        subtasks: [...subtasks, { id: createLocalSubtaskId(), title: '', completed: false }],
+      } as Task;
+    });
+  }, []);
+
+  const updateSubtask = useCallback((subtaskId: string, title: string) => {
+    setSelectedTask(prev => {
+      if (!prev) return prev;
+      return {
+        ...(prev as any),
+        subtasks: normalizeModalSubtasks((prev as any).subtasks).map((subtask) =>
+          subtask.id === subtaskId ? { ...subtask, title } : subtask
+        ),
+      } as Task;
+    });
+  }, []);
+
+  const removeSubtask = useCallback((subtaskId: string) => {
+    setSelectedTask(prev => {
+      if (!prev) return prev;
+      const subtasks = normalizeModalSubtasks((prev as any).subtasks);
+      const next = subtasks.filter((subtask) => subtask.id !== subtaskId);
+      return { ...(prev as any), subtasks: next.length ? next : subtasks } as Task;
+    });
   }, []);
 
   const executeSaveTask = useCallback(async () => {
     if (!selectedTask) return;
 
     const normalizedReminder = normalizeReminderValue((selectedTask as any).reminder);
+    const normalizedSubtasks = normalizeSubtasksForSave((selectedTask as any).subtasks);
     const successMessage = isCreating ? 'Opgaveskabelon oprettet' : 'Opgaveskabelon opdateret';
     setIsSaving(true);
 
@@ -571,8 +783,10 @@ export default function TasksScreen() {
       const categoryIds = Array.from(new Set((((selectedTask as any)?.categoryIds ?? []) as string[]).filter(Boolean)));
       const taskToSave = {
         ...selectedTask,
+        title: String((selectedTask as any).title ?? '').trim(),
         reminder: normalizedReminder,
         videoUrl: videoUrl.trim() ? videoUrl.trim() : null,
+        subtasks: normalizedSubtasks,
         categoryIds,
         afterTrainingEnabled: selectedTask.afterTrainingEnabled ?? false,
         afterTrainingDelayMinutes: selectedTask.afterTrainingEnabled ? (selectedTask.afterTrainingDelayMinutes ?? 0) : null,
@@ -581,13 +795,13 @@ export default function TasksScreen() {
         afterTrainingFeedbackEnableNote: selectedTask.afterTrainingFeedbackEnableNote ?? true,
         taskDurationEnabled: selectedTask.taskDurationEnabled ?? false,
         taskDurationMinutes: selectedTask.taskDurationEnabled ? (selectedTask.taskDurationMinutes ?? 0) : null,
-        // Always enable intensity when persisting feedback settings
-        afterTrainingFeedbackEnableIntensity: true,
+        afterTrainingFeedbackEnableIntensity: !!selectedTask.afterTrainingEnabled,
       } as Task;
 
       if (isCreating) {
         await taskService.createTask({
           task: taskToSave,
+          subtasks: normalizedSubtasks,
           adminMode,
           adminTargetType,
           adminTargetId,
@@ -597,15 +811,16 @@ export default function TasksScreen() {
 
         const taskToSave = {
           ...selectedTask,
+          title: String((selectedTask as any).title ?? '').trim(),
           reminder: normalizedReminder,
           videoUrl: videoUrl.trim() ? videoUrl.trim() : null,
+          subtasks: normalizedSubtasks,
           categoryIds,
           afterTrainingEnabled: selectedTask.afterTrainingEnabled ?? false,
           afterTrainingDelayMinutes: selectedTask.afterTrainingEnabled ? (selectedTask.afterTrainingDelayMinutes ?? 0) : null,
           taskDurationEnabled: selectedTask.taskDurationEnabled ?? false,
           taskDurationMinutes: selectedTask.taskDurationEnabled ? (selectedTask.taskDurationMinutes ?? 0) : null,
-          // Force intensity to remain enabled on updates
-          afterTrainingFeedbackEnableIntensity: true,
+          afterTrainingFeedbackEnableIntensity: !!selectedTask.afterTrainingEnabled,
         };
 
         await updateTask(String((selectedTask as any).id), taskToSave);
@@ -628,6 +843,7 @@ export default function TasksScreen() {
 
   const handleSaveTask = useCallback(async () => {
     if (!selectedTask) return;
+    if (!validateTaskForm()) return;
 
     if (adminMode !== 'self' && selectedContext?.type) {
       setPendingAction({
@@ -639,7 +855,7 @@ export default function TasksScreen() {
     }
 
     await executeSaveTask();
-  }, [selectedTask, adminMode, selectedContext, isCreating, videoUrl, executeSaveTask]);
+  }, [selectedTask, adminMode, selectedContext, isCreating, videoUrl, executeSaveTask, validateTaskForm]);
 
   const handleArchiveTask = useCallback(
     async (task: Task) => {
@@ -748,20 +964,25 @@ export default function TasksScreen() {
     [],
   );
 
-  const getCategoryNames = useCallback(
+  const getCategoryItems = useCallback(
     (categoryIds: string[]) => {
       const uniqueIds = Array.from(new Set((categoryIds ?? []).filter(Boolean)));
       return uniqueIds
-        .map((id) => String(categories.find((c: any) => c.id === id)?.name ?? '').toLowerCase())
+        .map((id) => categories.find((c: any) => String(c.id) === String(id)))
         .filter(Boolean)
-        .join(', ');
+        .map((category: any) => ({
+          id: String(category.id),
+          name: String(category.name ?? ''),
+          color: category.color || colors.primary,
+          emoji: category.emoji ?? '',
+        }));
     },
     [categories],
   );
 
   const openVideoModal = useCallback((url: string) => {
     if (!isValidVideoUrl(url)) {
-      Alert.alert('Fejl', 'Ugyldig video URL. Kun YouTube, Vimeo og Instagram understøttes.');
+      Alert.alert('Fejl', 'Ugyldig video URL. Kun YouTube, youtu.be og Vimeo understøttes.');
       return;
     }
     setSelectedVideoUrl(url);
@@ -831,12 +1052,35 @@ export default function TasksScreen() {
     });
   }, []);
 
+  const openNewTaskModal = useCallback(() => {
+    openTaskModal(
+      {
+        id: '',
+        title: '',
+        description: '',
+        completed: false,
+        isTemplate: true,
+        categoryIds: [],
+        subtasks: [{ id: createLocalSubtaskId(), title: '', completed: false }],
+        videoUrl: undefined,
+        afterTrainingEnabled: false,
+        afterTrainingDelayMinutes: 0,
+        afterTrainingFeedbackEnableScore: true,
+        afterTrainingFeedbackScoreExplanation: '',
+        afterTrainingFeedbackEnableIntensity: false,
+        afterTrainingFeedbackEnableNote: true,
+        taskDurationEnabled: false,
+        taskDurationMinutes: null,
+      } as any,
+      true,
+    );
+  }, [openTaskModal]);
+
   const reminderEnabled =
     !!selectedTask && (selectedTask as any).reminder !== null && (selectedTask as any).reminder !== undefined;
   const taskDurationEnabled = !!selectedTask?.taskDurationEnabled;
 
   const afterTrainingScoreEnabled = selectedTask?.afterTrainingFeedbackEnableScore ?? true;
-  const afterTrainingNoteEnabled = selectedTask?.afterTrainingFeedbackEnableNote ?? true;
   const afterTrainingScoreExplanation = selectedTask?.afterTrainingFeedbackScoreExplanation ?? '';
 
   // Memoized render functions for FlatList
@@ -850,11 +1094,11 @@ export default function TasksScreen() {
         onArchive={() => void handleArchiveTask(task)}
         onDelete={() => handleDeleteTask(task)}
         onVideoPress={openVideoModal}
-        getCategoryNames={getCategoryNames}
+        getCategoryItems={getCategoryItems}
         isArchived={typeof (task as any)?.archivedAt === 'string' && String((task as any).archivedAt).trim().length > 0}
       />
     ),
-    [isDark, openTaskModal, handleDuplicateTask, handleArchiveTask, handleDeleteTask, openVideoModal, getCategoryNames],
+    [isDark, openTaskModal, handleDuplicateTask, handleArchiveTask, handleDeleteTask, openVideoModal, getCategoryItems],
   );
 
   const bgColor = isDark ? '#1a1a1a' : colors.background;
@@ -864,7 +1108,7 @@ export default function TasksScreen() {
 
   const renderFolder = useCallback(
     ({ item }: { item: FolderItem }) => {
-      const isExpanded = expanded.has(item.id);
+      const isExpanded = expandedFolders.has(item.id);
       return (
         <FolderItemComponent
           folder={item}
@@ -877,18 +1121,13 @@ export default function TasksScreen() {
         />
       );
     },
-    [expanded, toggleFolder, renderTaskCard, textColor, textSecondaryColor, cardBgColor],
+    [expandedFolders, toggleFolder, renderTaskCard, textColor, textSecondaryColor, cardBgColor],
   );
 
   const ListHeaderComponent = useMemo(() => {
     return (
       <>
-        <View style={styles.header}>
-          <Text style={[styles.headerTitle, { color: textColor }]}>Opgaver</Text>
-          <Text style={[styles.headerSubtitle, { color: textSecondaryColor }]}>{templateTasks.length} skabeloner</Text>
-        </View>
-
-        {adminMode === 'self' && (
+        {adminMode === 'self' && userRole === 'player' && (
           <View style={[styles.infoBox, { backgroundColor: isDark ? '#2a3a4a' : '#e3f2fd' }]}>
             <IconSymbol ios_icon_name="info.circle" android_material_icon_name="info" size={20} color={colors.secondary} />
             <Text style={[styles.infoText, { color: isDark ? '#90caf9' : '#1976d2' }]}>
@@ -897,7 +1136,7 @@ export default function TasksScreen() {
           </View>
         )}
 
-        <View style={[styles.searchContainer, { backgroundColor: cardBgColor }]}>
+        <View style={[styles.searchBarWrap, { backgroundColor: cardBgColor, borderColor: isDark ? '#333' : colors.highlight }]}>
           <IconSymbol ios_icon_name="magnifyingglass" android_material_icon_name="search" size={20} color={textSecondaryColor} />
           <TextInput
             style={[styles.searchInput, { color: textColor }]}
@@ -906,89 +1145,176 @@ export default function TasksScreen() {
             value={searchQuery}
             onChangeText={setSearchQuery}
             testID="tasks.searchInput"
+            autoCorrect={false}
+            autoCapitalize="none"
+            returnKeyType="search"
+          />
+          {searchQuery.trim().length ? (
+            <TouchableOpacity onPress={() => setSearchQuery('')} style={styles.iconButton} activeOpacity={0.8}>
+              <IconSymbol ios_icon_name="xmark.circle.fill" android_material_icon_name="cancel" size={20} color={textSecondaryColor} />
+            </TouchableOpacity>
+          ) : null}
+        </View>
+
+        <View style={styles.categoryFilterHeader}>
+          <TouchableOpacity
+            style={[
+              styles.categoryFilterButton,
+              {
+                backgroundColor: selectedCategoryFilter ? colors.primary : cardBgColor,
+                borderColor: selectedCategoryFilter ? colors.primary : isDark ? '#333' : colors.highlight,
+                opacity: uniqueCategories.length ? 1 : 0.55,
+              },
+            ]}
+            onPress={toggleCategoryFilterOpen}
+            disabled={!uniqueCategories.length}
+            activeOpacity={0.85}
+            testID="tasks.categoryFilter.button"
+          >
+            <IconSymbol
+              ios_icon_name="line.3.horizontal.decrease.circle"
+              android_material_icon_name="filter_list"
+              size={18}
+              color={selectedCategoryFilter ? '#fff' : textSecondaryColor}
+            />
+            <Text
+              style={[
+                styles.categoryFilterButtonText,
+                { color: selectedCategoryFilter ? '#fff' : textColor },
+              ]}
+              numberOfLines={1}
+            >
+              {selectedCategoryFilter
+                ? `${String((selectedCategoryFilter as any).emoji ?? '').trim()} ${String((selectedCategoryFilter as any).name ?? '')}`.trim()
+                : 'Filter'}
+            </Text>
+            <IconSymbol
+              ios_icon_name={categoryFilterOpen ? 'chevron.up' : 'chevron.down'}
+              android_material_icon_name={categoryFilterOpen ? 'expand_less' : 'expand_more'}
+              size={16}
+              color={selectedCategoryFilter ? '#fff' : textSecondaryColor}
+            />
+          </TouchableOpacity>
+
+          {selectedCategoryFilter ? (
+            <TouchableOpacity
+              style={[styles.categoryFilterClearButton, { backgroundColor: cardBgColor, borderColor: isDark ? '#333' : colors.highlight }]}
+              onPress={() => selectCategoryFilter(null)}
+              activeOpacity={0.85}
+              testID="tasks.categoryFilter.clearButton"
+            >
+              <IconSymbol ios_icon_name="xmark" android_material_icon_name="close" size={16} color={textSecondaryColor} />
+            </TouchableOpacity>
+          ) : null}
+        </View>
+
+        {categoryFilterOpen ? (
+          <View style={[styles.categoryFilterPanel, { backgroundColor: cardBgColor, borderColor: isDark ? '#333' : colors.highlight }]}>
+            <TouchableOpacity
+              style={[
+                styles.categoryFilterChip,
+                {
+                  backgroundColor: !selectedCategoryFilterId ? colors.primary : 'transparent',
+                  borderColor: colors.primary,
+                },
+              ]}
+              onPress={() => selectCategoryFilter(null)}
+              activeOpacity={0.85}
+              testID="tasks.categoryFilter.option.all"
+            >
+              <Text style={[styles.categoryFilterChipText, { color: !selectedCategoryFilterId ? '#fff' : colors.primary }]}>
+                Alle
+              </Text>
+            </TouchableOpacity>
+
+            {uniqueCategories.map((category: any) => {
+              const catId = String(category.id);
+              const catColor = category.color || colors.primary;
+              const isSelected = selectedCategoryFilterId === catId;
+              const label = `${String(category.emoji ?? '').trim()} ${String(category.name ?? '')}`.trim();
+              return (
+                <TouchableOpacity
+                  key={catId}
+                  style={[
+                    styles.categoryFilterChip,
+                    {
+                      backgroundColor: isSelected ? withAlpha(catColor, 0.18) : 'transparent',
+                      borderColor: catColor,
+                    },
+                  ]}
+                  onPress={() => selectCategoryFilter(isSelected ? null : catId)}
+                  activeOpacity={0.85}
+                  testID={`tasks.categoryFilter.option.${sanitizeTestIdSegment(catId)}`}
+                >
+                  <Text style={[styles.categoryFilterChipText, { color: isSelected ? catColor : textColor }]} numberOfLines={1}>
+                    {label}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        ) : null}
+
+        <View style={styles.sectionDivider}>
+          <Text style={[styles.sectionDividerText, { color: textSecondaryColor }]}>Mapper</Text>
+          <LinearGradient
+            colors={[withAlpha(colors.highlight, 0), withAlpha(colors.highlight, 0.92), withAlpha(colors.primary, 0.35)]}
+            start={{ x: 0, y: 0.5 }}
+            end={{ x: 1, y: 0.5 }}
+            style={styles.sectionDividerLine}
           />
         </View>
 
-        <View style={styles.section}>
-          <View style={styles.sectionHeader}>
-            <Text style={[styles.sectionTitle, { color: textColor }]}>Skabeloner</Text>
-            <TouchableOpacity
-              style={styles.addButton}
-              onPress={() =>
-                openTaskModal(
-                  {
-                    id: '',
-                    title: '',
-                    description: '',
-                    completed: false,
-                    isTemplate: true,
-                    categoryIds: [],
-                    subtasks: [],
-                    videoUrl: undefined,
-                    afterTrainingEnabled: false,
-                    afterTrainingDelayMinutes: 0,
-                    afterTrainingFeedbackEnableScore: true,
-                    afterTrainingFeedbackScoreExplanation: '',
-                    afterTrainingFeedbackEnableNote: true,
-                    taskDurationEnabled: false,
-                    taskDurationMinutes: null,
-                  } as any,
-                  true,
-                )
-              }
-              testID="tasks.newTemplateButton"
-            >
-              <IconSymbol ios_icon_name="plus.circle.fill" android_material_icon_name="add_circle" size={28} color={colors.primary} />
-              <Text style={[styles.addButtonText, { color: colors.primary }]}>Ny skabelon</Text>
-            </TouchableOpacity>
-          </View>
-
+        {adminMode !== 'self' && selectedContext?.type ? (
           <Text style={[styles.sectionDescription, { color: textSecondaryColor }]}>
-            {adminMode !== 'self' && selectedContext?.type
-              ? `Opgaveskabeloner for ${String(selectedContext?.name ?? '')}. Disse vil automatisk blive tilføjet til relevante aktiviteter.`
-              : 'Opgaver organiseret i mapper efter oprindelse'}
+            Opgaveskabeloner for {String(selectedContext?.name ?? '')}.
           </Text>
+        ) : null}
 
-          <View style={[styles.templateViewToggle, { backgroundColor: cardBgColor }]}>
-            <TouchableOpacity
-              style={[
-                styles.templateViewToggleButton,
-                templateView === 'active' && { backgroundColor: colors.primary },
-              ]}
-              onPress={() => setTemplateView('active')}
-              testID="tasks.template.filter.activeButton"
-            >
-              <Text style={[styles.templateViewToggleText, { color: templateView === 'active' ? '#fff' : textColor }]}>
-                Aktive
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.templateViewToggleButton,
-                templateView === 'archived' && { backgroundColor: colors.primary },
-              ]}
-              onPress={() => setTemplateView('archived')}
-              testID="tasks.template.filter.archivedButton"
-            >
-              <Text style={[styles.templateViewToggleText, { color: templateView === 'archived' ? '#fff' : textColor }]}>
-                Arkiverede
-              </Text>
-            </TouchableOpacity>
-          </View>
+        <View style={[styles.templateViewToggle, { backgroundColor: cardBgColor }]}>
+          <TouchableOpacity
+            style={[
+              styles.templateViewToggleButton,
+              templateView === 'active' && { backgroundColor: colors.primary },
+            ]}
+            onPress={() => setTemplateView('active')}
+            testID="tasks.template.filter.activeButton"
+          >
+            <Text style={[styles.templateViewToggleText, { color: templateView === 'active' ? '#fff' : textColor }]}>
+              Aktive
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[
+              styles.templateViewToggleButton,
+              templateView === 'archived' && { backgroundColor: colors.primary },
+            ]}
+            onPress={() => setTemplateView('archived')}
+            testID="tasks.template.filter.archivedButton"
+          >
+            <Text style={[styles.templateViewToggleText, { color: templateView === 'archived' ? '#fff' : textColor }]}>
+              Arkiverede
+            </Text>
+          </TouchableOpacity>
         </View>
       </>
     );
   }, [
-    templateTasks.length,
     adminMode,
     selectedContext,
+    userRole,
     isDark,
     textColor,
     textSecondaryColor,
     searchQuery,
-    openTaskModal,
     cardBgColor,
     templateView,
+    categoryFilterOpen,
+    selectedCategoryFilter,
+    selectedCategoryFilterId,
+    uniqueCategories,
+    toggleCategoryFilterOpen,
+    selectCategoryFilter,
   ]);
 
   const ListEmptyComponent = useMemo(() => {
@@ -996,34 +1322,22 @@ export default function TasksScreen() {
       <View style={[styles.emptyState, { backgroundColor: cardBgColor }]}>
         <IconSymbol ios_icon_name="folder" android_material_icon_name="folder_open" size={48} color={textSecondaryColor} />
         <Text style={[styles.emptyStateText, { color: textSecondaryColor }]}>
-          {searchQuery
-            ? 'Ingen opgaver matcher din søgning'
+          {searchQuery || selectedCategoryFilterId
+            ? 'Ingen opgaver matcher dit filter'
             : templateView === 'active'
               ? 'Ingen aktive opgaveskabeloner'
               : 'Ingen arkiverede opgaveskabeloner'}
         </Text>
       </View>
     );
-  }, [searchQuery, cardBgColor, textSecondaryColor, templateView]);
+  }, [searchQuery, selectedCategoryFilterId, cardBgColor, textSecondaryColor, templateView]);
 
   const ListFooterComponent = useMemo(() => <View style={{ height: 100 }} />, []);
 
-  const uniqueCategories = useMemo(() => {
-    const map = new Map<string, any>();
-    (categories ?? []).forEach((c: any) => {
-      if (c?.id) map.set(String(c.id), c);
-    });
-    return Array.from(map.values());
-  }, [categories]);
-
-  const selectedCategoryObjects = useMemo(() => {
-    const selectedIds = Array.from(new Set((((selectedTask as any)?.categoryIds ?? []) as string[]).filter(Boolean)));
-    if (!selectedIds.length) return [];
-    const byId = new Map(uniqueCategories.map((category: any) => [String(category.id), category]));
-    return selectedIds
-      .map((id) => byId.get(String(id)))
-      .filter(Boolean) as any[];
-  }, [selectedTask, uniqueCategories]);
+  const modalSubtasks = useMemo(
+    () => normalizeModalSubtasks((selectedTask as any)?.subtasks),
+    [selectedTask],
+  );
 
   const isPlayerAdmin = adminMode !== 'self' && adminTargetType === 'player';
   const isTeamAdmin = adminMode !== 'self' && adminTargetType === 'team';
@@ -1033,8 +1347,13 @@ export default function TasksScreen() {
   if (isLoading) {
     return (
       <AdminContextWrapper isAdmin={isAdminMode} contextName={selectedContext?.name} contextType={adminTargetType || 'player'}>
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" />
+        <View style={[styles.screen, { backgroundColor: bgColor }]}>
+          <View style={styles.topBar}>
+            <Text style={[styles.screenTitle, { color: textColor }]} testID="tasks.header.title">Opgaver</Text>
+          </View>
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="large" color={colors.primary} />
+          </View>
         </View>
       </AdminContextWrapper>
     );
@@ -1042,21 +1361,48 @@ export default function TasksScreen() {
 
   return (
     <AdminContextWrapper isAdmin={isAdminMode} contextName={selectedContext?.name} contextType={adminTargetType || 'player'}>
-      <FlatList
-        ref={listRef}
-        data={folders}
-        keyExtractor={(f) => f.id}
-        renderItem={renderFolder}
-        contentContainerStyle={styles.contentContainer}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-        removeClippedSubviews={Platform.OS !== 'web'}
-        initialNumToRender={8}
-        maxToRenderPerBatch={6}
-        windowSize={10}
-        ListHeaderComponent={ListHeaderComponent}
-        ListEmptyComponent={ListEmptyComponent}
-        ListFooterComponent={ListFooterComponent}
-      />
+      <View style={[styles.screen, { backgroundColor: bgColor }]} testID="tasks.screen">
+        <View style={styles.topBar}>
+          <View style={styles.topBarTitleWrap}>
+            <Text
+              style={[styles.screenTitle, { color: textColor }]}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              testID="tasks.header.title"
+            >
+              Opgaver
+            </Text>
+            <Text style={[styles.headerSubtitle, { color: textSecondaryColor }]} numberOfLines={1}>
+              {templateTasks.length} skabeloner
+            </Text>
+          </View>
+          <TouchableOpacity
+            activeOpacity={0.9}
+            style={[styles.createButton, { backgroundColor: colors.primary }]}
+            onPress={openNewTaskModal}
+            testID="tasks.header.newTaskButton"
+          >
+            <IconSymbol ios_icon_name="plus" android_material_icon_name="add" size={16} color="#fff" />
+            <Text style={styles.createButtonText}>Ny opgave</Text>
+          </TouchableOpacity>
+        </View>
+
+        <FlatList
+          ref={listRef}
+          data={folders}
+          keyExtractor={(f) => f.id}
+          renderItem={renderFolder}
+          contentContainerStyle={styles.contentContainer}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+          removeClippedSubviews={Platform.OS !== 'web'}
+          initialNumToRender={8}
+          maxToRenderPerBatch={6}
+          windowSize={10}
+          ListHeaderComponent={ListHeaderComponent}
+          ListEmptyComponent={ListEmptyComponent}
+          ListFooterComponent={ListFooterComponent}
+        />
+      </View>
 
       <Modal visible={isModalVisible} animationType="slide" transparent>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.modalOverlay}>
@@ -1072,36 +1418,44 @@ export default function TasksScreen() {
               data={[{ key: 'form' }]}
               keyExtractor={(item) => item.key}
               renderItem={() => (
-                <View style={styles.modalBody} testID="tasks.template.formBody">
+                <View style={styles.modalBody} testID="tasks.modal.formBody">
                   <Text style={[styles.label, { color: textColor }]}>Titel</Text>
                   <TextInput
                     style={[styles.input, { backgroundColor: bgColor, color: textColor }]}
                     value={String((selectedTask as any)?.title ?? '')}
-                    onChangeText={(text) => setSelectedTask(selectedTask ? ({ ...(selectedTask as any), title: text } as any) : null)}
+                    onChangeText={updateTaskTitle}
                     placeholder="Opgavens titel"
                     placeholderTextColor={textSecondaryColor}
                     editable={!isSaving}
-                    testID="tasks.template.titleInput"
+                    testID="tasks.modal.titleInput"
                   />
+                  {formErrors.title ? (
+                    <Text style={[styles.errorText, { color: colors.error }]}>{formErrors.title}</Text>
+                  ) : null}
 
                   <Text style={[styles.label, { color: textColor }]}>Beskrivelse</Text>
                   <TextInput
                     style={[styles.input, styles.textArea, { backgroundColor: bgColor, color: textColor }]}
                     value={String((selectedTask as any)?.description ?? '')}
-                    onChangeText={(text) => setSelectedTask(selectedTask ? ({ ...(selectedTask as any), description: text } as any) : null)}
+                    onChangeText={updateTaskDescription}
                     placeholder="Beskrivelse af opgaven"
                     placeholderTextColor={textSecondaryColor}
                     multiline
                     numberOfLines={4}
                     editable={!isSaving}
-                    testID="tasks.template.descriptionInput"
+                    testID="tasks.modal.descriptionInput"
                   />
 
                   <View style={styles.videoSection}>
                     <View style={styles.videoLabelRow}>
                       <Text style={[styles.label, { color: textColor }]}>Indsæt link til video</Text>
                       {videoUrl.trim() ? (
-                        <TouchableOpacity style={styles.deleteVideoButton} onPress={handleDeleteVideo} disabled={isSaving}>
+                        <TouchableOpacity
+                          style={styles.deleteVideoButton}
+                          onPress={handleDeleteVideo}
+                          disabled={isSaving}
+                          testID="tasks.modal.deleteVideoButton"
+                        >
                           <IconSymbol ios_icon_name="trash.fill" android_material_icon_name="delete" size={18} color={colors.error} />
                           <Text style={[styles.deleteVideoText, { color: colors.error }]}>Slet video</Text>
                         </TouchableOpacity>
@@ -1111,26 +1465,74 @@ export default function TasksScreen() {
                     <TextInput
                       style={[styles.input, { backgroundColor: bgColor, color: textColor }]}
                       value={videoUrl}
-                      onChangeText={setVideoUrl}
-                      placeholder="https://youtube.com/... eller https://vimeo.com/... eller https://instagram.com/..."
+                      onChangeText={updateVideoUrl}
+                      placeholder="https://youtube.com/... eller https://vimeo.com/..."
                       placeholderTextColor={textSecondaryColor}
                       autoCapitalize="none"
                       editable={!isSaving}
+                      testID="tasks.modal.videoUrlInput"
                     />
 
                     {videoUrl.trim() && isValidVideoUrl(videoUrl) && (
                       <View style={styles.videoPreviewSmall}>
-                        <TouchableOpacity style={styles.videoPreviewButton} onPress={() => openVideoModal(videoUrl)} activeOpacity={0.8}>
+                        <TouchableOpacity
+                          style={styles.videoPreviewButton}
+                          onPress={() => openVideoModal(videoUrl)}
+                          activeOpacity={0.8}
+                          testID="tasks.modal.videoPreview"
+                        >
                           <IconSymbol ios_icon_name="play.circle.fill" android_material_icon_name="play_circle" size={32} color={colors.primary} />
                           <Text style={[styles.videoPreviewText, { color: colors.primary }]}>Forhåndsvisning</Text>
                         </TouchableOpacity>
-                        <Text style={[styles.helperText, { color: colors.secondary }]}>✓ Video URL gemt</Text>
                       </View>
                     )}
 
-                    {videoUrl.trim() && !isValidVideoUrl(videoUrl) && (
-                      <Text style={[styles.helperText, { color: colors.error }]}>⚠ Ugyldig video URL. Kun YouTube, Vimeo og Instagram understøttes.</Text>
+                    {(formErrors.videoUrl || (videoUrl.trim() && !isValidVideoUrl(videoUrl))) && (
+                      <Text style={[styles.errorText, { color: colors.error }]}>
+                        {formErrors.videoUrl || 'Video URL skal være fra YouTube, youtu.be eller Vimeo.'}
+                      </Text>
                     )}
+                  </View>
+
+                  <View style={styles.subtasksSection}>
+                    <View style={styles.subtasksHeader}>
+                      <Text style={[styles.label, { color: textColor, marginBottom: 0 }]}>Delopgaver</Text>
+                      <TouchableOpacity
+                        style={[styles.addSubtaskButton, { borderColor: colors.primary }]}
+                        onPress={addSubtask}
+                        disabled={isSaving}
+                        testID="tasks.modal.addSubtaskButton"
+                      >
+                        <IconSymbol ios_icon_name="plus" android_material_icon_name="add" size={16} color={colors.primary} />
+                        <Text style={[styles.addSubtaskButtonText, { color: colors.primary }]}>Tilføj</Text>
+                      </TouchableOpacity>
+                    </View>
+                    {modalSubtasks.map((subtask) => {
+                      const canRemove = modalSubtasks.length > 1;
+                      return (
+                        <View key={subtask.id} style={styles.subtaskRow}>
+                          <TextInput
+                            style={[styles.input, styles.subtaskInput, { backgroundColor: bgColor, color: textColor }]}
+                            value={subtask.title}
+                            onChangeText={(value) => updateSubtask(subtask.id, value)}
+                            placeholder="Delopgave"
+                            placeholderTextColor={textSecondaryColor}
+                            editable={!isSaving}
+                            testID={`tasks.modal.subtaskInput.${sanitizeTestIdSegment(subtask.id)}`}
+                          />
+                          {canRemove ? (
+                            <TouchableOpacity
+                              style={styles.removeSubtaskButton}
+                              onPress={() => removeSubtask(subtask.id)}
+                              disabled={isSaving}
+                              testID={`tasks.modal.removeSubtask.${sanitizeTestIdSegment(subtask.id)}`}
+                            >
+                              <IconSymbol ios_icon_name="minus.circle.fill" android_material_icon_name="remove_circle" size={24} color={colors.error} />
+                            </TouchableOpacity>
+                          ) : null}
+                        </View>
+                      );
+                    })}
                   </View>
 
                   <View
@@ -1156,7 +1558,7 @@ export default function TasksScreen() {
                         thumbColor={Platform.OS === 'android' ? '#fff' : undefined}
                         ios_backgroundColor={isDark ? '#555' : '#d0d7e3'}
                         disabled={isSaving}
-                        testID="tasks.template.reminderToggle"
+                        testID="tasks.modal.reminderToggle"
                       />
                     </View>
 
@@ -1186,7 +1588,7 @@ export default function TasksScreen() {
                                   )
                                 }
                                 disabled={isSaving}
-                                testID={`tasks.template.reminderOption.${option.value}`}
+                                testID={`tasks.modal.reminderOption.${option.value}`}
                               >
                                 <Text style={{ color: selected ? '#fff' : textColor, fontWeight: selected ? '700' : '600' }}>
                                   {option.label}
@@ -1228,7 +1630,7 @@ export default function TasksScreen() {
                         thumbColor={Platform.OS === 'android' ? '#fff' : undefined}
                         ios_backgroundColor={isDark ? '#555' : '#d0d7e3'}
                         disabled={isSaving}
-                        testID="tasks.template.feedbackToggle"
+                        testID="tasks.modal.feedbackToggle"
                       />
                     </View>
 
@@ -1256,7 +1658,7 @@ export default function TasksScreen() {
                                   setSelectedTask(prev => (prev ? ({ ...prev, afterTrainingDelayMinutes: option.value } as Task) : prev))
                                 }
                                 disabled={isSaving}
-                                testID={`tasks.template.feedbackDelayOption.${option.value}`}
+                                testID={`tasks.modal.feedbackDelayOption.${option.value}`}
                               >
                                 <Text style={{ color: selected ? '#fff' : textColor, fontWeight: selected ? '700' : '600' }}>
                                   {option.label}
@@ -1268,6 +1670,37 @@ export default function TasksScreen() {
                         <Text style={[styles.helperText, { color: textSecondaryColor, marginTop: 6 }]}>
                           Vises efter aktivitetens sluttidspunkt + valgt delay.
                         </Text>
+                        {afterTrainingScoreEnabled ? (
+                          <>
+                            <Text style={[styles.label, { color: textColor, marginTop: 14 }]}>Score-forklaring</Text>
+                            <TextInput
+                              style={[
+                                styles.feedbackExplanationInput,
+                                {
+                                  backgroundColor: bgColor,
+                                  color: textColor,
+                                  borderColor: isDark ? '#444' : '#d0d7e3',
+                                },
+                              ]}
+                              value={afterTrainingScoreExplanation}
+                              onChangeText={(text) =>
+                                setSelectedTask(prev =>
+                                  prev
+                                    ? ({
+                                        ...prev,
+                                        afterTrainingFeedbackScoreExplanation: text,
+                                      } as Task)
+                                    : prev
+                                )
+                              }
+                              placeholder="Forklaring til score-feedback"
+                              placeholderTextColor={textSecondaryColor}
+                              multiline
+                              editable={!isSaving}
+                              testID="tasks.modal.feedbackScoreExplanationInput"
+                            />
+                          </>
+                        ) : null}
                       </View>
                     )}
                   </View>
@@ -1326,77 +1759,53 @@ export default function TasksScreen() {
                   </View>
 
                   <Text style={[styles.label, { color: textColor }]}>Aktivitetskategorier</Text>
-                  <TouchableOpacity
-                    style={[
-                      styles.categoryDropdownToggle,
-                      {
-                        backgroundColor: bgColor,
-                        borderColor: isDark ? '#444' : '#d0d7e3',
-                        opacity: isSaving ? 0.6 : 1,
-                      },
-                    ]}
-                    onPress={() => setIsCategoryDropdownOpen((prev) => !prev)}
-                    disabled={isSaving}
-                    testID="tasks.template.categoryDropdownToggle"
-                  >
-                    <Text style={[styles.categoryDropdownToggleText, { color: textColor }]}>
-                      {selectedCategoryObjects.length
-                        ? selectedCategoryObjects.map((category: any) => String(category.name ?? '')).join(', ')
-                        : 'Vælg kategorier'}
-                    </Text>
-                    <IconSymbol
-                      ios_icon_name={isCategoryDropdownOpen ? 'chevron.up' : 'chevron.down'}
-                      android_material_icon_name={isCategoryDropdownOpen ? 'expand_less' : 'expand_more'}
-                      size={18}
-                      color={textSecondaryColor}
-                    />
-                  </TouchableOpacity>
-                  {isCategoryDropdownOpen && (
-                    <FlatList
-                      data={uniqueCategories}
-                      keyExtractor={(item: any) => String(item.id)}
-                      scrollEnabled={false}
-                      contentContainerStyle={styles.categoryDropdownList}
-                      renderItem={({ item, index }) => {
-                        const catId = String(item.id);
-                        const catColor = item.color || colors.primary;
-                        const isSelected = !!selectedTask?.categoryIds?.includes?.(catId);
-                        return (
-                          <TouchableOpacity
-                            style={[
-                              styles.categorySelectionRow,
-                              {
-                                backgroundColor: isSelected ? catColor : bgColor,
-                                borderColor: catColor,
-                              },
-                            ]}
-                            onPress={() => toggleCategory(catId)}
-                            disabled={isSaving}
-                            testID={`tasks.template.categoryOption.${index}`}
-                          >
-                            <Text style={styles.categoryEmoji}>{String(item.emoji ?? '')}</Text>
-                            <Text style={[styles.categoryName, { color: isSelected ? '#fff' : textColor }]}>
-                              {String(item.name ?? '')}
-                            </Text>
-                          </TouchableOpacity>
-                        );
-                      }}
-                    />
-                  )}
+                  <View style={styles.categoriesGrid} testID="tasks.modal.categoryDropdownToggle">
+                    {uniqueCategories.map((item: any, index: number) => {
+                      const catId = String(item.id);
+                      const catColor = item.color || colors.primary;
+                      const isSelected = !!selectedTask?.categoryIds?.includes?.(catId);
+                      return (
+                        <TouchableOpacity
+                          key={catId}
+                          style={[
+                            styles.categoryChip,
+                            {
+                              backgroundColor: isSelected ? catColor : bgColor,
+                              borderColor: catColor,
+                              opacity: isSaving ? 0.6 : 1,
+                            },
+                          ]}
+                          onPress={() => toggleCategory(catId)}
+                          disabled={isSaving}
+                          testID={`tasks.modal.categoryOption.${index}`}
+                        >
+                          <Text style={styles.categoryEmoji}>{String(item.emoji ?? '')}</Text>
+                          <Text style={[styles.categoryName, { color: isSelected ? '#fff' : textColor }]}>
+                            {String(item.name ?? '')}
+                          </Text>
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </View>
                 </View>
               )}
               showsVerticalScrollIndicator={false}
             />
 
             <View style={styles.modalFooter}>
-              <TouchableOpacity style={[styles.modalButton, styles.cancelButton, { backgroundColor: bgColor }]} onPress={closeTaskModal} disabled={isSaving}>
+              <TouchableOpacity
+                style={[styles.modalButton, styles.cancelButton, { backgroundColor: bgColor }]}
+                onPress={closeTaskModal}
+                disabled={isSaving}
+                testID="tasks.modal.cancelButton"
+              >
                 <Text style={[styles.modalButtonText, { color: textColor }]}>Annuller</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 style={[styles.modalButton, styles.saveButton, { backgroundColor: colors.primary, opacity: isSaving ? 0.6 : 1 }]}
                 onPress={handleSaveTask}
                 disabled={isSaving}
-                testID="tasks.template.saveButton"
+                testID="tasks.modal.saveButton"
               >
                 <Text style={[styles.modalButtonText, { color: '#fff' }]}>{isSaving ? 'Gemmer...' : 'Gem'}</Text>
               </TouchableOpacity>
@@ -1509,40 +1918,155 @@ export default function TasksScreen() {
 }
 
 const styles = StyleSheet.create({
+  screen: { flex: 1 },
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  contentContainer: { paddingHorizontal: 16, paddingBottom: 24 },
-  header: { paddingTop: Platform.OS === 'android' ? 60 : 70, paddingBottom: 16 },
-  headerTitle: { fontSize: 32, fontWeight: 'bold', marginBottom: 4 },
-  headerSubtitle: { fontSize: 16 },
-  infoBox: { flexDirection: 'row', gap: 12, paddingHorizontal: 16, paddingVertical: 12, marginBottom: 12, borderRadius: 12 },
+  contentContainer: { paddingHorizontal: 18, paddingBottom: 24 },
+  topBar: {
+    paddingTop: Platform.OS === 'android' ? 54 : 56,
+    paddingHorizontal: 18,
+    paddingBottom: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  topBarTitleWrap: { flex: 1, minWidth: 0 },
+  screenTitle: {
+    fontSize: 34,
+    lineHeight: 40,
+    fontWeight: '800',
+  },
+  topBarRight: { flexDirection: 'row', gap: 10, alignItems: 'center', flexShrink: 0 },
+  headerSubtitle: { fontSize: 13, fontWeight: '800', marginTop: 2 },
+  iconButton: { padding: 6 },
+  createButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 13,
+    paddingVertical: 8,
+    borderRadius: 999,
+    flexShrink: 0,
+  },
+  createButtonText: { color: '#fff', fontSize: 13, fontWeight: '800' },
+  infoBox: { flexDirection: 'row', gap: 12, paddingHorizontal: 16, paddingVertical: 12, marginBottom: 12, borderRadius: 16 },
   infoText: { flex: 1, fontSize: 14, lineHeight: 20 },
-  searchContainer: { flexDirection: 'row', alignItems: 'center', borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12, marginBottom: 16 },
-  searchInput: { flex: 1, marginLeft: 8, fontSize: 16 },
+  searchBarWrap: {
+    marginBottom: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 16,
+    borderWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  searchInput: { flex: 1, fontSize: 14, fontWeight: '600' },
+  categoryFilterHeader: { flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: -4, marginBottom: 14 },
+  categoryFilterButton: {
+    flex: 1,
+    minHeight: 42,
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  categoryFilterButtonText: { flex: 1, fontSize: 14, fontWeight: '800' },
+  categoryFilterClearButton: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  categoryFilterPanel: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: 10,
+    marginTop: -8,
+    marginBottom: 14,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  categoryFilterChip: {
+    minHeight: 36,
+    maxWidth: '100%',
+    borderRadius: 999,
+    borderWidth: 1.5,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    justifyContent: 'center',
+  },
+  categoryFilterChipText: { fontSize: 13, fontWeight: '800' },
   section: { marginBottom: 24 },
   sectionHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },
   sectionTitle: { fontSize: 22, fontWeight: 'bold' },
-  sectionDescription: { fontSize: 14, marginBottom: 12, lineHeight: 20 },
+  sectionDescription: { fontSize: 13, marginBottom: 12, lineHeight: 18, fontWeight: '600' },
   addButton: { flexDirection: 'row', alignItems: 'center', gap: 4 },
   addButtonText: { fontSize: 16, fontWeight: '600' },
-  templateViewToggle: { flexDirection: 'row', padding: 4, borderRadius: 12, gap: 6 },
+  sectionDivider: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginTop: 2,
+    marginBottom: 10,
+  },
+  sectionDividerText: {
+    fontSize: 12,
+    fontWeight: '800',
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+  },
+  sectionDividerLine: {
+    flex: 1,
+    height: 2,
+    borderRadius: 999,
+  },
+  templateViewToggle: { flexDirection: 'row', padding: 4, borderRadius: 16, gap: 6, marginBottom: 14 },
   templateViewToggleButton: { flex: 1, alignItems: 'center', paddingVertical: 8, borderRadius: 10 },
   templateViewToggleText: { fontSize: 14, fontWeight: '600' },
-  folderHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 16, borderRadius: 12, marginBottom: 8 },
+  folderWrap: { marginBottom: 10 },
+  folderHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingVertical: 14, paddingHorizontal: 14, borderRadius: 16 },
   folderHeaderLeft: { flexDirection: 'row', alignItems: 'center', gap: 12, flex: 1 },
-  folderName: { fontSize: 18, fontWeight: '600', flex: 1 },
+  folderIconWrap: {
+    width: 34,
+    height: 34,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  folderTextWrap: { flex: 1, gap: 2 },
+  folderName: { fontSize: 16, fontWeight: '700', flex: 1 },
+  folderSubtitle: { fontSize: 13, fontWeight: '500' },
   countBadge: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: 12 },
-  countBadgeText: { fontSize: 12, fontWeight: 'bold', color: '#fff' },
-  folderContent: { marginBottom: 8 },
+  countBadgeText: { fontSize: 12, fontWeight: '800' },
+  folderContent: { marginTop: 10, marginBottom: 4 },
 
-  emptyState: { padding: 48, borderRadius: 12, alignItems: 'center', gap: 16 },
+  emptyState: { padding: 48, borderRadius: 16, alignItems: 'center', gap: 16 },
   emptyStateText: { fontSize: 16, textAlign: 'center' },
 
-  taskCard: { borderRadius: 12, padding: 16, marginBottom: 8 },
-  taskHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },
-  taskHeaderLeft: { flexDirection: 'row', alignItems: 'center', flex: 1, gap: 12 },
-  checkbox: { width: 24, height: 24, borderRadius: 12, borderWidth: 2, borderColor: colors.primary, alignItems: 'center', justifyContent: 'center' },
-  taskTitle: { fontSize: 16, fontWeight: '600', flex: 1 },
-  taskActions: { flexDirection: 'row', gap: 8 },
+  taskCard: { borderRadius: 24, padding: 14, marginBottom: 12, borderWidth: 1, borderColor: 'rgba(148,163,184,0.28)' },
+  taskCardShadow: {
+    shadowColor: '#64748b',
+    shadowOffset: { width: 0, height: 10 },
+    shadowOpacity: 0.12,
+    shadowRadius: 18,
+    elevation: 6,
+  },
+  taskHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8, gap: 10 },
+  taskHeaderLeft: { flexDirection: 'row', alignItems: 'center', flex: 1, gap: 12, minWidth: 0 },
+  taskIconWrap: { width: 34, height: 34, borderRadius: 12, alignItems: 'center', justifyContent: 'center', backgroundColor: 'rgba(59,130,246,0.12)' },
+  taskTitleWrap: { flex: 1, minWidth: 0, gap: 5 },
+  taskTitleRow: { flexDirection: 'row', alignItems: 'flex-start' },
+  taskTitle: { fontSize: 16, fontWeight: '800', flex: 1, lineHeight: 21 },
+  taskDescription: { fontSize: 13, lineHeight: 18, fontWeight: '500' },
+  taskDescriptionIndented: { marginLeft: 46, marginTop: -4, marginBottom: 10 },
+  taskActions: { flexDirection: 'row', gap: 8, flexShrink: 0 },
   actionButton: { padding: 4 },
 
   videoThumbnailWrapper: { height: 180, borderRadius: 12, overflow: 'hidden', marginBottom: 12, backgroundColor: '#000' },
@@ -1567,21 +2091,53 @@ const styles = StyleSheet.create({
   reminderBadge: { flexDirection: 'row', alignItems: 'center', gap: 4, marginBottom: 8 },
   reminderText: { fontSize: 12, fontWeight: '600' },
 
-  categoriesRow: { flexDirection: 'row', alignItems: 'center', gap: 4 },
-  categoriesText: { fontSize: 12, flex: 1 },
+  categoriesBlock: { marginTop: 6, gap: 8 },
+  categoriesLabelRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  categoriesLabelText: { fontSize: 12, fontWeight: '800', textTransform: 'uppercase' },
+  taskCategoryBadges: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  taskCategoryBadge: {
+    minHeight: 30,
+    maxWidth: '100%',
+    borderRadius: 999,
+    borderWidth: 1.5,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+  },
+  taskCategoryBadgeEmoji: { fontSize: 13 },
+  taskCategoryBadgeText: { fontSize: 12, fontWeight: '800' },
 
-  modalOverlay: { flex: 1, backgroundColor: 'rgba(0, 0, 0, 0.5)', justifyContent: 'flex-end' },
-  modalContent: { borderTopLeftRadius: 20, borderTopRightRadius: 20, maxHeight: '90%' },
-  modalHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, borderBottomWidth: 1, borderBottomColor: colors.highlight },
-  modalTitle: { fontSize: 20, fontWeight: 'bold' },
-  modalBody: { padding: 20 },
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0, 0, 0, 0.45)', justifyContent: 'flex-end' },
+  modalContent: { borderTopLeftRadius: 22, borderTopRightRadius: 22, maxHeight: '92%', overflow: 'hidden' },
+  modalHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 18, borderBottomWidth: 1, borderBottomColor: colors.highlight },
+  modalTitle: { fontSize: 20, fontWeight: '900' },
+  modalBody: { padding: 18 },
   label: { fontSize: 16, fontWeight: '600', marginBottom: 8 },
   input: { borderRadius: 8, padding: 12, fontSize: 16, marginBottom: 16 },
   textArea: { height: 100, textAlignVertical: 'top' },
+  errorText: { fontSize: 13, fontWeight: '600', marginTop: -10, marginBottom: 12 },
 
 
-  categoriesGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
-  categoryChip: { flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 12, paddingVertical: 8, borderRadius: 20 },
+  subtasksSection: { marginBottom: 18 },
+  subtasksHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 },
+  addSubtaskButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  addSubtaskButtonText: { fontSize: 13, fontWeight: '800' },
+  subtaskRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 10 },
+  subtaskInput: { flex: 1, marginBottom: 0 },
+  removeSubtaskButton: { padding: 4 },
+
+  categoriesGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 12 },
+  categoryChip: { flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 12, paddingVertical: 8, borderRadius: 20, borderWidth: 1.5 },
   categoryEmoji: { fontSize: 16 },
   categoryName: { fontSize: 14, fontWeight: '600' },
   categoryDropdownToggle: {

--- a/e2e/flows/activity_task_flow_smoke.yaml
+++ b/e2e/flows/activity_task_flow_smoke.yaml
@@ -92,73 +92,73 @@ tags:
 - openLink: 'footballcoach:///(tabs)/tasks'
 - extendedWaitUntil:
     visible:
-      id: '^tasks\.newTemplateButton$'
+      id: '^tasks\.header\.newTaskButton$'
     timeout: 15000
 - tapOn:
-    id: '^tasks\.newTemplateButton$'
+    id: '^tasks\.header\.newTaskButton$'
 - extendedWaitUntil:
     visible:
-      id: '^tasks\.template\.titleInput$'
+      id: '^tasks\.modal\.titleInput$'
     timeout: 15000
 - tapOn:
-    id: '^tasks\.template\.titleInput$'
+    id: '^tasks\.modal\.titleInput$'
 - inputText: 'Maestro Opgave E2E ${MAESTRO_PLATFORM_SUFFIX}'
 - tapOn:
-    id: '^tasks\.template\.descriptionInput$'
+    id: '^tasks\.modal\.descriptionInput$'
 - inputText: 'E2E opgave til activity-task-flow'
 - tapOn:
-    id: '^tasks\.template\.titleInput$'
+    id: '^tasks\.modal\.titleInput$'
 - runFlow: _platform_keyboard_commit_input.yaml
 - scrollUntilVisible:
     element:
-      id: '^tasks\.template\.reminderToggle$'
+      id: '^tasks\.modal\.reminderToggle$'
     direction: DOWN
     timeout: 15000
 - tapOn:
-    id: '^tasks\.template\.reminderToggle$'
+    id: '^tasks\.modal\.reminderToggle$'
 - runFlow:
     when:
       visible:
-        id: '^tasks\.template\.reminderOption\.15$'
+        id: '^tasks\.modal\.reminderOption\.15$'
     commands:
       - tapOn:
-          id: '^tasks\.template\.reminderOption\.15$'
+          id: '^tasks\.modal\.reminderOption\.15$'
 - swipe:
     start: 50%, 80%
     end: 50%, 30%
 - scrollUntilVisible:
     element:
-      id: '^tasks\.template\.feedbackToggle$'
+      id: '^tasks\.modal\.feedbackToggle$'
     direction: DOWN
     timeout: 15000
 - tapOn:
-    id: '^tasks\.template\.feedbackToggle$'
+    id: '^tasks\.modal\.feedbackToggle$'
 - runFlow:
     when:
       visible:
-        id: '^tasks\.template\.feedbackDelayOption\.15$'
+        id: '^tasks\.modal\.feedbackDelayOption\.15$'
     commands:
       - tapOn:
-          id: '^tasks\.template\.feedbackDelayOption\.15$'
+          id: '^tasks\.modal\.feedbackDelayOption\.15$'
 - scrollUntilVisible:
     element:
-      id: '^tasks\.template\.categoryDropdownToggle$'
+      id: '^tasks\.modal\.categoryDropdownToggle$'
     direction: DOWN
     timeout: 15000
 - tapOn:
-    id: '^tasks\.template\.categoryDropdownToggle$'
+    id: '^tasks\.modal\.categoryDropdownToggle$'
 - swipe:
     start: 50%, 80%
     end: 50%, 20%
 - scrollUntilVisible:
     element:
-      id: '^tasks\.template\.categoryOption\.3$'
+      id: '^tasks\.modal\.categoryOption\.3$'
     direction: DOWN
     timeout: 15000
 - tapOn:
-    id: '^tasks\.template\.categoryOption\.3$'
+    id: '^tasks\.modal\.categoryOption\.3$'
 - tapOn:
-    id: '^tasks\.template\.saveButton$'
+    id: '^tasks\.modal\.saveButton$'
 - runFlow:
     when:
       visible: 'Succes'
@@ -437,10 +437,10 @@ tags:
 - openLink: 'footballcoach:///(tabs)/tasks'
 - extendedWaitUntil:
     visible:
-      id: '^tasks\.folder\.toggle\.personal$'
+      id: '^tasks\.folder\.personal$'
     timeout: 15000
 - tapOn:
-    id: '^tasks\.folder\.toggle\.personal$'
+    id: '^tasks\.folder\.personal$'
 - runFlow:
     when:
       visible:
@@ -452,7 +452,7 @@ tags:
 - tapOn:
     id: '^tasks\.template\.filter\.archivedButton$'
 - assertVisible:
-    id: '^tasks\.template\.card\..+$'
+    id: '^tasks\.taskCard\..+$'
 - tapOn:
     id: '^tasks\.template\.filter\.activeButton$'
 
@@ -494,39 +494,39 @@ tags:
     id: '^tasks\.template\.filter\.archivedButton$'
 - extendedWaitUntil:
     visible:
-      id: '^tasks\.folder\.toggle\.personal$'
+      id: '^tasks\.folder\.personal$'
     timeout: 15000
 - scrollUntilVisible:
     element:
-      id: '^tasks\.folder\.toggle\.personal$'
+      id: '^tasks\.folder\.personal$'
     direction: UP
     timeout: 10000
 - tapOn:
-    id: '^tasks\.folder\.toggle\.personal$'
+    id: '^tasks\.folder\.personal$'
 - runFlow:
     when:
       notVisible:
-        id: '^tasks\.template\.deleteButton\..+$'
+        id: '^tasks\.task\.delete\..+$'
     commands:
       - tapOn:
-          id: '^tasks\.folder\.toggle\.personal$'
+          id: '^tasks\.folder\.personal$'
 - runFlow:
     when:
       notVisible:
-        id: '^tasks\.template\.deleteButton\..+$'
+        id: '^tasks\.task\.delete\..+$'
     commands:
       - scrollUntilVisible:
           element:
-            id: '^tasks\.template\.deleteButton\..+$'
+            id: '^tasks\.task\.delete\..+$'
           direction: DOWN
           timeout: 10000
 - runFlow:
     when:
       visible:
-        id: '^tasks\.template\.deleteButton\..+$'
+        id: '^tasks\.task\.delete\..+$'
     commands:
       - tapOn:
-          id: '^tasks\.template\.deleteButton\..+$'
+          id: '^tasks\.task\.delete\..+$'
           index: 0
       - runFlow:
           when:

--- a/e2e/flows/library_add_to_tasks_smoke.yaml
+++ b/e2e/flows/library_add_to_tasks_smoke.yaml
@@ -193,62 +193,62 @@ tags:
 - openLink: "footballcoach:///(tabs)/tasks"
 - extendedWaitUntil:
     visible:
-      id: '^tasks\.folder\.toggle\.footballcoach$'
+      id: '^tasks\.folder\.inspiration$'
     timeout: 15000
 - assertVisible:
-    id: '^tasks\.folder\.toggle\.footballcoach$'
+    id: '^tasks\.folder\.inspiration$'
 - tapOn:
-    id: '^tasks\.folder\.toggle\.footballcoach$'
+    id: '^tasks\.folder\.inspiration$'
 - extendedWaitUntil:
     visible:
-      id: '^tasks\.template\.card\..*$'
+      id: '^tasks\.taskCard\..*$'
     timeout: 15000
 - tapOn:
-    id: '^tasks\.template\.card\..*$'
+    id: '^tasks\.taskCard\..*$'
     index: 0
 - extendedWaitUntil:
     visible:
-      id: '^tasks\.template\.formBody$'
+      id: '^tasks\.modal\.formBody$'
     timeout: 15000
 - assertVisible:
-    id: '^tasks\.template\.formBody$'
+    id: '^tasks\.modal\.formBody$'
 - tapOn:
-    id: '^tasks\.template\.descriptionInput$'
+    id: '^tasks\.modal\.descriptionInput$'
 - eraseText
 - inputText: "Opdateret via smoke flow"
 - runFlow: _platform_keyboard_commit_input.yaml
 - scrollUntilVisible:
     element:
-      id: '^tasks\.template\.reminderToggle$'
+      id: '^tasks\.modal\.reminderToggle$'
     direction: DOWN
     timeout: 15000
 - tapOn:
-    id: '^tasks\.template\.reminderToggle$'
+    id: '^tasks\.modal\.reminderToggle$'
 - tapOn:
-    id: '^tasks\.template\.reminderOption\.15$'
+    id: '^tasks\.modal\.reminderOption\.15$'
 - swipe:
     start: 50%, 80%
     end: 50%, 30%
 - scrollUntilVisible:
     element:
-      id: '^tasks\.template\.feedbackToggle$'
+      id: '^tasks\.modal\.feedbackToggle$'
     direction: DOWN
     timeout: 15000
 - assertVisible:
-    id: '^tasks\.template\.feedbackToggle$'
+    id: '^tasks\.modal\.feedbackToggle$'
 - runFlow:
     when:
       notVisible:
-        id: '^tasks\.template\.feedbackDelayOption\.15$'
+        id: '^tasks\.modal\.feedbackDelayOption\.15$'
     commands:
       - tapOn:
-          id: '^tasks\.template\.feedbackToggle$'
+          id: '^tasks\.modal\.feedbackToggle$'
 - extendedWaitUntil:
     visible:
-      id: '^tasks\.template\.feedbackDelayOption\.15$'
+      id: '^tasks\.modal\.feedbackDelayOption\.15$'
     timeout: 15000
 - tapOn:
-    id: '^tasks\.template\.feedbackDelayOption\.15$'
+    id: '^tasks\.modal\.feedbackDelayOption\.15$'
 - scrollUntilVisible:
     element:
       text: '.*Fysisk træning.*'
@@ -260,7 +260,7 @@ tags:
     end: 50%, 20%
 - extendedWaitUntil:
     visible:
-      id: '^tasks\.template\.saveButton$'
+      id: '^tasks\.modal\.saveButton$'
     timeout: 15000
 - scrollUntilVisible:
     element:
@@ -269,7 +269,7 @@ tags:
     timeout: 8000
 - tapOn: '.*Fysisk træning.*'
 - tapOn:
-    id: '^tasks\.template\.saveButton$'
+    id: '^tasks\.modal\.saveButton$'
 - runFlow:
     when:
       visible: 'Succes'
@@ -664,17 +664,17 @@ tags:
 - openLink: "footballcoach:///(tabs)/tasks"
 - extendedWaitUntil:
     visible:
-      id: '^tasks\.folder\.toggle\.footballcoach$'
+      id: '^tasks\.folder\.inspiration$'
     timeout: 15000
 - tapOn:
-    id: '^tasks\.folder\.toggle\.footballcoach$'
+    id: '^tasks\.folder\.inspiration$'
 - runFlow:
     when:
       visible:
-        id: '^tasks\.template\.deleteButton\..+$'
+        id: '^tasks\.task\.delete\..+$'
     commands:
       - tapOn:
-          id: '^tasks\.template\.deleteButton\..+$'
+          id: '^tasks\.task\.delete\..+$'
           index: 0
       - runFlow:
           when:
@@ -706,10 +706,10 @@ tags:
 - runFlow:
     when:
       visible:
-        id: '^tasks\.template\.deleteButton\..+$'
+        id: '^tasks\.task\.delete\..+$'
     commands:
       - tapOn:
-          id: '^tasks\.template\.deleteButton\..+$'
+          id: '^tasks\.task\.delete\..+$'
           index: 0
       - runFlow:
           when:
@@ -741,10 +741,10 @@ tags:
 - runFlow:
     when:
       visible:
-        id: '^tasks\.template\.deleteButton\..+$'
+        id: '^tasks\.task\.delete\..+$'
     commands:
       - tapOn:
-          id: '^tasks\.template\.deleteButton\..+$'
+          id: '^tasks\.task\.delete\..+$'
           index: 0
       - runFlow:
           when:
@@ -776,10 +776,10 @@ tags:
 - runFlow:
     when:
       visible:
-        id: '^tasks\.template\.deleteButton\..+$'
+        id: '^tasks\.task\.delete\..+$'
     commands:
       - tapOn:
-          id: '^tasks\.template\.deleteButton\..+$'
+          id: '^tasks\.task\.delete\..+$'
           index: 0
       - runFlow:
           when:
@@ -811,10 +811,10 @@ tags:
 - runFlow:
     when:
       visible:
-        id: '^tasks\.template\.deleteButton\..+$'
+        id: '^tasks\.task\.delete\..+$'
     commands:
       - tapOn:
-          id: '^tasks\.template\.deleteButton\..+$'
+          id: '^tasks\.task\.delete\..+$'
           index: 0
       - runFlow:
           when:

--- a/hooks/useFootballData.ts
+++ b/hooks/useFootballData.ts
@@ -603,10 +603,15 @@ export const useFootballData = ({
 
       if (catError) throw catError;
 
-      const {
-        data: { session },
-        error: sessionError,
-      } = await supabase.auth.getSession();
+      let session: any = null;
+      let sessionError: any = null;
+      try {
+        const sessionResult = await supabase.auth.getSession();
+        session = sessionResult?.data?.session ?? null;
+        sessionError = sessionResult?.error ?? null;
+      } catch (error) {
+        sessionError = error;
+      }
 
       if (sessionError) {
         console.error('[refreshCategories] session lookup failed:', sessionError);
@@ -683,6 +688,9 @@ export const useFootballData = ({
         .select(
           `
           id,
+          user_id,
+          player_id,
+          team_id,
           title,
           description,
           reminder_minutes,
@@ -699,6 +707,11 @@ export const useFootballData = ({
           archived_at,
           task_template_categories (
             category_id
+          ),
+          task_template_subtasks (
+            id,
+            title,
+            sort_order
           )
         `
         )
@@ -706,15 +719,68 @@ export const useFootballData = ({
 
       if (error) throw error;
 
+      let session: any = null;
+      let sessionError: any = null;
+      try {
+        const sessionResult = await supabase.auth.getSession();
+        session = sessionResult?.data?.session ?? null;
+        sessionError = sessionResult?.error ?? null;
+      } catch (error) {
+        sessionError = error;
+      }
+
+      const currentUserId = session?.user?.id ?? null;
+      const ownerIds = Array.from(
+        new Set(
+          (data || [])
+            .map((t: any) => String(t?.user_id ?? '').trim())
+            .filter((ownerId) => ownerId.length > 0 && ownerId !== currentUserId)
+        )
+      );
+      const trainerNameByUserId = new Map<string, string>();
+
+      if (ownerIds.length) {
+        try {
+          const profileQuery = await supabase
+            .from('profiles')
+            .select('user_id, full_name')
+            .in('user_id', ownerIds);
+
+          if (!profileQuery.error && Array.isArray(profileQuery.data)) {
+            profileQuery.data.forEach((profile: any) => {
+              const ownerId = String(profile?.user_id ?? '').trim();
+              const fullName = String(profile?.full_name ?? '').trim();
+              if (ownerId && fullName) {
+                trainerNameByUserId.set(ownerId, fullName);
+              }
+            });
+          }
+        } catch (profileError) {
+          console.warn('[fetchTasks] trainer profile lookup failed:', profileError);
+        }
+      }
+
       const transformed: Task[] = (data || []).map((t: any) => ({
         id: t.id,
+        userId: t.user_id ?? null,
+        playerId: t.player_id ?? null,
+        teamId: t.team_id ?? null,
+        trainerName: trainerNameByUserId.get(String(t.user_id ?? '').trim()) ?? null,
         title: t.title,
         description: t.description || '',
         completed: false,
         isTemplate: true,
         categoryIds: t.task_template_categories?.map((c: any) => c.category_id) ?? [],
         reminder: t.reminder_minutes ?? undefined,
-        subtasks: [],
+        subtasks: (t.task_template_subtasks ?? [])
+          .slice()
+          .sort((a: any, b: any) => Number(a?.sort_order ?? 0) - Number(b?.sort_order ?? 0))
+          .map((subtask: any) => ({
+            id: String(subtask?.id ?? ''),
+            title: String(subtask?.title ?? ''),
+            completed: false,
+          }))
+          .filter((subtask: any) => subtask.id && subtask.title),
         videoUrl: t.video_url ?? undefined,
         source_folder: t.source_folder ?? undefined,
         afterTrainingEnabled: !!t.after_training_enabled,
@@ -730,11 +796,6 @@ export const useFootballData = ({
 
       // Filter out hidden tasks
       try {
-        const {
-          data: { session },
-          error: sessionError,
-        } = await supabase.auth.getSession();
-
         if (sessionError) {
           console.error('[fetchTasks] session lookup failed for hidden filter:', sessionError);
           setTasks(transformed);
@@ -1565,6 +1626,7 @@ export const useFootballData = ({
           categoryIds: task.categoryIds || [],
           reminder: task.reminder,
           videoUrl: task.videoUrl,
+          subtasks: task.subtasks ?? [],
           afterTrainingEnabled: !!task.afterTrainingEnabled,
           afterTrainingDelayMinutes: task.afterTrainingEnabled ? (task.afterTrainingDelayMinutes ?? 0) : null,
           afterTrainingFeedbackEnableScore: task.afterTrainingFeedbackEnableScore ?? true,
@@ -1735,6 +1797,7 @@ export const useFootballData = ({
         categoryIds: updates.categoryIds,
         reminder: updates.reminder,
         videoUrl: updates.videoUrl,
+        subtasks: updates.subtasks,
         afterTrainingEnabled: updates.afterTrainingEnabled,
         afterTrainingDelayMinutes: updates.afterTrainingEnabled ? (updates.afterTrainingDelayMinutes ?? 0) : null,
         afterTrainingFeedbackEnableScore: updates.afterTrainingFeedbackEnableScore,
@@ -1796,6 +1859,11 @@ export const useFootballData = ({
           categoryIds: taskToDuplicate.categoryIds,
           reminder: taskToDuplicate.reminder,
           videoUrl: taskToDuplicate.videoUrl,
+          subtasks: (taskToDuplicate.subtasks ?? []).map((subtask) => ({
+            ...subtask,
+            id: `copy-${String(subtask.id ?? '')}-${Date.now()}`,
+            completed: false,
+          })),
           afterTrainingEnabled: !!taskToDuplicate.afterTrainingEnabled,
           afterTrainingDelayMinutes: taskToDuplicate.afterTrainingEnabled ? (taskToDuplicate.afterTrainingDelayMinutes ?? 0) : null,
           afterTrainingFeedbackEnableScore: taskToDuplicate.afterTrainingFeedbackEnableScore ?? true,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,7 +1,12 @@
 /* global beforeAll, afterEach, afterAll, jest */
 import "@testing-library/jest-native/extend-expect";
 import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
+import WebSocket from 'ws';
 import { mockApiServer, resetMockApiState } from './test-harness';
+
+if (typeof globalThis.WebSocket === 'undefined') {
+  globalThis.WebSocket = WebSocket;
+}
 
 jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 jest.mock('expo-av', () => {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "date-fns": "^4.1.0",
     "difflib": "^0.2.4",
     "expo": "~54.0.33",
+    "expo-asset": "~12.0.12",
     "expo-av": "~16.0.8",
     "expo-blur": "^15.0.6",
     "expo-constants": "~18.0.13",
@@ -122,8 +123,8 @@
     "@types/react": "~19.1.12",
     "@typescript-eslint/eslint-plugin": "^8.12.1",
     "@typescript-eslint/parser": "^8.12.1",
-    "babel-preset-expo": "~54.0.10",
     "babel-plugin-module-resolver": "^5.0.2",
+    "babel-preset-expo": "~54.0.10",
     "csv-parse": "^5.5.6",
     "eslint": "^9.39.2",
     "eslint-config-expo": "~10.0.0",
@@ -137,7 +138,8 @@
     "react-test-renderer": "19.1.0",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^6.0.1",
+    "ws": "^8.21.0"
   },
   "resolutions": {
     "@expo/prebuild-config": "latest"

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "@types/react": "~19.1.12",
     "@typescript-eslint/eslint-plugin": "^8.12.1",
     "@typescript-eslint/parser": "^8.12.1",
+    "babel-preset-expo": "~54.0.10",
     "babel-plugin-module-resolver": "^5.0.2",
     "csv-parse": "^5.5.6",
     "eslint": "^9.39.2",

--- a/screens/TasksScreen.tsx
+++ b/screens/TasksScreen.tsx
@@ -87,7 +87,7 @@ function organizeFolders(templateTasks: Task[]): FolderItem[] {
 }
 
 export default function TasksScreen() {
-  const { tasks, duplicateTask, deleteTask, refreshData, isLoading } = useFootballData();
+  const { tasks, categories, duplicateTask, deleteTask, refreshData, isLoading } = useFootballData();
   const scheme = useColorScheme();
   const theme = getColors(scheme);
 
@@ -161,6 +161,22 @@ export default function TasksScreen() {
     });
   }, [isDuplicating]);
 
+  const getCategoryItems = useCallback(
+    (categoryIds: string[]) => {
+      const uniqueIds = Array.from(new Set((categoryIds ?? []).filter(Boolean)));
+      return uniqueIds
+        .map(id => categories.find((category: any) => String(category.id) === String(id)))
+        .filter(Boolean)
+        .map((category: any) => ({
+          id: String(category.id),
+          name: String(category.name ?? ''),
+          color: category.color,
+          emoji: category.emoji ?? '',
+        }));
+    },
+    [categories],
+  );
+
   const renderTask = useCallback(
     ({ item }: { item: Task }) => (
       <TaskCard
@@ -170,10 +186,10 @@ export default function TasksScreen() {
         onDuplicate={() => void handleDuplicateTask(item.id)}
         onDelete={() => void handleDeleteTask(item.id)}
         onVideoPress={() => {}}
-        getCategoryNames={() => 'aktiviteter'}
+        getCategoryItems={getCategoryItems}
       />
     ),
-    [handleDuplicateTask, handleDeleteTask, scheme],
+    [getCategoryItems, handleDuplicateTask, handleDeleteTask, scheme],
   );
 
   const styles = useMemo(
@@ -294,4 +310,3 @@ export default function TasksScreen() {
     </View>
   );
 }
-

--- a/services/taskService.ts
+++ b/services/taskService.ts
@@ -11,6 +11,7 @@ export interface CreateTaskData {
   categoryIds: string[];
   reminder?: number | null;
   videoUrl?: string | null;
+  subtasks?: TaskSubtaskInput[];
   afterTrainingEnabled?: boolean;
   afterTrainingDelayMinutes?: number | null;
   afterTrainingFeedbackEnableScore?: boolean;
@@ -31,6 +32,7 @@ export interface UpdateTaskData {
   categoryIds?: string[];
   reminder?: number | null;
   videoUrl?: string | null;
+  subtasks?: TaskSubtaskInput[];
   afterTrainingEnabled?: boolean;
   afterTrainingDelayMinutes?: number | null;
   afterTrainingFeedbackEnableScore?: boolean;
@@ -51,7 +53,7 @@ type SeriesFeedbackSummary = {
   dryRun?: boolean;
 };
 
-type TaskSubtaskInput = { id?: string; title: string };
+export type TaskSubtaskInput = { id?: string; title: string };
 
 export interface P8CreateTaskArgs {
   task: Task;
@@ -88,6 +90,82 @@ const uniqueStringIds = (values: unknown[]): string[] => {
   return Array.from(new Set(ids));
 };
 
+const toActivityStartMs = (activityDate: unknown, activityTime: unknown): number | null => {
+  const date =
+    activityDate instanceof Date
+      ? Number.isFinite(activityDate.getTime())
+        ? activityDate.toISOString().slice(0, 10)
+        : ''
+      : String(activityDate ?? '').slice(0, 10);
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
+
+  const rawTime = String(activityTime ?? '').trim();
+  const time = rawTime.length >= 8
+    ? rawTime.slice(0, 8)
+    : rawTime.length >= 5
+      ? `${rawTime.slice(0, 5)}:00`
+      : '00:00:00';
+  const ms = Date.parse(`${date}T${time}`);
+  return Number.isFinite(ms) ? ms : null;
+};
+
+const isFutureActivityStart = (activityDate: unknown, activityTime: unknown, now = new Date()): boolean => {
+  const startMs = toActivityStartMs(activityDate, activityTime);
+  return startMs !== null && startMs >= now.getTime();
+};
+
+const isFutureExternalMetaStart = (metaRow: any, now = new Date()): boolean => {
+  const localOverride = metaRow?.local_start_override;
+  if (localOverride) {
+    const localMs = Date.parse(String(localOverride));
+    return Number.isFinite(localMs) && localMs >= now.getTime();
+  }
+
+  const external = Array.isArray(metaRow?.events_external)
+    ? metaRow.events_external[0]
+    : metaRow?.events_external;
+  return isFutureActivityStart(external?.start_date, external?.start_time, now);
+};
+
+const normalizeSubtasksForTemplate = (subtasks: TaskSubtaskInput[] | undefined | null): { title: string; sort_order: number }[] =>
+  (subtasks ?? [])
+    .map((subtask, index) => ({
+      title: String(subtask?.title ?? '').trim(),
+      sort_order: index,
+    }))
+    .filter((subtask) => subtask.title.length > 0);
+
+const syncTaskTemplateSubtasks = async (
+  taskTemplateId: string,
+  subtasks: TaskSubtaskInput[] | undefined | null,
+  signal: AbortSignal,
+): Promise<void> => {
+  const normalizedTaskTemplateId = normalizeStringId(taskTemplateId);
+  if (!normalizedTaskTemplateId) return;
+
+  await supabase
+    .from('task_template_subtasks')
+    .delete()
+    .eq('task_template_id', normalizedTaskTemplateId)
+    .abortSignal(signal);
+
+  const rows = normalizeSubtasksForTemplate(subtasks).map((subtask) => ({
+    task_template_id: normalizedTaskTemplateId,
+    title: subtask.title,
+    sort_order: subtask.sort_order,
+  }));
+
+  if (!rows.length) return;
+
+  const { error } = await supabase
+    .from('task_template_subtasks')
+    .insert(rows)
+    .abortSignal(signal);
+
+  if (error) throw error;
+};
+
 const removeStaleActivityTemplateTasks = async (
   taskId: string,
   nextCategoryIds: string[],
@@ -114,24 +192,29 @@ const removeStaleActivityTemplateTasks = async (
 
     const { data: activities, error: activitiesError } = await supabase
       .from('activities')
-      .select('id, category_id')
+      .select('id, category_id, activity_date, activity_time')
       .in('id', activityIds)
       .abortSignal(signal);
 
     if (activitiesError) throw activitiesError;
 
-    const categoryByActivityId = new Map<string, string | null>();
+    const activityById = new Map<string, { categoryId: string | null; isFuture: boolean }>();
     (activities ?? []).forEach((row: any) => {
       const activityId = normalizeStringId(row?.id);
       if (!activityId) return;
-      categoryByActivityId.set(activityId, normalizeStringId(row?.category_id));
+      activityById.set(activityId, {
+        categoryId: normalizeStringId(row?.category_id),
+        isFuture: isFutureActivityStart(row?.activity_date, row?.activity_time),
+      });
     });
 
     return uniqueStringIds(
       taskRows
         .filter((row: any) => {
           const activityId = normalizeStringId(row?.activity_id);
-          const categoryId = activityId ? categoryByActivityId.get(activityId) ?? null : null;
+          const activity = activityId ? activityById.get(activityId) ?? null : null;
+          if (!activity?.isFuture) return false;
+          const categoryId = activity.categoryId;
           return !categoryId || !allowedCategoryIds.has(categoryId);
         })
         .map((row: any) => row?.id)
@@ -180,24 +263,29 @@ const removeStaleExternalTemplateTasks = async (
 
     const { data: metaRows, error: metaRowsError } = await supabase
       .from('events_local_meta')
-      .select('id, category_id')
+      .select('id, category_id, local_start_override, events_external(start_date, start_time)')
       .in('id', localMetaIds)
       .abortSignal(signal);
 
     if (metaRowsError) throw metaRowsError;
 
-    const categoryByLocalMetaId = new Map<string, string | null>();
+    const metaById = new Map<string, { categoryId: string | null; isFuture: boolean }>();
     (metaRows ?? []).forEach((row: any) => {
       const localMetaId = normalizeStringId(row?.id);
       if (!localMetaId) return;
-      categoryByLocalMetaId.set(localMetaId, normalizeStringId(row?.category_id));
+      metaById.set(localMetaId, {
+        categoryId: normalizeStringId(row?.category_id),
+        isFuture: isFutureExternalMetaStart(row),
+      });
     });
 
     return uniqueStringIds(
       taskRows
         .filter((row: any) => {
           const localMetaId = normalizeStringId(row?.local_meta_id);
-          const categoryId = localMetaId ? categoryByLocalMetaId.get(localMetaId) ?? null : null;
+          const meta = localMetaId ? metaById.get(localMetaId) ?? null : null;
+          if (!meta?.isFuture) return false;
+          const categoryId = meta.categoryId;
           return !categoryId || !allowedCategoryIds.has(categoryId);
         })
         .map((row: any) => row?.id)
@@ -255,6 +343,9 @@ export const taskService = {
     const resolvedCategoryIds = (isP8Payload
       ? ((sourceTask as any).categoryIds ?? [])
       : (rawData as CreateTaskData).categoryIds ?? []) as string[];
+    const resolvedSubtasks = (isP8Payload
+      ? ((rawData as P8CreateTaskArgs).subtasks ?? (sourceTask as any).subtasks)
+      : (rawData as CreateTaskData).subtasks) as TaskSubtaskInput[] | undefined;
     const resolvedReminder =
       ('reminder' in sourceTask ? (sourceTask as any).reminder : (rawData as CreateTaskData).reminder) ?? null;
     const resolvedVideoUrl =
@@ -338,7 +429,7 @@ export const taskService = {
       after_training_feedback_score_explanation: resolvedAfterTrainingFeedbackEnableScore
         ? resolvedAfterTrainingFeedbackScoreExplanation || null
         : null,
-      after_training_feedback_enable_intensity: true,
+      after_training_feedback_enable_intensity: !!resolvedAfterTrainingEnabled,
       after_training_feedback_enable_note: resolvedAfterTrainingFeedbackEnableNote,
       task_duration_enabled: resolvedTaskDurationEnabled,
       task_duration_minutes: resolvedTaskDurationMinutes,
@@ -434,7 +525,9 @@ export const taskService = {
       }
     }
 
-    // Hotfix #215: template subtasks are deprecated and intentionally ignored.
+    if (templateCreated || resolvedSubtasks !== undefined) {
+      await syncTaskTemplateSubtasks(template.id, resolvedSubtasks, signal);
+    }
 
     // Return the created task in the expected format
     return {
@@ -445,15 +538,18 @@ export const taskService = {
       isTemplate: true,
       categoryIds: resolvedCategoryIds || [],
       reminder: template.reminder_minutes ?? undefined,
-      subtasks: [],
+      subtasks: normalizeSubtasksForTemplate(resolvedSubtasks).map((subtask, index) => ({
+        id: `${template.id}-subtask-${index}`,
+        title: subtask.title,
+        completed: false,
+      })),
       videoUrl: template.video_url ?? undefined,
       source_folder: template.source_folder ?? undefined,
       afterTrainingEnabled: template.after_training_enabled ?? false,
       afterTrainingDelayMinutes: template.after_training_delay_minutes ?? null,
       afterTrainingFeedbackEnableScore: template.after_training_feedback_enable_score ?? true,
       afterTrainingFeedbackScoreExplanation: template.after_training_feedback_score_explanation ?? null,
-      // Always return true so UI/clients see a consistent state
-      afterTrainingFeedbackEnableIntensity: true,
+      afterTrainingFeedbackEnableIntensity: !!template.after_training_feedback_enable_intensity,
       afterTrainingFeedbackEnableNote: template.after_training_feedback_enable_note ?? true,
       taskDurationEnabled: template.task_duration_enabled ?? false,
       taskDurationMinutes: template.task_duration_minutes ?? null,
@@ -502,9 +598,8 @@ export const taskService = {
       }
     }
 
-    // Do not allow disabling intensity – enforce true on relevant updates
     if (shouldSyncSeriesFeedback) {
-      updateData.after_training_feedback_enable_intensity = true;
+      updateData.after_training_feedback_enable_intensity = updates.afterTrainingEnabled === false ? false : true;
     }
 
     if (updates.afterTrainingFeedbackScoreExplanation !== undefined) {
@@ -568,6 +663,10 @@ export const taskService = {
 
         if (error) throw error;
       }
+    }
+
+    if (updates.subtasks !== undefined) {
+      await syncTaskTemplateSubtasks(taskId, updates.subtasks, signal);
     }
 
     if (updates.categoryIds !== undefined) {
@@ -691,24 +790,41 @@ export const taskService = {
       throw error;
     }
 
-    if (Array.isArray(data) && data.length > 0) {
-      return;
+    if (!Array.isArray(data) || data.length === 0) {
+      // Fallback for assigned templates where actor is player/team member (non-owner).
+      const { data: toggled, error: rpcError } = await (supabase as any)
+        .rpc('set_task_template_archived_for_actor', {
+          p_task_id: taskId,
+          p_archived: archived,
+        })
+        .abortSignal(signal);
+
+      if (rpcError) {
+        throw rpcError;
+      }
+
+      if (toggled !== true) {
+        throw new Error('Du kan kun arkivere eller gendanne opgaver, du har adgang til');
+      }
     }
 
-    // Fallback for assigned templates where actor is player/team member (non-owner).
-    const { data: toggled, error: rpcError } = await (supabase as any)
-      .rpc('set_task_template_archived_for_actor', {
-        p_task_id: taskId,
-        p_archived: archived,
-      })
-      .abortSignal(signal);
+    try {
+      const { error: syncError } = await supabase.rpc(
+        'update_all_tasks_from_template',
+        {
+          p_template_id: taskId,
+          p_dry_run: false,
+        }
+      );
 
-    if (rpcError) {
-      throw rpcError;
-    }
-
-    if (toggled !== true) {
-      throw new Error('Du kan kun arkivere eller gendanne opgaver, du har adgang til');
+      if (syncError) {
+        console.error('[TEMPLATE_ARCHIVE_SYNC] update_all_tasks_from_template failed', {
+          templateId: taskId,
+          error: syncError.message,
+        });
+      }
+    } catch (syncUnexpectedError) {
+      console.error('[TEMPLATE_ARCHIVE_SYNC] Unexpected update_all_tasks_from_template failure', syncUnexpectedError);
     }
   },
 

--- a/supabase/migrations/20260527143000_future_only_task_template_activity_sync.sql
+++ b/supabase/migrations/20260527143000_future_only_task_template_activity_sync.sql
@@ -1,0 +1,630 @@
+create or replace function public.is_internal_activity_future(
+  p_activity_date date,
+  p_activity_time time without time zone
+)
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+  select p_activity_date is not null
+     and (
+       p_activity_date > current_date
+       or (
+         p_activity_date = current_date
+         and coalesce(p_activity_time, time '00:00') >= localtime
+       )
+     );
+$$;
+
+create or replace function public.is_external_local_meta_future(p_local_meta_id uuid)
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+  select coalesce(
+    (
+      select case
+        when elm.local_start_override is not null then elm.local_start_override >= now()
+        else public.is_internal_activity_future(ee.start_date, ee.start_time)
+      end
+      from public.events_local_meta elm
+      left join public.events_external ee on ee.id = elm.external_event_id
+      where elm.id = p_local_meta_id
+      limit 1
+    ),
+    false
+  );
+$$;
+
+create or replace function public.create_tasks_for_activity(p_activity_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_category_id uuid;
+  v_activity_user_id uuid;
+  v_activity_player_id uuid;
+  v_is_future boolean := false;
+  v_template record;
+  v_task_id uuid;
+  v_subtask record;
+  v_existing_task_id uuid;
+  v_reflection_user_id uuid;
+  v_template_ids uuid[] := array[]::uuid[];
+begin
+  select
+    category_id,
+    user_id,
+    player_id,
+    public.is_internal_activity_future(activity_date, activity_time)
+    into v_category_id, v_activity_user_id, v_activity_player_id, v_is_future
+    from public.activities
+   where id = p_activity_id;
+
+  if not coalesce(v_is_future, false) then
+    return;
+  end if;
+
+  if v_category_id is null or v_activity_user_id is null then
+    return;
+  end if;
+
+  select coalesce(array_remove(array_agg(distinct tt.id), null), array[]::uuid[])
+    into v_template_ids
+    from public.task_templates tt
+    join public.task_template_categories ttc on ttc.task_template_id = tt.id
+   where ttc.category_id = v_category_id
+     and tt.user_id = v_activity_user_id
+     and tt.archived_at is null;
+
+  delete from public.activity_task_subtasks
+   where activity_task_id in (
+     select at.id
+       from public.activity_tasks at
+      where at.activity_id = p_activity_id
+        and at.task_template_id is null
+        and at.description is not null
+        and at.description like '%[auto-after-training:%'
+        and not exists (
+          select 1
+            from public.task_templates tt
+           where tt.id = substring(at.description from '\[auto-after-training:([0-9a-fA-F-]+)\]')::uuid
+             and (
+               coalesce(tt.source_folder, '') = 'activity_local_task'
+               or (tt.user_id = v_activity_user_id and tt.archived_at is null)
+             )
+        )
+   );
+
+  delete from public.activity_tasks at
+   where at.activity_id = p_activity_id
+     and at.task_template_id is null
+     and at.description is not null
+     and at.description like '%[auto-after-training:%'
+     and not exists (
+       select 1
+         from public.task_templates tt
+        where tt.id = substring(at.description from '\[auto-after-training:([0-9a-fA-F-]+)\]')::uuid
+          and (
+            coalesce(tt.source_folder, '') = 'activity_local_task'
+            or (tt.user_id = v_activity_user_id and tt.archived_at is null)
+          )
+     );
+
+  delete from public.activity_task_subtasks
+   where activity_task_id in (
+     select at.id
+       from public.activity_tasks at
+      where at.activity_id = p_activity_id
+        and at.task_template_id is not null
+        and (
+          coalesce(array_length(v_template_ids, 1), 0) = 0
+          or not (at.task_template_id = any(v_template_ids))
+        )
+        and not exists (
+          select 1
+            from public.task_templates tt
+           where tt.id = at.task_template_id
+             and (
+               coalesce(tt.source_folder, '') = 'activity_local_task'
+               or (tt.user_id = v_activity_user_id and tt.archived_at is null)
+             )
+        )
+   );
+
+  delete from public.activity_tasks at
+   where at.activity_id = p_activity_id
+     and at.task_template_id is not null
+     and (
+       coalesce(array_length(v_template_ids, 1), 0) = 0
+       or not (at.task_template_id = any(v_template_ids))
+     )
+     and not exists (
+       select 1
+         from public.task_templates tt
+        where tt.id = at.task_template_id
+          and (
+            coalesce(tt.source_folder, '') = 'activity_local_task'
+            or (tt.user_id = v_activity_user_id and tt.archived_at is null)
+          )
+     );
+
+  for v_template in
+    select distinct tt.*
+      from public.task_templates tt
+      join public.task_template_categories ttc on ttc.task_template_id = tt.id
+     where ttc.category_id = v_category_id
+       and tt.user_id = v_activity_user_id
+       and tt.archived_at is null
+  loop
+    select id
+      into v_existing_task_id
+      from public.activity_tasks
+     where activity_id = p_activity_id
+       and task_template_id = v_template.id;
+
+    if v_existing_task_id is not null then
+      update public.activity_tasks
+         set title = v_template.title,
+             description = v_template.description,
+             reminder_minutes = v_template.reminder_minutes,
+             updated_at = now()
+       where id = v_existing_task_id;
+
+      delete from public.activity_task_subtasks
+       where activity_task_id = v_existing_task_id;
+
+      for v_subtask in
+        select *
+          from public.task_template_subtasks
+         where task_template_id = v_template.id
+         order by sort_order
+      loop
+        insert into public.activity_task_subtasks (activity_task_id, title, sort_order)
+        values (v_existing_task_id, v_subtask.title, v_subtask.sort_order);
+      end loop;
+    else
+      insert into public.activity_tasks (activity_id, task_template_id, title, description, reminder_minutes)
+      values (p_activity_id, v_template.id, v_template.title, v_template.description, v_template.reminder_minutes)
+      returning id into v_task_id;
+
+      for v_subtask in
+        select *
+          from public.task_template_subtasks
+         where task_template_id = v_template.id
+         order by sort_order
+      loop
+        insert into public.activity_task_subtasks (activity_task_id, title, sort_order)
+        values (v_task_id, v_subtask.title, v_subtask.sort_order);
+      end loop;
+    end if;
+
+    if coalesce(v_template.after_training_enabled, false) then
+      v_reflection_user_id := coalesce(v_activity_player_id, v_activity_user_id);
+
+      if v_reflection_user_id is not null then
+        insert into public.training_reflections (activity_id, user_id, category_id, rating, note)
+        values (p_activity_id, v_reflection_user_id, v_category_id, null, null)
+        on conflict (activity_id) do nothing;
+      end if;
+
+      perform public.upsert_after_training_feedback_task(
+        p_activity_id := p_activity_id,
+        p_task_template_id := v_template.id,
+        p_base_title := v_template.title
+      );
+    end if;
+  end loop;
+end;
+$$;
+
+create or replace function public.create_tasks_for_external_event(p_local_meta_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_category_id uuid;
+  v_user_id uuid;
+  v_template record;
+  v_base_task_id uuid;
+  v_feedback_task_id uuid;
+  v_template_ids uuid[] := array[]::uuid[];
+
+  v_has_local_meta_id boolean := false;
+  v_has_task_template_id boolean := false;
+  v_has_title boolean := false;
+  v_has_description boolean := false;
+  v_has_reminder_minutes boolean := false;
+  v_has_completed boolean := false;
+  v_has_feedback_template_id boolean := false;
+  v_has_is_feedback_task boolean := false;
+  v_has_video_url boolean := false;
+
+  v_has_after_training_enabled boolean := false;
+  v_has_after_training_delay_minutes boolean := false;
+
+  v_should_create_feedback boolean := false;
+  v_feedback_reminder_minutes integer := null;
+begin
+  if p_local_meta_id is null then
+    return;
+  end if;
+
+  if not public.is_external_local_meta_future(p_local_meta_id) then
+    return;
+  end if;
+
+  if to_regclass('public.external_event_tasks') is null
+     or to_regclass('public.events_local_meta') is null
+     or to_regclass('public.task_templates') is null
+     or to_regclass('public.task_template_categories') is null then
+    return;
+  end if;
+
+  select
+    coalesce(bool_or(column_name = 'local_meta_id'), false),
+    coalesce(bool_or(column_name = 'task_template_id'), false),
+    coalesce(bool_or(column_name = 'title'), false),
+    coalesce(bool_or(column_name = 'description'), false),
+    coalesce(bool_or(column_name = 'reminder_minutes'), false),
+    coalesce(bool_or(column_name = 'completed'), false),
+    coalesce(bool_or(column_name = 'feedback_template_id'), false),
+    coalesce(bool_or(column_name = 'is_feedback_task'), false),
+    coalesce(bool_or(column_name = 'video_url'), false)
+  into
+    v_has_local_meta_id,
+    v_has_task_template_id,
+    v_has_title,
+    v_has_description,
+    v_has_reminder_minutes,
+    v_has_completed,
+    v_has_feedback_template_id,
+    v_has_is_feedback_task,
+    v_has_video_url
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'external_event_tasks';
+
+  if not (
+    v_has_local_meta_id
+    and v_has_task_template_id
+    and v_has_title
+    and v_has_description
+    and v_has_reminder_minutes
+    and v_has_completed
+  ) then
+    return;
+  end if;
+
+  if not v_has_feedback_template_id then
+    return;
+  end if;
+
+  select
+    coalesce(bool_or(column_name = 'after_training_enabled'), false),
+    coalesce(bool_or(column_name = 'after_training_delay_minutes'), false)
+  into
+    v_has_after_training_enabled,
+    v_has_after_training_delay_minutes
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'task_templates';
+
+  select category_id, user_id
+    into v_category_id, v_user_id
+  from public.events_local_meta
+  where id = p_local_meta_id;
+
+  if v_category_id is null or v_user_id is null then
+    return;
+  end if;
+
+  select coalesce(array_remove(array_agg(distinct tt.id), null), array[]::uuid[])
+    into v_template_ids
+    from public.task_templates tt
+    join public.task_template_categories ttc on ttc.task_template_id = tt.id
+   where ttc.category_id = v_category_id
+     and tt.user_id = v_user_id
+     and tt.archived_at is null;
+
+  delete from public.external_event_tasks eet
+   where eet.local_meta_id = p_local_meta_id
+     and eet.task_template_id is not null
+     and (
+       coalesce(array_length(v_template_ids, 1), 0) = 0
+       or not (eet.task_template_id = any(v_template_ids))
+     )
+     and not exists (
+       select 1
+         from public.task_templates tt
+        where tt.id = eet.task_template_id
+          and (
+            coalesce(tt.source_folder, '') = 'activity_local_task'
+            or (tt.user_id = v_user_id and tt.archived_at is null)
+          )
+     );
+
+  delete from public.external_event_tasks eet
+   where eet.local_meta_id = p_local_meta_id
+     and eet.feedback_template_id is not null
+     and (
+       coalesce(array_length(v_template_ids, 1), 0) = 0
+       or not (eet.feedback_template_id = any(v_template_ids))
+     )
+     and not exists (
+       select 1
+         from public.task_templates tt
+        where tt.id = eet.feedback_template_id
+          and (
+            coalesce(tt.source_folder, '') = 'activity_local_task'
+            or (tt.user_id = v_user_id and tt.archived_at is null)
+          )
+     );
+
+  for v_template in
+    select distinct tt.*
+      from public.task_templates tt
+      join public.task_template_categories ttc on ttc.task_template_id = tt.id
+     where ttc.category_id = v_category_id
+       and tt.user_id = v_user_id
+       and tt.archived_at is null
+  loop
+    select id
+      into v_base_task_id
+    from public.external_event_tasks
+    where local_meta_id = p_local_meta_id
+      and task_template_id = v_template.id
+    limit 1;
+
+    if v_base_task_id is null then
+      insert into public.external_event_tasks (
+        local_meta_id,
+        task_template_id,
+        title,
+        description,
+        reminder_minutes,
+        completed
+      )
+      values (
+        p_local_meta_id,
+        v_template.id,
+        v_template.title,
+        v_template.description,
+        v_template.reminder_minutes,
+        false
+      )
+      returning id into v_base_task_id;
+    else
+      update public.external_event_tasks
+         set title = v_template.title,
+             description = v_template.description,
+             reminder_minutes = v_template.reminder_minutes,
+             completed = false,
+             is_feedback_task = false
+       where id = v_base_task_id;
+    end if;
+
+    if v_has_after_training_enabled then
+      v_should_create_feedback := coalesce(v_template.after_training_enabled, false);
+      v_feedback_reminder_minutes := null;
+
+      if v_has_after_training_delay_minutes and coalesce(v_template.after_training_enabled, false) then
+        v_feedback_reminder_minutes := coalesce(v_template.after_training_delay_minutes, 0);
+      end if;
+    else
+      v_should_create_feedback := false;
+      v_feedback_reminder_minutes := null;
+    end if;
+
+    if v_should_create_feedback then
+      select id
+        into v_feedback_task_id
+      from public.external_event_tasks
+      where local_meta_id = p_local_meta_id
+        and feedback_template_id = v_template.id
+      limit 1;
+
+      if v_feedback_task_id is null then
+        insert into public.external_event_tasks (
+          local_meta_id,
+          feedback_template_id,
+          title,
+          description,
+          reminder_minutes,
+          completed,
+          is_feedback_task
+        )
+        values (
+          p_local_meta_id,
+          v_template.id,
+          'Feedback på ' || coalesce(v_template.title, 'opgaven'),
+          'Del din feedback efter træningen direkte til træneren. [auto-after-training:' || v_template.id::text || ']',
+          v_feedback_reminder_minutes,
+          false,
+          true
+        );
+      else
+        update public.external_event_tasks
+           set title = 'Feedback på ' || coalesce(v_template.title, 'opgaven'),
+               description = 'Del din feedback efter træningen direkte til træneren. [auto-after-training:' || v_template.id::text || ']',
+               reminder_minutes = v_feedback_reminder_minutes,
+               completed = false,
+               is_feedback_task = true
+         where id = v_feedback_task_id;
+      end if;
+    end if;
+  end loop;
+end;
+$$;
+
+create or replace function public.update_all_tasks_from_template(
+  p_template_id uuid,
+  p_dry_run boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_activity_ids uuid[] := array[]::uuid[];
+  v_series_ids uuid[] := array[]::uuid[];
+  v_series_activity_ids uuid[] := array[]::uuid[];
+  v_external_ids uuid[] := array[]::uuid[];
+  v_activity_id uuid;
+  v_local_meta_id uuid;
+  v_direct_count integer := 0;
+  v_series_count integer := 0;
+  v_series_activity_count integer := 0;
+  v_total_activity_updates integer := 0;
+  v_external_count integer := 0;
+  v_result jsonb;
+begin
+  if p_template_id is null then
+    return jsonb_build_object(
+      'templateId', null,
+      'seriesCount', 0,
+      'directActivityUpdates', 0,
+      'seriesActivityUpdates', 0,
+      'totalActivityUpdates', 0,
+      'externalEventUpdates', 0,
+      'dryRun', p_dry_run
+    );
+  end if;
+
+  select coalesce(array_remove(array_agg(distinct candidate.id), null), array[]::uuid[])
+    into v_activity_ids
+    from (
+      select at.activity_id as id
+        from public.activity_tasks at
+        join public.activities a on a.id = at.activity_id
+       where (at.task_template_id = p_template_id or at.feedback_template_id = p_template_id)
+         and public.is_internal_activity_future(a.activity_date, a.activity_time)
+      union
+      select a.id
+        from public.activities a
+        join public.task_template_categories ttc on ttc.category_id = a.category_id
+       where ttc.task_template_id = p_template_id
+         and coalesce(a.is_external, false) = false
+         and public.is_internal_activity_future(a.activity_date, a.activity_time)
+    ) candidate;
+
+  select coalesce(array_remove(array_agg(distinct a.series_id), null), array[]::uuid[])
+    into v_series_ids
+    from public.activity_tasks at
+    join public.activities a on a.id = at.activity_id
+    where (at.task_template_id = p_template_id or at.feedback_template_id = p_template_id)
+      and a.series_id is not null;
+
+  if coalesce(array_length(v_series_ids, 1), 0) > 0 then
+    select coalesce(array_remove(array_agg(distinct a2.id), null), array[]::uuid[])
+      into v_series_activity_ids
+      from public.activities a2
+      where a2.series_id = any(v_series_ids)
+        and public.is_internal_activity_future(a2.activity_date, a2.activity_time)
+        and not (a2.id = any(v_activity_ids));
+  else
+    v_series_activity_ids := array[]::uuid[];
+  end if;
+
+  select coalesce(array_remove(array_agg(distinct candidate.id), null), array[]::uuid[])
+    into v_external_ids
+    from (
+      select eet.local_meta_id as id
+        from public.external_event_tasks eet
+       where (eet.task_template_id = p_template_id or eet.feedback_template_id = p_template_id)
+         and public.is_external_local_meta_future(eet.local_meta_id)
+      union
+      select elm.id
+        from public.events_local_meta elm
+        join public.task_template_categories ttc on ttc.category_id = elm.category_id
+       where ttc.task_template_id = p_template_id
+         and public.is_external_local_meta_future(elm.id)
+    ) candidate;
+
+  v_direct_count := coalesce(array_length(v_activity_ids, 1), 0);
+  v_series_count := coalesce(array_length(v_series_ids, 1), 0);
+  v_series_activity_count := coalesce(array_length(v_series_activity_ids, 1), 0);
+  v_external_count := coalesce(array_length(v_external_ids, 1), 0);
+  v_total_activity_updates := v_direct_count + v_series_activity_count;
+
+  if not p_dry_run then
+    foreach v_activity_id in array v_activity_ids loop
+      perform public.create_tasks_for_activity(v_activity_id);
+    end loop;
+
+    foreach v_activity_id in array v_series_activity_ids loop
+      perform public.create_tasks_for_activity(v_activity_id);
+    end loop;
+
+    foreach v_local_meta_id in array v_external_ids loop
+      perform public.create_tasks_for_external_event(v_local_meta_id);
+    end loop;
+
+    raise notice '[SERIES_FEEDBACK_SYNC] template=% series=% future_activities=% future_external=%',
+      p_template_id,
+      v_series_count,
+      v_total_activity_updates,
+      v_external_count;
+  end if;
+
+  v_result := jsonb_build_object(
+    'templateId', p_template_id,
+    'seriesCount', v_series_count,
+    'directActivityUpdates', v_direct_count,
+    'seriesActivityUpdates', v_series_activity_count,
+    'totalActivityUpdates', v_total_activity_updates,
+    'externalEventUpdates', v_external_count,
+    'dryRun', p_dry_run
+  );
+
+  return v_result;
+end;
+$$;
+
+create or replace function public.trigger_fix_tasks_on_template_category_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if tg_op = 'INSERT' then
+    perform public.create_tasks_for_activity(a.id)
+      from public.activities a
+      join public.task_templates tt on tt.id = new.task_template_id
+     where a.category_id = new.category_id
+       and a.user_id = tt.user_id
+       and coalesce(a.is_external, false) = false
+       and public.is_internal_activity_future(a.activity_date, a.activity_time);
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.trigger_fix_external_tasks_on_template_category_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if tg_op = 'INSERT' then
+    perform public.create_tasks_for_external_event(elm.id)
+      from public.events_local_meta elm
+      join public.task_templates tt on tt.id = new.task_template_id
+     where elm.category_id = new.category_id
+       and elm.user_id = tt.user_id
+       and public.is_external_local_meta_future(elm.id);
+  end if;
+
+  return new;
+end;
+$$;

--- a/types/index.ts
+++ b/types/index.ts
@@ -56,9 +56,9 @@ export interface Task {
   completed: boolean;
   isTemplate: boolean;
   categoryIds: string[];
-  reminder?: number;
+  reminder?: number | null;
   subtasks: Subtask[];
-  videoUrl?: string;
+  videoUrl?: string | null;
   afterTrainingEnabled?: boolean;
   afterTrainingDelayMinutes?: number | null;
   afterTrainingFeedbackEnableScore?: boolean;
@@ -72,6 +72,10 @@ export interface Task {
   taskTemplateId?: string | null;
   feedbackTemplateId?: string | null;
   isFeedbackTask?: boolean;
+  userId?: string | null;
+  playerId?: string | null;
+  teamId?: string | null;
+  trainerName?: string | null;
   source_folder?: string | null;
   sourceFolder?: string | null;
   archivedAt?: string | null;


### PR DESCRIPTION
```markdown
## Resumé

Implementerer den nye opgaveside med bibliotekslignende UI, kategori-filter, kategori-badges på opgaver og forbedret opgave-sync, så kategoriændringer og arkivering kun påvirker fremtidige aktiviteter.

## Root Cause

Opgavesiden manglede visuel konsistens med Bibliotekssiden, og template/category-sync ramte både historiske og fremtidige aktiviteter. Det kunne føre til, at gamle aktiviteter fik fjernet eller tilføjet opgaver ved arkivering eller kategoriændringer.

## Ændringer

- Redesignet Opgavesiden, så header, mapper, kort, søgning, modal og spacing matcher Bibliotekssiden.
- Tilføjet “Ny opgave” CTA for både trænere og spillere.
- Tilføjet kategori-filter på opgavesiden.
- Viser opgavens kategorier som kategori-badges i stedet for tekst.
- Skjuler kategori-label når opgaven ikke har kategorier.
- Justeret task card-layout, så ikoner og titel står bedre på linje.
- Fjernet lille play-ikon i task card header, så kun video-previewens store play-knap bruges.
- Tilføjet/forbedret modal-felter for titel, beskrivelse, video URL, delopgaver, reminders, efter-træning feedback og kategorier.
- Tilføjet stabile testIDs til opgaveside og modal.
- Opdateret opgave-service, så fjernede kategorier kun rydder fremtidige activity/external task-rækker.
- Arkivering/gendannelse trigger nu template-sync.
- Tilføjet Supabase migration, der gør task-template backfill/sync fremtidsbaseret.

## Tests

Kørt lokalt:

- `npm run typecheck` ✅ exit `0`
- `npm run lint` ✅ exit `0`
- `npm test` ✅ exit `0`

Derudover målrettet test:

- `npm test -- --runTestsByPath __tests__/taskService.updateTask.category-sync.test.ts --runInBand` ✅ exit `0`

## Maestro

Maestro er ikke kørt lokalt.

Relevante smoke flows bør køres:

- `activity_task_flow_smoke.yaml`
- `library_add_to_tasks_smoke.yaml`
- `role_based_ui_smoke.yaml`

## Risici / Edge Cases

- Supabase migrationen skal deployes, før DB-side sync/backfill kun rammer fremtidige aktiviteter.
- “Fremtid” beregnes ud fra DB-tid i migrationen.
- Eksisterende historiske opgaver bevares; ændringen forhindrer nye sync-operationer i at påvirke historiske aktiviteter.
```