### PR TITLE
feat: træner kan se en spillers performance (#198)

### DIFF
--- a/__tests__/performance.screen.test.tsx
+++ b/__tests__/performance.screen.test.tsx
@@ -1,17 +1,59 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
 import PerformanceScreen from '../app/(tabs)/performance';
 
 const mockUseFootball = jest.fn();
 const mockUseHomeActivities = jest.fn();
+const mockStartAdminPlayer = jest.fn();
+const mockSetSelectedContext = jest.fn();
+const mockEnsureRosterLoaded = jest.fn();
+
+const mockAdminState = {
+  adminMode: 'self' as 'self' | 'player' | 'team',
+  adminTargetId: null as string | null,
+  adminTargetType: null as 'player' | 'team' | null,
+};
+const mockTeamPlayerState = {
+  players: [] as { id: string; full_name: string; email: string; phone_number?: string }[],
+  loading: false,
+};
+const mockUserRoleState = {
+  userRole: 'player' as 'admin' | 'trainer' | 'player' | null,
+};
+
+jest.mock('@/contexts/AdminContext', () => ({
+  useAdmin: () => ({
+    ...mockAdminState,
+    startAdminPlayer: mockStartAdminPlayer,
+  }),
+}));
 
 jest.mock('@/contexts/FootballContext', () => ({
   useFootball: () => mockUseFootball(),
 }));
 
+jest.mock('@/contexts/TeamPlayerContext', () => ({
+  useTeamPlayer: () => ({
+    players: mockTeamPlayerState.players,
+    loading: mockTeamPlayerState.loading,
+    ensureRosterLoaded: mockEnsureRosterLoaded,
+    setSelectedContext: mockSetSelectedContext,
+  }),
+}));
+
 jest.mock('@/hooks/useHomeActivities', () => ({
   useHomeActivities: () => mockUseHomeActivities(),
+}));
+
+jest.mock('@/hooks/useUserRole', () => ({
+  useUserRole: () => ({
+    userRole: mockUserRoleState.userRole,
+    loading: false,
+    isAdmin: mockUserRoleState.userRole === 'admin' || mockUserRoleState.userRole === 'trainer',
+    refreshUserRole: jest.fn(),
+    isAuthenticated: true,
+  }),
 }));
 
 jest.mock('@react-navigation/native', () => ({
@@ -30,9 +72,13 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('@/components/ProgressionSection', () => {
   const React = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
+  const { Text, View } = jest.requireActual('react-native');
   return {
-    ProgressionSection: () => <View testID="mock.progressionSection" />,
+    ProgressionSection: ({ targetUserId }: { targetUserId?: string | null }) => (
+      <View testID="mock.progressionSection">
+        <Text testID="mock.progressionTarget">{targetUserId ?? 'self'}</Text>
+      </View>
+    ),
   };
 });
 
@@ -65,6 +111,15 @@ describe('PerformanceScreen', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAdminState.adminMode = 'self';
+    mockAdminState.adminTargetId = null;
+    mockAdminState.adminTargetType = null;
+    mockTeamPlayerState.players = [];
+    mockTeamPlayerState.loading = false;
+    mockUserRoleState.userRole = 'player';
+    mockSetSelectedContext.mockResolvedValue(undefined);
+    mockEnsureRosterLoaded.mockReturnValue(new Promise(() => {}));
+
     mockUseFootball.mockReturnValue({
       trophies: [],
       hasPerformanceDataLoaded: true,
@@ -111,6 +166,161 @@ describe('PerformanceScreen', () => {
 
     fireEvent.press(getByTestId('performance.progression.toggle'));
     expect(queryByTestId('mock.progressionSection')).toBeNull();
+  });
+
+  it('shows player dropdown for trainer profiles', () => {
+    mockUserRoleState.userRole = 'trainer';
+
+    const { getByTestId } = render(<PerformanceScreen />);
+
+    expect(getByTestId('performance.playerDropdown.trigger')).toBeTruthy();
+  });
+
+  it('does not show player dropdown for player profiles', () => {
+    mockUserRoleState.userRole = 'player';
+
+    const { queryByTestId } = render(<PerformanceScreen />);
+
+    expect(queryByTestId('performance.playerDropdown.trigger')).toBeNull();
+  });
+
+  it('only renders trainer-linked players in the dropdown', () => {
+    mockUserRoleState.userRole = 'trainer';
+    mockTeamPlayerState.players = [
+      { id: 'player-1', email: '', full_name: 'Alma Angriber' },
+      { id: 'player-2', email: '', full_name: 'Birk Back' },
+    ];
+
+    const { getByTestId, getByText, queryByTestId } = render(<PerformanceScreen />);
+
+    fireEvent.press(getByTestId('performance.playerDropdown.trigger'));
+
+    expect(getByText('Alma Angriber')).toBeTruthy();
+    expect(getByText('Birk Back')).toBeTruthy();
+    expect(queryByTestId('performance.playerDropdown.option.player-3')).toBeNull();
+  });
+
+  it('shows the trainer player dropdown loading state', () => {
+    mockUserRoleState.userRole = 'trainer';
+    mockEnsureRosterLoaded.mockReturnValue(new Promise(() => {}));
+
+    const { getByTestId } = render(<PerformanceScreen />);
+
+    fireEvent.press(getByTestId('performance.playerDropdown.trigger'));
+
+    expect(getByTestId('performance.playerDropdown.loading')).toBeTruthy();
+  });
+
+  it('shows the trainer player dropdown empty state', async () => {
+    mockUserRoleState.userRole = 'trainer';
+    mockEnsureRosterLoaded.mockResolvedValue(undefined);
+
+    const { getByTestId } = render(<PerformanceScreen />);
+
+    fireEvent.press(getByTestId('performance.playerDropdown.trigger'));
+
+    await waitFor(() => {
+      expect(getByTestId('performance.playerDropdown.empty')).toBeTruthy();
+    });
+  });
+
+  it('shows the trainer player dropdown error state', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockUserRoleState.userRole = 'trainer';
+    mockEnsureRosterLoaded.mockRejectedValue(new Error('roster failed'));
+
+    const { getByTestId } = render(<PerformanceScreen />);
+
+    fireEvent.press(getByTestId('performance.playerDropdown.trigger'));
+
+    await waitFor(() => {
+      expect(getByTestId('performance.playerDropdown.error')).toBeTruthy();
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('selects a linked player and updates the performance target', async () => {
+    mockUserRoleState.userRole = 'trainer';
+    mockTeamPlayerState.players = [
+      { id: 'player-1', email: '', full_name: 'Alma Angriber' },
+    ];
+
+    const screen = render(<PerformanceScreen />);
+
+    fireEvent.press(screen.getByTestId('performance.playerDropdown.trigger'));
+    fireEvent.press(screen.getByTestId('performance.playerDropdown.option.player-1'));
+
+    await waitFor(() => {
+      expect(mockSetSelectedContext).toHaveBeenCalledWith({
+        type: 'player',
+        id: 'player-1',
+        name: 'Alma Angriber',
+      });
+      expect(mockStartAdminPlayer).toHaveBeenCalledWith('player-1');
+    });
+
+    mockAdminState.adminMode = 'player';
+    mockAdminState.adminTargetId = 'player-1';
+    mockAdminState.adminTargetType = 'player';
+    mockUseFootball.mockReturnValue({
+      trophies: [
+        { week: 7, year: 2026, type: 'gold', percentage: 100, completedTasks: 2, totalTasks: 2 },
+      ],
+      hasPerformanceDataLoaded: true,
+      ensurePerformanceDataLoaded: jest.fn(),
+      currentWeekStats: {
+        percentage: 100,
+        completedTasks: 2,
+        totalTasks: 2,
+        completedTasksForWeek: 2,
+        totalTasksForWeek: 2,
+        weekActivities: [],
+      },
+      externalCalendars: [],
+      fetchExternalCalendarEvents: jest.fn(),
+      categories: [],
+    });
+
+    screen.rerender(<PerformanceScreen />);
+
+    expect(screen.getByText('Viser performance for Alma Angriber')).toBeTruthy();
+    expect(screen.getByTestId('mock.progressionTarget').props.children).toBe('player-1');
+    expect(screen.getByTestId('performance.trophies.count.gold').props.children).toBe(1);
+  });
+
+  it('keeps the selected player visible while selected performance data is loading', () => {
+    mockUserRoleState.userRole = 'trainer';
+    mockAdminState.adminMode = 'player';
+    mockAdminState.adminTargetId = 'player-1';
+    mockAdminState.adminTargetType = 'player';
+    mockTeamPlayerState.players = [
+      { id: 'player-1', email: '', full_name: 'Alma Angriber' },
+    ];
+    mockUseFootball.mockReturnValue({
+      trophies: [
+        { week: 7, year: 2026, type: 'gold', percentage: 100, completedTasks: 2, totalTasks: 2 },
+      ],
+      hasPerformanceDataLoaded: false,
+      ensurePerformanceDataLoaded: jest.fn(() => new Promise(() => {})),
+      currentWeekStats: {
+        percentage: 60,
+        completedTasks: 3,
+        totalTasks: 5,
+        completedTasksForWeek: 5,
+        totalTasksForWeek: 8,
+        weekActivities: [],
+      },
+      externalCalendars: [],
+      fetchExternalCalendarEvents: jest.fn(),
+      categories: [],
+    });
+
+    const { getByTestId, getByText, queryByTestId } = render(<PerformanceScreen />);
+
+    expect(getByTestId('performance.selectedPlayer')).toBeTruthy();
+    expect(getByText('Indlæser pokaler og kalendere...')).toBeTruthy();
+    expect(queryByTestId('performance.trophies.count.gold')).toBeNull();
   });
 
   it('shows historik and excludes current week activities', () => {
@@ -232,7 +442,7 @@ describe('PerformanceScreen', () => {
         { week: 7, year: 2026, type: 'gold', percentage: 100, completedTasks: 2, totalTasks: 2 },
       ],
       hasPerformanceDataLoaded: false,
-      ensurePerformanceDataLoaded: jest.fn().mockResolvedValue(undefined),
+      ensurePerformanceDataLoaded: jest.fn(() => new Promise(() => {})),
       currentWeekStats: {
         percentage: 60,
         completedTasks: 3,

--- a/__tests__/useProgressionData.target-player.test.tsx
+++ b/__tests__/useProgressionData.target-player.test.tsx
@@ -1,0 +1,111 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { supabase } from '@/integrations/supabase/client';
+import { useProgressionData } from '@/hooks/useProgressionData';
+
+type EqCall = {
+  table: string;
+  column: string;
+  value: unknown;
+};
+
+const mockEqCalls: EqCall[] = [];
+
+jest.mock('@/integrations/supabase/client', () => {
+  const createQueryBuilder = (tableName: string) => {
+    const builder: any = {
+      select: jest.fn(() => builder),
+      eq: jest.fn((column: string, value: unknown) => {
+        mockEqCalls.push({ table: tableName, column, value });
+        return builder;
+      }),
+      gte: jest.fn(() => builder),
+      lt: jest.fn(() => builder),
+      not: jest.fn(() => builder),
+      or: jest.fn(() => builder),
+      in: jest.fn(() => builder),
+      order: jest.fn(() => builder),
+      then: (resolve: any, reject: any) =>
+        Promise.resolve({ data: [], error: null }).then(resolve, reject),
+    };
+    return builder;
+  };
+
+  return {
+    supabase: {
+      auth: {
+        getSession: jest.fn(),
+      },
+      from: jest.fn((tableName: string) => createQueryBuilder(tableName)),
+    },
+  };
+});
+
+jest.mock('@/utils/afterTrainingMarkers', () => ({
+  parseTemplateIdFromMarker: jest.fn(() => null),
+}));
+
+describe('useProgressionData target player queries', () => {
+  beforeEach(() => {
+    mockEqCalls.length = 0;
+    (supabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: { user: { id: 'trainer-1' } } },
+      error: null,
+    });
+  });
+
+  it('uses the selected player id for progression queries', async () => {
+    const categories: any[] = [];
+
+    renderHook(() =>
+      useProgressionData({
+        days: 30,
+        metric: 'rating',
+        categories,
+        targetUserId: 'player-1',
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockEqCalls.length).toBeGreaterThanOrEqual(14);
+    });
+
+    expect(mockEqCalls).toEqual(
+      expect.arrayContaining([
+        { table: 'task_template_self_feedback', column: 'user_id', value: 'player-1' },
+        { table: 'activity_tasks', column: 'activities.user_id', value: 'player-1' },
+        { table: 'activities', column: 'user_id', value: 'player-1' },
+        { table: 'external_event_tasks', column: 'events_local_meta.user_id', value: 'player-1' },
+        { table: 'events_local_meta', column: 'user_id', value: 'player-1' },
+      ])
+    );
+    expect(mockEqCalls.some((call) => call.value === 'trainer-1')).toBe(false);
+  });
+
+  it('falls back to the signed-in user when no target player id is supplied', async () => {
+    const categories: any[] = [];
+
+    renderHook(() =>
+      useProgressionData({
+        days: 30,
+        metric: 'rating',
+        categories,
+        targetUserId: '   ',
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockEqCalls.length).toBeGreaterThanOrEqual(14);
+    });
+
+    expect(mockEqCalls).toEqual(
+      expect.arrayContaining([
+        { table: 'task_template_self_feedback', column: 'user_id', value: 'trainer-1' },
+        { table: 'activity_tasks', column: 'activities.user_id', value: 'trainer-1' },
+        { table: 'activities', column: 'user_id', value: 'trainer-1' },
+        { table: 'external_event_tasks', column: 'events_local_meta.user_id', value: 'trainer-1' },
+        { table: 'events_local_meta', column: 'user_id', value: 'trainer-1' },
+      ])
+    );
+  });
+});

--- a/app/(tabs)/performance.tsx
+++ b/app/(tabs)/performance.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
+  Modal,
   Platform,
   Pressable,
   RefreshControl,
@@ -19,8 +20,11 @@ import ActivityCard from '@/components/ActivityCard';
 import { IconSymbol } from '@/components/IconSymbol';
 import { ProgressionSection } from '@/components/ProgressionSection';
 import { WeeklySummaryCard } from '@/components/WeeklySummaryCard';
+import { useAdmin } from '@/contexts/AdminContext';
 import { useFootball } from '@/contexts/FootballContext';
+import { useTeamPlayer, type Player } from '@/contexts/TeamPlayerContext';
 import { useHomeActivities } from '@/hooks/useHomeActivities';
+import { useUserRole } from '@/hooks/useUserRole';
 import * as CommonStyles from '@/styles/commonStyles';
 import {
   buildPerformanceHistoryWeeks,
@@ -47,6 +51,7 @@ function buildHistoryActivityKey(activity: any, weekKey: string, index: number):
 }
 
 export default function PerformanceScreen() {
+  const { adminMode, adminTargetId, adminTargetType, startAdminPlayer } = useAdmin();
   const {
     trophies,
     externalCalendars,
@@ -61,16 +66,27 @@ export default function PerformanceScreen() {
     hasLoadedFullWindow: hasLoadedFullHistoryWindow,
     loadFullWindow,
   } = useHomeActivities();
+  const { userRole } = useUserRole();
+  const {
+    players,
+    ensureRosterLoaded,
+    loading: rosterLoading,
+    setSelectedContext,
+  } = useTeamPlayer();
 
   const colorScheme = useColorScheme();
   const [refreshing, setRefreshing] = useState(false);
   const [isBootstrappingPerformanceData, setIsBootstrappingPerformanceData] = useState(false);
   const [isBootstrappingHistoryData, setIsBootstrappingHistoryData] = useState(false);
+  const [isBootstrappingRoster, setIsBootstrappingRoster] = useState(false);
+  const [playerDropdownError, setPlayerDropdownError] = useState<string | null>(null);
+  const [isPlayerDropdownOpen, setIsPlayerDropdownOpen] = useState(false);
   const [expandedTrophy, setExpandedTrophy] = useState<'gold' | 'silver' | 'bronze' | null>(null);
   const [expandedHistoryWeeks, setExpandedHistoryWeeks] = useState<Record<string, boolean>>({});
   const [isTrophySectionExpanded, setIsTrophySectionExpanded] = useState(true);
   const [isProgressionSectionExpanded, setIsProgressionSectionExpanded] = useState(true);
   const [isHistorySectionExpanded, setIsHistorySectionExpanded] = useState(false);
+  const isTrainerProfile = userRole === 'trainer';
 
   const palette = useMemo(() => {
     const fromHelper =
@@ -97,6 +113,42 @@ export default function PerformanceScreen() {
   const textColor = isDark ? '#e3e3e3' : palette.text;
   const textSecondaryColor = isDark ? '#999' : palette.textSecondary;
   const showTrophyLoadingState = !hasPerformanceDataLoaded || isBootstrappingPerformanceData;
+  const selectedPerformancePlayer = useMemo(() => {
+    if (!isTrainerProfile || adminMode !== 'player' || adminTargetType !== 'player' || !adminTargetId) {
+      return null;
+    }
+    return players.find((player) => player.id === adminTargetId) ?? null;
+  }, [adminMode, adminTargetId, adminTargetType, isTrainerProfile, players]);
+  const selectedPerformancePlayerId = selectedPerformancePlayer?.id ?? null;
+  const isPlayerRosterLoading = rosterLoading || isBootstrappingRoster;
+
+  useEffect(() => {
+    if (!isTrainerProfile) {
+      setIsPlayerDropdownOpen(false);
+      return;
+    }
+
+    let active = true;
+    setPlayerDropdownError(null);
+    setIsBootstrappingRoster(true);
+
+    void ensureRosterLoaded()
+      .catch((error) => {
+        console.error('[Performance] Failed to load trainer players:', error);
+        if (active) {
+          setPlayerDropdownError('Kunne ikke indlæse spillere');
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setIsBootstrappingRoster(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [ensureRosterLoaded, isTrainerProfile]);
 
   useFocusEffect(
     useCallback(() => {
@@ -247,6 +299,53 @@ export default function PerformanceScreen() {
     setExpandedTrophy((prev) => (prev === type ? null : type));
   }, []);
 
+  const handleOpenPlayerDropdown = useCallback(() => {
+    setIsPlayerDropdownOpen(true);
+  }, []);
+
+  const handleSelectPlayer = useCallback(
+    async (player: Player) => {
+      await setSelectedContext({
+        type: 'player',
+        id: player.id,
+        name: player.full_name,
+      });
+      startAdminPlayer(player.id);
+      setIsPlayerDropdownOpen(false);
+    },
+    [setSelectedContext, startAdminPlayer]
+  );
+
+  const renderPlayerOption = useCallback(
+    ({ item }: { item: Player }) => {
+      const isSelected = item.id === selectedPerformancePlayerId;
+      return (
+        <Pressable
+          testID={`performance.playerDropdown.option.${item.id}`}
+          onPress={() => handleSelectPlayer(item)}
+          style={({ pressed }) => [
+            styles.playerOption,
+            { backgroundColor: isSelected ? palette.primary : palette.card },
+            pressed && styles.playerOptionPressed,
+          ]}
+        >
+          <Text style={[styles.playerOptionName, { color: isSelected ? '#fff' : textColor }]}>
+            {item.full_name}
+          </Text>
+          {isSelected ? (
+            <IconSymbol
+              ios_icon_name="checkmark.circle.fill"
+              android_material_icon_name="check_circle"
+              size={20}
+              color="#fff"
+            />
+          ) : null}
+        </Pressable>
+      );
+    },
+    [handleSelectPlayer, palette.card, palette.primary, selectedPerformancePlayerId, textColor]
+  );
+
   return (
     <ScrollView
       testID="performance.screen"
@@ -261,10 +360,49 @@ export default function PerformanceScreen() {
         />
       }
     >
-      <View style={styles.header}>
-        <Text style={[styles.headerTitle, { color: textColor }]}>🏆 Din Performance</Text>
-        <Text style={[styles.headerSubtitle, { color: textSecondaryColor }]}>Se hvordan du klarer dig over tid</Text>
+      <View style={styles.header} testID="performance.result">
+        <Text style={[styles.headerTitle, { color: textColor }]}>🏆 Performance</Text>
+        <Text style={[styles.headerSubtitle, { color: textSecondaryColor }]}>Se dine spilleres performance over tid</Text>
       </View>
+
+      {isTrainerProfile ? (
+        <View style={styles.playerSelector}>
+          <Pressable
+            testID="performance.playerDropdown.trigger"
+            onPress={handleOpenPlayerDropdown}
+            style={({ pressed }) => [
+              styles.playerDropdownTrigger,
+              {
+                backgroundColor: isDark ? '#24362C' : '#EAF5EE',
+                borderColor: selectedPerformancePlayer ? palette.primary : isDark ? '#385442' : '#C8E2D0',
+              },
+              pressed && styles.playerDropdownTriggerPressed,
+            ]}
+          >
+            <View style={styles.playerDropdownTextBlock}>
+              <Text style={[styles.playerDropdownLabel, { color: textSecondaryColor }]}>Spiller</Text>
+              <Text style={[styles.playerDropdownValue, { color: textColor }]} numberOfLines={1}>
+                {selectedPerformancePlayer?.full_name ?? 'Vælg spiller'}
+              </Text>
+            </View>
+            <IconSymbol
+              ios_icon_name="chevron.down"
+              android_material_icon_name="keyboard-arrow-down"
+              size={22}
+              color={textSecondaryColor}
+            />
+          </Pressable>
+
+          {selectedPerformancePlayer ? (
+            <Text
+              testID="performance.selectedPlayer"
+              style={[styles.selectedPlayerText, { color: textSecondaryColor }]}
+            >
+              Viser performance for {selectedPerformancePlayer.full_name}
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
 
       <View style={styles.historySection}>
         <Pressable
@@ -497,7 +635,9 @@ export default function PerformanceScreen() {
         </Pressable>
       </View>
 
-      {isProgressionSectionExpanded ? <ProgressionSection categories={categories} /> : null}
+      {isProgressionSectionExpanded ? (
+        <ProgressionSection categories={categories} targetUserId={selectedPerformancePlayerId} />
+      ) : null}
 
       <View style={styles.historySection}>
         <Pressable
@@ -615,6 +755,79 @@ export default function PerformanceScreen() {
       ) : null}
 
       <View style={{ height: 100 }} />
+
+      {isTrainerProfile ? (
+        <Modal
+          visible={isPlayerDropdownOpen}
+          transparent
+          animationType="fade"
+          onRequestClose={() => setIsPlayerDropdownOpen(false)}
+        >
+          <Pressable style={styles.playerModalBackdrop} onPress={() => setIsPlayerDropdownOpen(false)}>
+            <Pressable
+              style={[styles.playerModalCard, { backgroundColor: bgColor, borderColor: isDark ? '#385442' : '#C8E2D0' }]}
+              onPress={() => undefined}
+            >
+              <View style={styles.playerModalHeader}>
+                <Text style={[styles.playerModalTitle, { color: textColor }]}>Vælg spiller</Text>
+                <Pressable
+                  testID="performance.playerDropdown.close"
+                  onPress={() => setIsPlayerDropdownOpen(false)}
+                  hitSlop={10}
+                >
+                  <IconSymbol
+                    ios_icon_name="xmark"
+                    android_material_icon_name="close"
+                    size={22}
+                    color={textSecondaryColor}
+                  />
+                </Pressable>
+              </View>
+
+              <FlatList
+                data={players}
+                keyExtractor={(item) => item.id}
+                renderItem={renderPlayerOption}
+                ListEmptyComponent={
+                  <View style={[styles.playerDropdownState, { backgroundColor: palette.card }]}>
+                    {isPlayerRosterLoading ? (
+                      <>
+                        <ActivityIndicator size="small" color={palette.primary} />
+                        <Text
+                          testID="performance.playerDropdown.loading"
+                          style={[styles.playerDropdownStateText, { color: textSecondaryColor }]}
+                        >
+                          Indlæser spillere...
+                        </Text>
+                      </>
+                    ) : playerDropdownError ? (
+                      <Text
+                        testID="performance.playerDropdown.error"
+                        style={[styles.playerDropdownStateText, { color: textSecondaryColor }]}
+                      >
+                        {playerDropdownError}
+                      </Text>
+                    ) : (
+                      <Text
+                        testID="performance.playerDropdown.empty"
+                        style={[styles.playerDropdownStateText, { color: textSecondaryColor }]}
+                      >
+                        Ingen spillere tilknyttet endnu
+                      </Text>
+                    )}
+                  </View>
+                }
+                initialNumToRender={8}
+                maxToRenderPerBatch={8}
+                windowSize={5}
+                removeClippedSubviews={Platform.OS !== 'web'}
+                keyboardShouldPersistTaps="handled"
+                testID="performance.playerDropdown.list"
+              />
+            </Pressable>
+          </Pressable>
+        </Modal>
+      ) : null}
     </ScrollView>
   );
 }
@@ -637,6 +850,93 @@ const styles = StyleSheet.create({
   },
   headerSubtitle: {
     fontSize: 16,
+  },
+  playerSelector: {
+    marginBottom: 4,
+  },
+  playerDropdownTrigger: {
+    minHeight: 58,
+    borderRadius: 8,
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    columnGap: 12,
+  },
+  playerDropdownTriggerPressed: {
+    opacity: 0.92,
+  },
+  playerDropdownTextBlock: {
+    flex: 1,
+  },
+  playerDropdownLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    marginBottom: 3,
+  },
+  playerDropdownValue: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  selectedPlayerText: {
+    marginTop: 8,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  playerModalBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  playerModalCard: {
+    maxHeight: '70%',
+    borderRadius: 8,
+    borderWidth: 1,
+    padding: 16,
+  },
+  playerModalHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  playerModalTitle: {
+    fontSize: 18,
+    fontWeight: '800',
+  },
+  playerOption: {
+    minHeight: 52,
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    marginBottom: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    columnGap: 12,
+  },
+  playerOptionPressed: {
+    opacity: 0.9,
+  },
+  playerOptionName: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  playerDropdownState: {
+    borderRadius: 8,
+    padding: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    rowGap: 8,
+  },
+  playerDropdownStateText: {
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: 'center',
   },
   trophiesCard: {
     borderRadius: 16,

--- a/components/ProgressionSection.tsx
+++ b/components/ProgressionSection.tsx
@@ -19,6 +19,7 @@ import {
 
 type Props = {
   categories: ActivityCategory[];
+  targetUserId?: string | null;
 };
 
 type TierHistoryEntry = {
@@ -37,7 +38,7 @@ type TierTaskItem = {
   scoreExplanation?: string | null;
 };
 
-export function ProgressionSection({ categories }: Props) {
+export function ProgressionSection({ categories, targetUserId = null }: Props) {
   const colorScheme = useColorScheme();
   const palette = useMemo(() => CommonStyles.getColors(colorScheme), [colorScheme]);
 
@@ -61,6 +62,7 @@ export function ProgressionSection({ categories }: Props) {
       focusTaskTemplateId: metric === 'rating' ? selectedFocusId : null,
       intensityCategoryId: metric === 'intensity' ? selectedCategoryId : null,
       categories,
+      targetUserId,
     });
   const hasFocusedOnceRef = useRef(false);
 

--- a/e2e/flows/role_based_ui_smoke.yaml
+++ b/e2e/flows/role_based_ui_smoke.yaml
@@ -37,6 +37,13 @@ tags:
 - assertVisible:
     id: '^profile\.subscriptionPlanBadgeText$'
     text: '(?i).*spiller.*'
+- openLink: 'footballcoach:///(tabs)/performance'
+- extendedWaitUntil:
+    visible:
+      id: '^performance\.screen$'
+    timeout: 15000
+- assertNotVisible:
+    id: '^performance\.playerDropdown\.trigger$'
 - assertNotVisible: '^Hold\\s*&\\s*spillere$'
 - openLink: 'footballcoach:///(tabs)/library'
 - extendedWaitUntil:
@@ -226,6 +233,33 @@ tags:
     timeout: 15000
 - assertVisible:
     id: '^players\.card\..+$'
+
+# Performance: vælg tilknyttet spiller
+- openLink: 'footballcoach:///(tabs)/performance'
+- extendedWaitUntil:
+    visible:
+      id: '^performance\.screen$'
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: '^performance\.playerDropdown\.trigger$'
+    timeout: 15000
+- tapOn:
+    id: '^performance\.playerDropdown\.trigger$'
+- extendedWaitUntil:
+    visible:
+      id: '^performance\.playerDropdown\.option\..+$'
+    timeout: 15000
+- tapOn:
+    id: '^performance\.playerDropdown\.option\..+$'
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: '^performance\.selectedPlayer$'
+    timeout: 15000
+- assertVisible:
+    id: '^performance\.result$'
+- assertVisible: '^Pokaler$'
 
 # Cleanup: team + spiller
 - openLink: 'footballcoach:///(tabs)/profile'

--- a/hooks/useProgressionData.ts
+++ b/hooks/useProgressionData.ts
@@ -108,6 +108,7 @@ interface UseProgressionDataArgs {
   focusTaskTemplateId?: string | null;
   intensityCategoryId?: string | null;
   categories: ActivityCategory[];
+  targetUserId?: string | null;
 }
 
 interface UseProgressionDataResult {
@@ -452,6 +453,7 @@ export function useProgressionData({
   focusTaskTemplateId,
   intensityCategoryId,
   categories,
+  targetUserId,
 }: UseProgressionDataArgs): UseProgressionDataResult {
   const [focusEntries, setFocusEntries] = useState<ProgressionEntry[]>([]);
   const [focusEntriesPrevious, setFocusEntriesPrevious] = useState<ProgressionEntry[]>([]);
@@ -630,6 +632,9 @@ export function useProgressionData({
         runIfMounted(() => setRequiresLogin(true));
         return;
       }
+      const ownerUserId = typeof targetUserId === 'string' && targetUserId.trim().length > 0
+        ? targetUserId.trim()
+        : userId;
 
       runIfMounted(() => setRequiresLogin(false));
 
@@ -741,13 +746,13 @@ export function useProgressionData({
         (supabase as any)
           .from('task_template_self_feedback')
           .select(focusSelect)
-          .eq('user_id', userId)
+          .eq('user_id', ownerUserId)
           .gte('created_at', periodStart.toISOString())
           .order('created_at', { ascending: true }),
         (supabase as any)
           .from('task_template_self_feedback')
           .select(focusSelect)
-          .eq('user_id', userId)
+          .eq('user_id', ownerUserId)
           .gte('created_at', previousStart.toISOString())
           .lt('created_at', periodStart.toISOString())
           .order('created_at', { ascending: true }),
@@ -757,7 +762,7 @@ export function useProgressionData({
           .not('task_template_id', 'is', null)
           .gte('activities.activity_date', periodStartDate)
           .lt('activities.activity_date', periodEndDate)
-          .eq('activities.user_id', userId)
+          .eq('activities.user_id', ownerUserId)
           .order('created_at', { ascending: true }),
         supabase
           .from('activity_tasks')
@@ -765,19 +770,19 @@ export function useProgressionData({
           .not('task_template_id', 'is', null)
           .gte('activities.activity_date', previousStartDate)
           .lt('activities.activity_date', periodStartDate)
-          .eq('activities.user_id', userId)
+          .eq('activities.user_id', ownerUserId)
           .order('created_at', { ascending: true }),
         supabase
           .from('activities')
           .select(activitySelect)
-          .eq('user_id', userId)
+          .eq('user_id', ownerUserId)
           .gte('activity_date', periodStartDate)
           .lt('activity_date', periodEndDate)
           .order('activity_date', { ascending: true }),
         supabase
           .from('activities')
           .select(activitySelect)
-          .eq('user_id', userId)
+          .eq('user_id', ownerUserId)
           .gte('activity_date', previousStartDate)
           .lt('activity_date', periodStartDate)
           .order('activity_date', { ascending: true }),
@@ -785,7 +790,7 @@ export function useProgressionData({
           .from('external_event_tasks')
           .select(externalTaskSelect)
           .or('task_template_id.not.is.null,feedback_template_id.not.is.null')
-          .eq('events_local_meta.user_id', userId)
+          .eq('events_local_meta.user_id', ownerUserId)
           .gte('events_local_meta.events_external.start_date', periodStartDate)
           .lt('events_local_meta.events_external.start_date', periodEndDate)
           .order('created_at', { ascending: true }),
@@ -793,44 +798,44 @@ export function useProgressionData({
           .from('external_event_tasks')
           .select(externalTaskSelect)
           .or('task_template_id.not.is.null,feedback_template_id.not.is.null')
-          .eq('events_local_meta.user_id', userId)
+          .eq('events_local_meta.user_id', ownerUserId)
           .gte('events_local_meta.events_external.start_date', previousStartDate)
           .lt('events_local_meta.events_external.start_date', periodStartDate)
           .order('created_at', { ascending: true }),
         supabase
           .from('events_local_meta')
           .select(externalIntensitySelect)
-          .eq('user_id', userId)
+          .eq('user_id', ownerUserId)
           .gte('events_external.start_date', periodStartDate)
           .lt('events_external.start_date', periodEndDate),
         supabase
           .from('events_local_meta')
           .select(externalIntensitySelect)
-          .eq('user_id', userId)
+          .eq('user_id', ownerUserId)
           .gte('events_external.start_date', previousStartDate)
           .lt('events_external.start_date', periodStartDate),
         supabase
           .from('activity_tasks')
           .select(taskCounterInternalSelect)
-          .eq('activities.user_id', userId)
+          .eq('activities.user_id', ownerUserId)
           .gte('activities.activity_date', periodStartDate)
           .lt('activities.activity_date', periodEndDate),
         supabase
           .from('activity_tasks')
           .select(taskCounterInternalSelect)
-          .eq('activities.user_id', userId)
+          .eq('activities.user_id', ownerUserId)
           .gte('activities.activity_date', previousStartDate)
           .lt('activities.activity_date', previousEndDate),
         supabase
           .from('external_event_tasks')
           .select(taskCounterExternalSelect)
-          .eq('events_local_meta.user_id', userId)
+          .eq('events_local_meta.user_id', ownerUserId)
           .gte('events_local_meta.events_external.start_date', periodStartDate)
           .lt('events_local_meta.events_external.start_date', periodEndDate),
         supabase
           .from('external_event_tasks')
           .select(taskCounterExternalSelect)
-          .eq('events_local_meta.user_id', userId)
+          .eq('events_local_meta.user_id', ownerUserId)
           .gte('events_local_meta.events_external.start_date', previousStartDate)
           .lt('events_local_meta.events_external.start_date', previousEndDate),
       ]);
@@ -905,7 +910,7 @@ export function useProgressionData({
         const { data: taskCounterFeedbackRows, error: taskCounterFeedbackError } = await supabase
           .from('task_template_self_feedback')
           .select('activity_id, task_template_id, task_instance_id, rating, note, created_at')
-          .eq('user_id', userId)
+          .eq('user_id', ownerUserId)
           .in('activity_id', taskCounterActivityIds)
           .order('created_at', { ascending: false });
 
@@ -1163,7 +1168,7 @@ export function useProgressionData({
           ...entry,
           sessionKey: buildSessionKey({
             eventId: meta?.event_id ?? meta?.external_event_id ?? null,
-            userId: meta?.user_id ?? userId,
+            userId: meta?.user_id ?? ownerUserId,
             date: meta?.activity_date ?? null,
             time: meta?.activity_time ?? null,
           }),
@@ -1175,7 +1180,7 @@ export function useProgressionData({
         const event = meta.events_external ?? {};
         const activityDate = event.start_date ?? null;
         const activityTime = event.start_time ?? null;
-        const ownerId = meta.user_id ?? userId;
+        const ownerId = meta.user_id ?? ownerUserId;
         const eventId = event.id ?? meta.external_event_id ?? null;
         const templateId =
           row.task_template_id ? String(row.task_template_id) : row.feedback_template_id ? String(row.feedback_template_id) : null;
@@ -1226,7 +1231,7 @@ export function useProgressionData({
           focusColor: categoryMeta?.color,
           sessionKey: buildSessionKey({
             eventId,
-            userId: row.user_id ?? userId,
+            userId: row.user_id ?? ownerUserId,
             date: activityDate || row.created_at,
             time: activityTime,
           }),
@@ -1362,7 +1367,7 @@ export function useProgressionData({
     } finally {
       runIfMounted(() => setIsLoading(false));
     }
-  }, [days, mapFocusFeedbackRow, mapFocusPossibleRow, mapIntensityRow, categoryMap, clearDataState, runIfMounted]);
+  }, [days, targetUserId, mapFocusFeedbackRow, mapFocusPossibleRow, mapIntensityRow, categoryMap, clearDataState, runIfMounted]);
 
   const scheduleRefetch = useCallback(
     (delayMs: number = 250) => {


### PR DESCRIPTION
## Summary
- Tilføjer træner-only spiller-dropdown på Performance-siden.
- Genbruger eksisterende `AdminContext`/player-target flow, så performance-data, historik, pokaler og progression vises for valgt tilknyttet spiller.
- Holder almindelige spillere på eksisterende adfærd uden dropdown eller mulighed for at skifte bruger.
- Opdaterer Performance-header til:
  - `Performance`
  - `Se dine spilleres performance over tid`

## Access Control
- Træner/spiller-relationen genbruges via eksisterende roster/context og backendmodellen `admin_player_relationships`.
- Der er ikke tilføjet Supabase migration/RPC/policy.
- Backend/RLS forbliver den reelle adgangskontrol; klienten viser kun trænerens tilknyttede spillere, men autorisation afhænger ikke kun af klienten.

## Tests
Kørt uden Maestro:

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅

Jest:
- 65 test suites passed
- 383 tests passed
- 2 skipped

## Notes
- Maestro-flow er opdateret, men ikke kørt i denne runde.
- Jest-output har eksisterende console warnings/act warnings, men ingen test failures.